### PR TITLE
Test readme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ You can also type-hint the inputs and outputs of a function using a class, i.e.:
 
 ```python
 >>> from semantikon.typing import u
->>> from semantikon.convert import semantikon_class
+>>> from semantikon.converter import semantikon_class
 >>> 
 >>> @semantikon_class
 ... class MyRecord:
@@ -79,7 +79,7 @@ Future announcement: There will be no distrinction between `use_list=True` and `
 
 ```python
 >>> from semantikon.typing import u
->>> from semantikon.converters import units
+>>> from semantikon.converter import units
 >>> from pint import UnitRegistry
 >>> 
 >>> @units

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,13 +9,14 @@ In the realm of the workflow management systems, there are well defined inputs a
 `semantikon` provides a way to define types for any number of input parameters and any number of output values for function via type hinting, in particular: data type, unit and ontological type. Type hinting is done with the function `u`, which **requires** the type, and **optionally** you can define the units and the ontological type. The type hinting is done in the following way:
 
 ```python
-from semantikon.typing import u
+>>> from semantikon.typing import u
+>>> 
+>>> def my_function(
+...     distance: u(int, units="meter"),
+...     time: u(int, units="second")
+... ) -> u(int, units="meter/second", label="speed"):
+...     return distance / time
 
-def my_function(
-    distance: u(int, units="meter"),
-    time: u(int, units="second")
-) -> u(int, units="meter/second", label="speed"):
-    return distance / time
 ```
 
 `semantikon`'s type hinting does not require to follow any particular standard. It only needs to be compatible with the interpreter applied.
@@ -26,17 +27,18 @@ You can also type-hint the inputs and outputs of a function using a class, i.e.:
 
 
 ```python
-from semantikon.typing import u
-from semantikon.convert import semantikon_class
+>>> from semantikon.typing import u
+>>> from semantikon.convert import semantikon_class
+>>> 
+>>> @semantikon_class
+... class MyRecord:
+...     distance: u(int, units="meter")
+...     time: u(int, units="second")
+...     result: u(int, units="meter/second", label="speed")
+>>> 
+>>> def my_function(distance: MyRecord.distance, time: MyRecord.time) -> MyRecord.result:
+...     return distance / time
 
-@semantikon_class
-class MyRecord:
-    distance: u(int, units="meter")
-    time: u(int, units="second")
-    result: u(int, units="meter/second", label="speed")
-
-def my_function(distance: MyRecord.distance, time: MyRecord.time) -> MyRecord.result:
-    return distance / time
 ```
 
 This is equivalent to the previous example. Moreover, if you need to modify some parameters, you can use `u` again, e.g. `u(MyRecord.distance, units="kilometer")`.
@@ -50,24 +52,21 @@ In order to extract argument information, you can use the functions `parse_input
 Example:
 
 ```python
-from semantikon.typing import u
-from semantikon.converter import parse_input_args, parse_output_args
-
-def my_function(
-    a: u(int, units="meter"),
-    b: u(int, units="second")
-) -> u(int, units="meter/second", label="speed"):
-    return a / b
-
-print(parse_input_args(my_function))
-print(parse_output_args(my_function))
-```
-
-Output:
-
-```python
+>>> from semantikon.typing import u
+>>> from semantikon.converter import parse_input_args, parse_output_args
+>>> 
+>>> def my_function(
+...     a: u(int, units="meter"),
+...     b: u(int, units="second")
+... ) -> u(int, units="meter/second", label="speed"):
+...     return a / b
+>>> 
+>>> print(parse_input_args(my_function))
 {'distance': {'units': 'meter', 'label': None, 'uri': None, 'shape': None, 'dtype': <class 'float'>}, 'time': {'units': 'second', 'label': None, 'uri': None, 'shape': None, 'dtype': <class 'float'>}}
+
+>>> print(parse_output_args(my_function))
 {'units': 'meter/second', 'label': 'speed', 'uri': None, 'shape': None, 'dtype': <class 'float'>}
+
 ```
 
 Here the output is the same whether `use_list` is set to `True` or `False`. When `use_list` is `False`, you can use additionally any tag that you want to store. When `use_list` is `True`, you can store only the data type, `units`, `label`, `uri`, `shape` and `dtype`.
@@ -79,25 +78,23 @@ Future announcement: There will be no distrinction between `use_list=True` and `
 `semantikon` provides a way to interpret the types of inputs and outputs of a function via a decorator, in order to check consistency of the types and to convert them if necessary. Currently, `semantikon` provides an interpreter for `pint.UnitRegistry` objects. The interpreter is applied in the following way:
 
 ```python
-from semantikon.typing import u
-from semantikon.converters import units
-from pint import UnitRegistry
+>>> from semantikon.typing import u
+>>> from semantikon.converters import units
+>>> from pint import UnitRegistry
+>>> 
+>>> @units
+... def my_function(
+...     a: u(int, units="meter"),
+...     b: u(int, units="second")
+... ) -> u(int, units="meter/second", label="speed"):
+...     return a / b
+>>> 
+>>> ureg = UnitRegistry()
+>>> 
+>>> print(my_function(1 * ureg.meter, 1 * ureg.second))
+1.0 meter / second
 
-@units
-def my_function(
-    a: u(int, units="meter"),
-    b: u(int, units="second")
-) -> u(int, units="meter/second", label="speed"):
-    return a / b
-
-
-ureg = UnitRegistry()
-
-print(my_function(1 * ureg.meter, 1 * ureg.second))
 ```
-
-Output: `1.0 meter / second`
-
 
 The interpreters check all types and, if necessary, convert them to the expected types **before** the function is executed, in order for all possible errors would be raised before the function execution. The interpreters convert the types in the way that the underlying function would receive the raw values.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,10 +62,10 @@ Example:
 ...     return a / b
 >>> 
 >>> print(parse_input_args(my_function))
-{'distance': {'units': 'meter', 'label': None, 'uri': None, 'shape': None, 'dtype': <class 'float'>}, 'time': {'units': 'second', 'label': None, 'uri': None, 'shape': None, 'dtype': <class 'float'>}}
+{'a': {'units': 'meter', 'label': None, 'triples': None, 'uri': None, 'shape': None, 'restrictions': None, 'dtype': <class 'int'>}, 'b': {'units': 'second', 'label': None, 'triples': None, 'uri': None, 'shape': None, 'restrictions': None, 'dtype': <class 'int'>}}
 
 >>> print(parse_output_args(my_function))
-{'units': 'meter/second', 'label': 'speed', 'uri': None, 'shape': None, 'dtype': <class 'float'>}
+{'units': 'meter/second', 'label': 'speed', 'triples': None, 'uri': None, 'shape': None, 'restrictions': None, 'dtype': <class 'int'>}
 
 ```
 


### PR DESCRIPTION
Closes #58 

- Reformatting was trivial, but should later be applied to docstring examples in a similar way.
- Module updates were trivial, just variations on the path name
- Print results were seriously out of date with the example code, but I also just trivially copied and pasted whatever the test was saying I actually got to force the test to pass.