### PR TITLE
Return only items defined

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -66,8 +66,8 @@ print(parse_output_args(my_function))
 Output:
 
 ```python
-{'distance': {'units': 'meter', 'label': None, 'uri': None, 'shape': None, 'dtype': <class 'float'>}, 'time': {'units': 'second', 'label': None, 'uri': None, 'shape': None, 'dtype': <class 'float'>}}
-{'units': 'meter/second', 'label': 'speed', 'uri': None, 'shape': None, 'dtype': <class 'float'>}
+{'distance': {'units': 'meter', 'dtype': <class 'float'>}, 'time': {'units': 'second', 'dtype': <class 'float'>}}
+{'units': 'meter/second', 'label': 'speed', 'dtype': <class 'float'>}
 ```
 
 Here the output is the same whether `use_list` is set to `True` or `False`. When `use_list` is `False`, you can use additionally any tag that you want to store. When `use_list` is `True`, you can store only the data type, `units`, `label`, `uri`, `shape` and `dtype`.

--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -50,22 +50,15 @@ def parse_metadata(value):
 def meta_to_dict(value, default=inspect.Parameter.empty):
     semantikon_was_used = hasattr(value, "__metadata__")
     type_hint_was_present = value is not inspect.Parameter.empty
+    default_is_defined = default is not inspect.Parameter.empty
     if semantikon_was_used:
-        result = parse_metadata(value)
+        result = {k: v for k, v in parse_metadata(value).items() if v is not None}
         result["dtype"] = value.__args__[0]
     else:
-        result = {
-            "units": None,
-            "label": None,
-            "triples": None,
-            "uri": None,
-            "shape": None,
-            "restrictions": None,
-            "dtype": None,
-        }
+        result = {}
         if type_hint_was_present:
             result["dtype"] = value
-    if default is not inspect.Parameter.empty:
+    if default_is_defined:
         result["default"] = default
     return result
 

--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -105,7 +105,7 @@ def _get_converter(func):
     args = []
     for value in parse_input_args(func).values():
         if value is not None:
-            args.append(value["units"])
+            args.append(value.get("units", None))
         else:
             args.append(None)
     if any([arg is not None for arg in args]):
@@ -117,7 +117,7 @@ def _get_converter(func):
 def _get_ret_units(output, ureg, names):
     if output is None:
         return None
-    ret = _to_units_container(output["units"], ureg)
+    ret = _to_units_container(output.get("units", None), ureg)
     names = {key: 1.0 * value.units for key, value in names.items()}
     return ureg.Quantity(1, _replace_units(ret[0], names) if ret[1] else ret[0])
 

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -19,31 +19,18 @@ class TestParser(unittest.TestCase):
 
         input_args = parse_input_args(get_speed)
         for key in ["distance", "time"]:
-            self.assertTrue(key in input_args)
-        for key in [
-            "units",
-            "uri",
-            "triples",
-            "shape",
-            "label",
-            "restrictions",
-            "dtype",
-        ]:
-            self.assertTrue(key in input_args["distance"])
+            self.assertIn(key, input_args)
+        for key in ["units", "dtype"]:
+            self.assertIn(key, input_args["distance"])
         self.assertEqual(input_args["distance"]["units"], "meter")
         self.assertEqual(input_args["time"]["default"], 1.0)
         self.assertEqual(input_args["time"]["units"], "second")
         output_args = parse_output_args(get_speed)
         for key in [
             "units",
-            "uri",
-            "triples",
-            "shape",
-            "label",
-            "restrictions",
             "dtype",
         ]:
-            self.assertTrue(key in output_args)
+            self.assertIn(key, output_args)
         self.assertEqual(output_args["units"], "meter/second")
         self.assertEqual(output_args["label"], "speed")
         self.assertEqual(get_speed._semantikon_metadata["uri"], "abc")
@@ -72,16 +59,7 @@ class TestParser(unittest.TestCase):
         output_args = parse_output_args(get_speed)
         self.assertIsInstance(output_args, tuple)
         for output_arg in output_args:
-            for key in [
-                "units",
-                "uri",
-                "triples",
-                "shape",
-                "label",
-                "restrictions",
-                "dtype",
-            ]:
-                self.assertTrue(key in output_arg)
+            self.assertIn("dtype", output_arg)
         self.assertEqual(output_args[0]["units"], "meter/second")
         self.assertEqual(output_args[0]["label"], "speed")
         self.assertEqual(output_args[1]["units"], "meter")


### PR DESCRIPTION
There are default keys (such as "triples") in `u` which were set to `None` if they are not defined. I had the following problems:

- There might be a conflict with an actual definition of `None` (for example with `default`)
- Some keys were always present, while other keys (such as `dtype` and `default`) appeared only when they were defined

In order to overcome this problem, I decided to include the keys only if they were explicitly defined.