### PR TITLE
Enable triple cancellation

### DIFF
--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -414,7 +414,7 @@ def _parse_cancel(nodes: dict, label: str) -> list:
                         triples.append(
                             _parse_triple(c, label=_remove_us(node_label, io_, key))
                         )
-    return (_convert_to_uriref(t) for t in triples)
+    return ((_convert_to_uriref(tt) for tt in t) for t in triples)
 
 
 

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -4,6 +4,7 @@ import warnings
 from rdflib import Graph, Literal, RDF, RDFS, URIRef, OWL, PROV, Namespace
 from dataclasses import is_dataclass
 from semantikon.converter import meta_to_dict, get_function_dict
+from owlrl import DeductiveClosure, OWLRL_Semantics
 
 
 class PNS:
@@ -207,7 +208,7 @@ def _inherit_properties(
         n = len(graph)
 
 
-def validate_values(graph: Graph) -> list:
+def validate_values(graph: Graph, run_reasoner: bool = True) -> list:
     """
     Validate if all values required by restrictions are present in the graph
 
@@ -217,6 +218,8 @@ def validate_values(graph: Graph) -> list:
     Returns:
         (list): list of missing triples
     """
+    if run_reasoner:
+        DeductiveClosure(OWLRL_Semantics).expand(graph)
     missing_triples = []
     for restrictions in graph.subjects(RDF.type, OWL.Restriction):
         on_property = graph.value(restrictions, OWL.onProperty)

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -170,10 +170,7 @@ def _parse_triple(
 
 
 def _inherit_properties(
-    graph: Graph,
-    triples_to_cancel: list | None = None,
-    n_max: int = 1000,
-    ontology=PNS
+    graph: Graph, triples_to_cancel: list | None = None, n_max: int = 1000, ontology=PNS
 ):
     update_query = (
         f"PREFIX ns: <{ontology.BASE}>",
@@ -418,7 +415,6 @@ def _parse_cancel(nodes: dict, label: str) -> list:
                             _parse_triple(c, label=_remove_us(node_label, io_, key))
                         )
     return [tuple([_convert_to_uriref(tt) for tt in t]) for t in triples]
-
 
 
 def get_knowledge_graph(

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -372,7 +372,7 @@ def _parse_workflow(
 ) -> list:
     triples = []
     edge_dict = _get_edge_dict(wf_dict["data_edges"])
-    workflow_label = wf_dict.pop("label")
+    workflow_label = wf_dict["label"]
     if prefix is not None:
         workflow_label = dot(prefix, workflow_label)
     triples.append((workflow_label, RDFS.label, Literal(workflow_label)))

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -414,7 +414,7 @@ def _parse_cancel(nodes: dict, label: str) -> list:
                         triples.append(
                             _parse_triple(c, label=_remove_us(node_label, io_, key))
                         )
-    return ((_convert_to_uriref(tt) for tt in t) for t in triples)
+    return [tuple([_convert_to_uriref(tt) for tt in t]) for t in triples]
 
 
 

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -96,6 +96,43 @@ def add_three(macro, c: int) -> int:
     return w
 
 
+def create_vacancy(
+    structure: str,
+) -> u(
+    str,
+    triples=(
+        (PNS.inheritsPropertiesFrom, "inputs.structure"),
+        (EX.hasDefect, EX.vacancy),
+    ),
+    cancel=(EX.hasState, EX.relaxed),
+):
+    return structure
+
+
+def relax_structure(
+    structure: str,
+) -> u(
+    str,
+    triples=(
+        (PNS.inheritsPropertiesFrom, "inputs.structure"),
+        (EX.hasState, EX.relaxed),
+    ),
+):
+    return structure
+
+
+def get_vacancy_formation_energy(
+    structure: u(
+        str,
+        restrictions=(
+            ((OWL.onProperty, EX.hasDefect), (OWL.someValuesFrom, EX.vacancy)),
+            ((OWL.onProperty, EX.hasState), (OWL.someValuesFrom, EX.relaxed)),
+        ),
+    )
+):
+    return len(structure)
+
+
 def get_speed_dict():
     return {
         "inputs": {
@@ -324,6 +361,72 @@ def get_macro():
     }
 
 
+def get_wrong_order():
+    return {
+        "inputs": {"relaxed__structure": {"value": "abc", "type_hint": str}},
+        "outputs": {"energy__len(structure)": {}},
+        "nodes": {
+            "relaxed": {
+                "inputs": {"structure": {"value": "abc", "type_hint": str}},
+                "outputs": {
+                    "structure": {
+                        "type_hint": u(
+                            str,
+                            triples=(
+                                (PNS.inheritsPropertiesFrom, "inputs.structure"),
+                                (EX.hasState, EX.relaxed),
+                            ),
+                        )
+                    }
+                },
+                "function": relax_structure,
+            },
+            "vac": {
+                "inputs": {"structure": {"type_hint": str}},
+                "outputs": {
+                    "structure": {
+                        "type_hint": u(
+                            str,
+                            triples=(
+                                (PNS.inheritsPropertiesFrom, "inputs.structure"),
+                                (EX.hasDefect, EX.vacancy),
+                            ),
+                            cancel=(EX.hasState, EX.relaxed),
+                        )
+                    }
+                },
+                "function": create_vacancy,
+            },
+            "energy": {
+                "inputs": {
+                    "structure": {
+                        "type_hint": u(
+                            str,
+                            restrictions=(
+                                (
+                                    (OWL.onProperty, EX.hasDefect),
+                                    (OWL.someValuesFrom, EX.vacancy),
+                                ),
+                                (
+                                    (OWL.onProperty, EX.hasState),
+                                    (OWL.someValuesFrom, EX.relaxed),
+                                ),
+                            ),
+                        )
+                    }
+                },
+                "outputs": {"len(structure)": {}},
+                "function": get_vacancy_formation_energy,
+            },
+        },
+        "data_edges": [
+            ("relaxed.outputs.structure", "vac.inputs.structure"),
+            ("vac.outputs.structure", "energy.inputs.structure"),
+        ],
+        "label": "wrong_order",
+    }
+
+
 class TestOntology(unittest.TestCase):
     def test_units_with_sparql(self):
         graph = get_knowledge_graph(get_speed_dict())
@@ -402,6 +505,21 @@ class TestOntology(unittest.TestCase):
         for ii, pair in enumerate(sub_obj):
             with self.subTest(i=ii):
                 self.assertIn(pair, same_as)
+
+    def test_wrong_order(self):
+        data = get_wrong_order()
+        graph = get_knowledge_graph(data)
+        missing_triples = [[str(gg) for gg in g] for g in validate_values(graph)]
+        self.assertEqual(
+            missing_triples,
+            [
+                [
+                    "wrong_order.energy.inputs.structure",
+                    "http://example.org/hasState",
+                    "http://example.org/relaxed",
+                ]
+            ],
+        )
 
 
 @dataclass

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -469,8 +469,6 @@ class TestOntology(unittest.TestCase):
 
     def test_correct_analysis(self):
         graph = get_knowledge_graph(get_correct_analysis_dict())
-        _inherit_properties(graph)
-        DeductiveClosure(OWLRL_Semantics).expand(graph)
         missing_triples = validate_values(graph)
         self.assertEqual(
             len(missing_triples),
@@ -478,8 +476,6 @@ class TestOntology(unittest.TestCase):
             msg=f"{missing_triples} not found in {graph.serialize()}",
         )
         graph = get_knowledge_graph(get_wrong_analysis_dict())
-        _inherit_properties(graph)
-        DeductiveClosure(OWLRL_Semantics).expand(graph)
         self.assertEqual(len(validate_values(graph)), 1)
 
     def test_macro(self):


### PR DESCRIPTION
Basic idea: `create_vacancy` → `relax_structure` != `relax_structure` → `create_vacancy`

## Node

```python
@Workflow.wrap.as_function_node
def create_structure(element: str) -> Atoms:
    structure = build.bulk(element, cubic=True)
    return structure

@Workflow.wrap.as_function_node
def create_vacancy(structure: Atoms) -> u(
    Atoms,
    triples=((PNS.inheritsPropertiesFrom, "inputs.structure"), (EX.hasDefect, EX.vacancy)),
    cancel=(EX.hasState, EX.relaxed)
):
    del structure[0]
    return structure

@Workflow.wrap.as_function_node
def relax_structure(structure: Atoms) -> u(
    Atoms,
    triples=((PNS.inheritsPropertiesFrom, "inputs.structure"), (EX.hasState, EX.relaxed))
):
    return structure

@Workflow.wrap.as_function_node
def get_vacancy_formation_energy(
    structure: u(
        Atoms,
        restrictions=(
            ((OWL.onProperty, EX.hasDefect), (OWL.someValuesFrom, EX.vacancy)),
            ((OWL.onProperty, EX.hasState), (OWL.someValuesFrom, EX.relaxed))))
    ):
    E = len(structure)
    return E
```

## Workflow

### Correct order
```python
wf = Workflow("correct_order")

wf.bulk = create_structure("Al")
wf.vac = create_vacancy(wf.bulk)
wf.relaxed = relax_structure(wf.vac)
wf.energy = get_vacancy_formation_energy(wf.relaxed)

data = export_to_dict(wf)
graph = get_knowledge_graph(data)

print(validate_values(graph))
```

Output: `[]`

### Wrong order

```python
wf = Workflow("wrong_order")

wf.bulk = create_structure("Al")
wf.relaxed = relax_structure(wf.bulk)
wf.vac = create_vacancy(wf.relaxed)
wf.energy = get_vacancy_formation_energy(wf.vac)

data = export_to_dict(wf)
graph = get_knowledge_graph(data)

print(validate_values(graph))
```

Output: `[(rdflib.term.URIRef('wrong_order.energy.inputs.structure'), rdflib.term.URIRef('http://example.org/hasState'), rdflib.term.URIRef('http://example.org/relaxed'))]`