### PR TITLE
temporary bugfix for pint

### DIFF
--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -124,6 +124,7 @@ def _get_ret_units(output, ureg, names):
     if output is None:
         return None
     ret = _to_units_container(output["units"], ureg)
+    names = {key: 1.0 * value.units for key, value in names.items()}
     return ureg.Quantity(1, _replace_units(ret[0], names) if ret[1] else ret[0])
 
 


### PR DESCRIPTION
It looks like there's a bug with `pint`. Here's a simple example:

This one works:
```python
def f(C, x, P):
    return np.linalg.norm(P) / np.linalg.norm(C) / x**2

f(np.random.randn(2, 3, 4), np.random.randn(5, 6), np.random.randn(7, 8))
```

This one doesn't:

```python
@ureg.wraps("=P/C/x**2", ("=C", "=x", "=P"))
def f(C, x, P):
    return np.linalg.norm(P) / np.linalg.norm(C) / x**2

f(np.random.randn(2, 3, 4) * ureg.gigapascal, np.random.randn(5, 6) * ureg.meter, np.random.randn(7, 8) * ureg.joule)
```