### PR TITLE
Make use list true to default

### DIFF
--- a/semantikon/typing.py
+++ b/semantikon/typing.py
@@ -21,7 +21,7 @@ def u(
     triple: tuple[tuple[str, str, str], ...] | tuple[str, str, str] | None = None,
     uri: str | None = None,
     shape: tuple[int] | None = None,
-    use_list: bool = False,
+    use_list: bool = True,
     **kwargs,
 ):
     result = {

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -150,9 +150,9 @@ class TestUnits(unittest.TestCase):
     def test_use_list(self):
         @units
         def get_speed_use_list(
-            distance: u(float, "meter", use_list=True),
-            time: u(float, "second", use_list=True),
-        ) -> u(float, "meter/second", use_list=True):
+            distance: u(float, "meter", use_list=False),
+            time: u(float, "second", use_list=False),
+        ) -> u(float, "meter/second", use_list=False):
             return distance / time
 
         self.assertEqual(get_speed_use_list(1.0, 1.0), 1.0)


### PR DESCRIPTION
Since [this PR](https://github.com/pyiron/semantikon/pull/29) solved the problem that additional args couldn't be added, I make `use_list=True` the default behaviour, which would also solve the problem that @Tara-Lakshmipathy had encountered in the meeting yesterday.

Example that used to fail but fixed with this PR:

```python
from rdflib import URIRef
from semantikon.converter import parse_input_args

def f(x: u(float, URIRef("input"))) -> u(float, URIRef("output")):
    return x

d = parse_input_args(f)
```

Note: It would work with `u(float, URIRef("input"), use_list=True)` anyway.