### PR TITLE
Double typing

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,16 +12,34 @@ In the realm of the workflow management systems, there are well defined inputs a
 from semantikon.typing import u
 
 def my_function(
-    a: u(int, units="meter"),
-    b: u(int, units="second")
+    distance: u(int, units="meter"),
+    time: u(int, units="second")
 ) -> u(int, units="meter/second", label="speed"):
-    return a / b
+    return distance / time
 ```
 
 `semantikon`'s type hinting does not require to follow any particular standard. It only needs to be compatible with the interpreter applied.
 
 There are two possible ways to store the data for `semantikon`. The standard way is to do it by converting all arguments except for the data type as a string, which is the default behaviour. The other way is to store the data as a list, which is turned on by setting `use_list=True`. In most cases, the default behaviour is the safest option; in some cases, especially when the data cannot be represented as a string, you might want to switch on `use_list`, but `semantikon` is still under intensive development, and therefore there is no guarantee that you can retrieve the data across different versions correctly.
 
+You can also type-hint the inputs and outputs of a function using a class, i.e.:
+
+
+```python
+from semantikon.typing import u
+from semantikon.convert import semantikon_class
+
+@semantikon_class
+class MyRecord:
+    distance: u(int, units="meter")
+    time: u(int, units="second")
+    result: u(int, units="meter/second", label="speed")
+
+def my_function(distance: MyRecord.distance, time: MyRecord.time) -> MyRecord.result:
+    return distance / time
+```
+
+This is equivalent to the previous example. Moreover, if you need to modify some parameters, you can use `u` again, e.g. `u(MyRecord.distance, units="kilometer")`.
 
 ### **Interpreters**
 

--- a/semantikon/typing.py
+++ b/semantikon/typing.py
@@ -1,4 +1,5 @@
 from typing import Annotated, Any
+from semantikon.converter import parse_metadata
 
 __author__ = "Sam Waseda"
 __copyright__ = (
@@ -23,6 +24,10 @@ def u(
     use_list: bool = True,
     **kwargs,
 ):
+    parent_result = {}
+    if hasattr(type_, "__metadata__"):
+        parent_result = parse_metadata(type_)
+        type_ = type_.__origin__
     result = {
         "units": units,
         "label": label,
@@ -30,6 +35,9 @@ def u(
         "uri": uri,
         "shape": shape,
     }
+    for key, value in parent_result.items():
+        if result[key] is None:
+            result[key] = value
     result.update(kwargs)
     if use_list:
         items = [x for k, v in result.items() for x in [k, v]]

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -1,6 +1,6 @@
 import unittest
 from semantikon.typing import u
-from semantikon.converter import parse_input_args, parse_output_args
+from semantikon.converter import parse_input_args, parse_output_args, parse_metadata
 
 
 class TestUnits(unittest.TestCase):
@@ -71,6 +71,16 @@ class TestUnits(unittest.TestCase):
         output_args = parse_output_args(get_speed)
         self.assertIsInstance(output_args, dict)
         self.assertEqual(output_args["dtype"], Output)
+
+    def test_multiple_u(self):
+        initial_type = u(float, units="meter", label="distance")
+        result = parse_metadata(initial_type)
+        self.assertEqual(result["units"], "meter")
+        self.assertEqual(result["label"], "distance")
+        final_type = u(initial_type, units="millimeter")
+        result = parse_metadata(final_type)
+        self.assertEqual(result["units"], "millimeter")
+        self.assertEqual(result["label"], "distance")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Now you can modify parameters defined in a class:

```python
from semantikon.typing import u
from semantikon.convert import semantikon_class

@semantikon_class
class MyRecord:
    distance: u(int, units="meter")
    time: u(int, units="second")
    result: u(int, units="meter/second", label="speed")

def my_function(distance: u(MyRecord.distance, units="kilometer"), time: MyRecord.time) -> MyRecord.result:
    return distance / time
```