### PR TITLE
Add default and `meta_to_dict` should always return a dict

### DIFF
--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -47,7 +47,7 @@ def parse_metadata(value):
     return {k: v for k, v in zip(metadata[::2], metadata[1::2])}
 
 
-def meta_to_dict(value):
+def meta_to_dict(value, default=inspect.Parameter.empty):
     semantikon_was_used = hasattr(value, "__metadata__")
     type_hint_was_present = value is not inspect.Parameter.empty
     if semantikon_was_used:

--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -82,7 +82,7 @@ def parse_input_args(func: callable):
         `triples`, `uri` and `shape`. See `semantikon.typing.u` for more details.
     """
     return {
-        key: meta_to_dict(value.annotation)
+        key: meta_to_dict(value.annotation, value.default)
         for key, value in inspect.signature(func).parameters.items()
     }
 

--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -53,19 +53,21 @@ def meta_to_dict(value, default=inspect.Parameter.empty):
     if semantikon_was_used:
         result = parse_metadata(value)
         result["dtype"] = value.__args__[0]
-        return result
-    elif type_hint_was_present:
-        return {
+    else:
+        result = {
             "units": None,
             "label": None,
             "triples": None,
             "uri": None,
             "shape": None,
             "restrictions": None,
-            "dtype": value,
+            "dtype": None,
         }
-    else:
-        return None
+        if type_hint_was_present:
+            result["dtype"] = value
+    if default is not inspect.Parameter.empty:
+        result["default"] = default
+    return result
 
 
 def parse_input_args(func: callable):

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -13,7 +13,7 @@ class TestParser(unittest.TestCase):
         @u(uri="abc")
         def get_speed(
             distance: u(float, units="meter"),
-            time: u(float, units="second"),
+            time: u(float, units="second") = 1.0,
         ) -> u(float, units="meter/second", label="speed"):
             return distance / time
 
@@ -31,6 +31,7 @@ class TestParser(unittest.TestCase):
         ]:
             self.assertTrue(key in input_args["distance"])
         self.assertEqual(input_args["distance"]["units"], "meter")
+        self.assertEqual(input_args["time"]["default"], 1.0)
         self.assertEqual(input_args["time"]["units"], "second")
         output_args = parse_output_args(get_speed)
         for key in [
@@ -50,6 +51,13 @@ class TestParser(unittest.TestCase):
         f_dict = get_function_dict(get_speed)
         self.assertEqual(f_dict["uri"], "abc")
         self.assertEqual(f_dict["label"], "get_speed")
+
+    def test_canonical_types(self):
+        def f(x: float) -> float:
+            return x
+
+        input_args = parse_input_args(f)
+        self.assertEqual(input_args["x"]["dtype"], float)
 
     def test_multiple_output_args(self):
         def get_speed(


### PR DESCRIPTION
- If function arguments have default values, they are passed to the dict of `parse_input_args`
- Previously, `parse_input_args` returned `None` when there was no type hint. Now it always returns a dictionary