### PR TITLE
get rid of `otype`

### DIFF
--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -41,8 +41,8 @@ def parse_metadata(value):
         value: Quantity object
 
     Returns:
-        dictionary of the metadata. Available keys are `units`, `otype`,
-        `shape`, and `dtype`. See `semantikon.typing.u` for more details.
+        dictionary of the metadata. Available keys are `units`, `label`,
+        `triple`, `uri` and `shape`. See `semantikon.typing.u` for more details.
     """
     # When there is only one metadata `use_list=False` must have been used
     if len(value.__metadata__) == 1 and isinstance(value.__metadata__[0], str):
@@ -79,8 +79,8 @@ def parse_input_args(func: callable):
         func: function to be parsed
 
     Returns:
-        dictionary of the input arguments. Available keys are `units`, `otype`,
-        and `shape`. See `semantikon.typing.u` for more details.
+        dictionary of the input arguments. Available keys are `units`, `label`,
+        `triple`, `uri` and `shape`. See `semantikon.typing.u` for more details.
     """
     return {
         key: _meta_to_dict(value.annotation)
@@ -97,8 +97,9 @@ def parse_output_args(func: callable):
 
     Returns:
         dictionary of the output arguments if there is only one output. Otherwise,
-        a list of dictionaries is returned. Available keys are `units`, `otype`,
-        and `shape`. See `semantikon.typing.u` for more details.
+        a list of dictionaries is returned. Available keys are `units`,
+        `label`, `triple`, `uri` and `shape`. See `semantikon.typing.u` for
+        more details.
     """
     sig = inspect.signature(func)
     if get_origin(sig.return_annotation) is tuple:

--- a/semantikon/typing.py
+++ b/semantikon/typing.py
@@ -17,7 +17,6 @@ def u(
     /,
     units: str | None = None,
     label: str | None = None,
-    otype: str | tuple | None = None,
     triple: tuple[tuple[str, str, str], ...] | tuple[str, str, str] | None = None,
     uri: str | None = None,
     shape: tuple[int] | None = None,
@@ -27,7 +26,6 @@ def u(
     result = {
         "units": units,
         "label": label,
-        "otype": otype,
         "triple": triple,
         "uri": uri,
         "shape": shape,

--- a/tests/unit/test_dataclass.py
+++ b/tests/unit/test_dataclass.py
@@ -53,7 +53,6 @@ class TestDataclass(unittest.TestCase):
                 "units": "eV",
                 "label": "TotalEnergy",
                 "associate_to_sample": True,
-                "otype": None,
                 "triple": None,
                 "shape": None,
                 "uri": None,


### PR DESCRIPTION
Since the distinction between `otype` and `triple` is not very clear, I guess I'm gonna get rid of `otype` in the end.