### PR TITLE
Update units check

### DIFF
--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -59,6 +59,7 @@ def get_speed_relative(
 ) -> u(float, units="=A/B"):
     return distance / time
 
+
 @units
 def return_dict(
     distance: u(float, units="meter"), time: u(float, units="second")

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -59,6 +59,12 @@ def get_speed_relative(
 ) -> u(float, units="=A/B"):
     return distance / time
 
+@units
+def return_dict(
+    distance: u(float, units="meter"), time: u(float, units="second")
+) -> dict:
+    return {"distance": distance, "time": time}
+
 
 class TestUnits(unittest.TestCase):
     def test_relative(self):
@@ -169,6 +175,11 @@ class TestUnits(unittest.TestCase):
             get_speed_use_list(1.0 * ureg.millimeter, 1.0 * ureg.second),
             0.001 * ureg.meter / ureg.second,
         )
+
+    def test_return_dict(self):
+        self.assertEqual(return_dict(1, 1), {"distance": 1, "time": 1})
+        ureg = UnitRegistry()
+        self.assertIsInstance(return_dict(1 * ureg.meter, 1 * ureg.second), dict)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Before, the units were multiplied with the output value regardless of whether it was defined or not, but it doesn't work if for example `dict` is returned. It's fixed with this change.