### PR TITLE
Return only terms defined

### DIFF
--- a/semantikon/typing.py
+++ b/semantikon/typing.py
@@ -28,23 +28,22 @@ def _type_metadata(
     restrictions: tuple[tuple[str, str]] | None = None,
     **kwargs,
 ):
-    parent_result = {}
     if _is_annotated(type_):
-        parent_result = parse_metadata(type_)
+        kwargs.update(parse_metadata(type_))
         type_ = type_.__origin__
-    result = {
-        "units": units,
-        "label": label,
-        "triples": triples,
-        "uri": uri,
-        "shape": shape,
-        "restrictions": restrictions,
-    }
-    for key, value in parent_result.items():
-        if result[key] is None:
-            result[key] = value
-    result.update(kwargs)
-    items = [x for k, v in result.items() for x in [k, v]]
+    kwargs.update(
+        _kwargs_to_dict(
+            units=units,
+            label=label,
+            triples=triples,
+            uri=uri,
+            shape=shape,
+            restrictions=restrictions,
+        )
+    )
+    if len(kwargs) == 0:
+        raise ValueError("No metadata provided.")
+    items = [x for k, v in kwargs.items() for x in [k, v]]
     return Annotated[type_, items]
 
 
@@ -67,6 +66,10 @@ def _function_metadata(
     return decorator
 
 
+def _kwargs_to_dict(**kwargs):
+    return {k: v for k, v in kwargs.items() if v is not None}
+
+
 def u(
     type_or_func=None,
     /,
@@ -83,14 +86,14 @@ def u(
     )
     is_decorator = type_or_func is None
     kwargs.update(
-        {
-            "units": units,
-            "label": label,
-            "triples": triples,
-            "uri": uri,
-            "shape": shape,
-            "restrictions": restrictions,
-        }
+        _kwargs_to_dict(
+            units=units,
+            label=label,
+            triples=triples,
+            uri=uri,
+            shape=shape,
+            restrictions=restrictions,
+        )
     )
     if is_type_hint:
         return _type_metadata(type_or_func, **kwargs)

--- a/semantikon/typing.py
+++ b/semantikon/typing.py
@@ -42,7 +42,7 @@ def _type_metadata(
         )
     )
     if len(kwargs) == 0:
-        raise ValueError("No metadata provided.")
+        raise TypeError("No metadata provided.")
     items = [x for k, v in kwargs.items() for x in [k, v]]
     return Annotated[type_, items]
 

--- a/tests/unit/test_dataclass.py
+++ b/tests/unit/test_dataclass.py
@@ -56,13 +56,9 @@ class TestDataclass(unittest.TestCase):
         self.assertEqual(
             metadata,
             {
+                "associate_to_sample": True,
                 "units": "eV",
                 "label": "TotalEnergy",
-                "associate_to_sample": True,
-                "triples": None,
-                "shape": None,
-                "uri": None,
-                "restrictions": None,
             },
         )
 

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -233,7 +233,7 @@ class TestOntology(unittest.TestCase):
         subj = list(
             graph.subjects(
                 PNS.hasValue,
-                URIRef("get_macro.add_three_0.add_two_0.outputs.output.value")
+                URIRef("get_macro.add_three_0.add_two_0.outputs.output.value"),
             )
         )
         self.assertEqual(len(subj), 3, msg=f"{subj} not found in {graph.serialize()}")
@@ -241,7 +241,7 @@ class TestOntology(unittest.TestCase):
             [
                 "add_three_0.add_two_0.outputs.output",
                 "add_three_0.outputs.w",
-                "add_one_0.inputs.a"
+                "add_one_0.inputs.a",
             ]
         ):
             with self.subTest(i=ii):

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -99,6 +99,11 @@ class TestParser(unittest.TestCase):
         self.assertEqual(result["units"], "millimeter")
         self.assertEqual(result["label"], "distance")
 
+    def test_invalid_u(self):
+        with self.assertRaises(TypeError) as context:
+            u(float)
+        self.assertEqual(str(context.exception), "No metadata provided.")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Since [this PR](https://github.com/pyiron/semantikon/pull/60) only the terms defined are parsed, meaning it also makes little sense to return them in `u`. So I removed them