### PR TITLE
Restructure parsing functions

### DIFF
--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -395,7 +395,9 @@ def _parse_workflow(
     )
     full_edge_dict = _get_full_edge_dict(wf_dict)
     triples.extend(
-        _nodes_to_triples(wf_dict["nodes"], full_edge_dict, workflow_label, ontology)
+        _nodes_to_triples(
+            wf_dict["nodes"], full_edge_dict, workflow_label, ontology
+        )
     )
     return triples
 

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -318,14 +318,6 @@ def _node_to_triples(n_label: str, node: dict, edge_dict: dict, prefix: str, ont
     return triples
 
 
-def _nodes_to_triples(nodes: dict, edge_dict: dict, prefix: str, ontology=PNS) -> list:
-    return [
-        n
-        for n_label, node in nodes.items()
-        for n in _node_to_triples(n_label, node, edge_dict, prefix, ontology)
-    ]
-
-
 def _remove_us(*arg) -> str:
     s = ".".join(arg)
     return ".".join(t.split("__")[-1] for t in s.split("."))
@@ -365,7 +357,7 @@ def _get_edge_dict(edges: list) -> dict:
 
 
 def _dot(*args):
-    return ".".join(args)
+    return ".".join([a for a in args if a is not None])
 
 
 def _convert_edge_triples(inp: str, out: str, prefix: str, ontology=PNS) -> tuple:
@@ -395,9 +387,13 @@ def _parse_workflow(
     )
     full_edge_dict = _get_full_edge_dict(wf_dict)
     triples.extend(
-        _nodes_to_triples(
-            wf_dict["nodes"], full_edge_dict, workflow_label, ontology
-        )
+        [
+            n
+            for n_label, node in wf_dict["nodes"].items()
+            for n in _node_to_triples(
+                n_label, node, full_edge_dict, workflow_label, ontology
+            )
+        ]
     )
     return triples
 

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -379,7 +379,6 @@ def _parse_workflow(
     workflow_label = wf_dict["label"]
     if prefix is not None:
         workflow_label = _dot(prefix, workflow_label)
-    triples.append((workflow_label, RDFS.label, Literal(workflow_label)))
     triples.extend(
         _edges_to_triples(
             _get_edge_dict(wf_dict["data_edges"]), workflow_label, ontology

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -271,7 +271,6 @@ def _parse_channel(
     channel_dict: dict, channel_label: str, edge_dict: str, prefix: str, ontology=PNS
 ):
     triples = []
-    triples.append((channel_label, RDFS.label, Literal(channel_label)))
     triples.append((channel_label, RDF.type, PROV.Entity))
     if channel_dict.get("uri", None) is not None:
         triples.append((channel_label, RDF.type, channel_dict["uri"]))

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -305,7 +305,7 @@ def _nodes_to_triples(nodes: dict, edge_dict: dict, prefix: str, ontology=PNS) -
         triples.extend(_parse_node(node, node_label, prefix, ontology))
         if "nodes" in node:
             triples.extend(
-                _parse_workflow(node, edge_dict, prefix=prefix, ontology=ontology)
+                _parse_workflow(node, prefix=prefix, ontology=ontology)
             )
         for io_ in ["inputs", "outputs"]:
             for key, channel_dict in node[io_].items():
@@ -381,7 +381,7 @@ def _edges_to_triples(edges: list, prefix: str, ontology=PNS) -> list:
 
 
 def _parse_workflow(
-    wf_dict: dict, full_edge_dict: dict, prefix=None, ontology=PNS
+    wf_dict: dict, prefix=None, ontology=PNS
 ) -> list:
     triples = []
     workflow_label = wf_dict["label"]
@@ -393,6 +393,7 @@ def _parse_workflow(
             _get_edge_dict(wf_dict["data_edges"]), workflow_label, ontology
         )
     )
+    full_edge_dict = _get_full_edge_dict(wf_dict)
     triples.extend(
         _nodes_to_triples(wf_dict["nodes"], full_edge_dict, workflow_label, ontology)
     )
@@ -440,8 +441,7 @@ def get_knowledge_graph(
     """
     if graph is None:
         graph = Graph()
-    full_edge_dict = _get_full_edge_dict(wf_dict)
-    triples = _parse_workflow(wf_dict, full_edge_dict, ontology=ontology)
+    triples = _parse_workflow(wf_dict, ontology=ontology)
     triples_to_cancel = _parse_cancel(wf_dict["nodes"], wf_dict["label"])
     for triple in triples:
         if any(t is None for t in triple):

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -1,4 +1,5 @@
 import unittest
+from textwrap import dedent
 from rdflib import Graph, OWL, Namespace, URIRef, Literal, RDF, RDFS
 from owlrl import DeductiveClosure, OWLRL_Semantics
 from semantikon.typing import u
@@ -259,6 +260,90 @@ class TestOntology(unittest.TestCase):
         for ii, pair in enumerate(sub_obj):
             with self.subTest(i=ii):
                 self.assertIn(pair, same_as)
+
+    def test_macro_full_comparison(self):
+        txt = dedent("""\
+        @prefix ns1: <http://pyiron.org/ontology/> .
+        @prefix owl: <http://www.w3.org/2002/07/owl#> .
+        @prefix prov: <http://www.w3.org/ns/prov#> .
+        @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+        <get_macro.add_one_0.inputs.a> a prov:Entity ;
+            ns1:hasValue <get_macro.add_three_0.add_two_0.outputs.output.value> ;
+            ns1:inheritsPropertiesFrom <get_macro.add_three_0.outputs.w> ;
+            ns1:inputOf <get_macro.add_one_0> ;
+            ns1:outputOf <get_macro.add_three_0> .
+
+        <get_macro.add_three_0.add_one_0.inputs.a> a prov:Entity ;
+            ns1:hasValue <get_macro.inputs.c.value> ;
+            ns1:inputOf <get_macro.add_three_0.add_one_0> ;
+            owl:sameAs <get_macro.add_three_0.inputs.c> .
+
+        <get_macro.add_three_0.add_two_0.inputs.b> a prov:Entity ;
+            ns1:hasValue <get_macro.add_three_0.add_one_0.outputs.output.value> ;
+            ns1:inheritsPropertiesFrom <get_macro.add_three_0.add_one_0.outputs.output> ;
+            ns1:inputOf <get_macro.add_three_0.add_two_0> ;
+            ns1:outputOf <get_macro.add_three_0.add_one_0> .
+
+        <get_macro.outputs.result> a prov:Entity ;
+            ns1:hasValue <get_macro.add_one_0.outputs.output.value> ;
+            ns1:outputOf <get_macro> ;
+            owl:sameAs <get_macro.add_one_0.outputs.output> .
+
+        <get_macro.add_one_0.outputs.output> a prov:Entity ;
+            ns1:hasValue <get_macro.add_one_0.outputs.output.value> ;
+            ns1:outputOf <get_macro.add_one_0> .
+
+        <get_macro.add_three_0.add_one_0.outputs.output> a prov:Entity ;
+            ns1:hasValue <get_macro.add_three_0.add_one_0.outputs.output.value> ;
+            ns1:outputOf <get_macro.add_three_0.add_one_0> .
+
+        <get_macro.add_three_0.add_two_0.outputs.output> a prov:Entity ;
+            ns1:hasValue <get_macro.add_three_0.add_two_0.outputs.output.value> ;
+            ns1:outputOf <get_macro.add_three_0.add_two_0> .
+
+        <get_macro.add_three_0.inputs.c> a prov:Entity ;
+            ns1:hasValue <get_macro.inputs.c.value> ;
+            ns1:inputOf <get_macro.add_three_0> ;
+            owl:sameAs <get_macro.inputs.c> .
+
+        <get_macro.add_three_0.outputs.w> a prov:Entity ;
+            ns1:hasValue <get_macro.add_three_0.add_two_0.outputs.output.value> ;
+            ns1:outputOf <get_macro.add_three_0> ;
+            owl:sameAs <get_macro.add_three_0.add_two_0.outputs.output> .
+
+        <get_macro.inputs.c> a prov:Entity ;
+            ns1:hasValue <get_macro.inputs.c.value> ;
+            ns1:inputOf <get_macro> .
+
+        <get_macro> a prov:Activity ;
+            ns1:hasNode <get_macro.add_one_0>,
+                <get_macro.add_three_0> .
+
+        <get_macro.add_one_0.outputs.output.value> rdf:value 5 .
+
+        <get_macro.add_three_0.add_one_0.outputs.output.value> rdf:value 2 .
+
+        <get_macro.add_one_0> a prov:Activity ;
+            ns1:hasSourceFunction <add_one> .
+
+        <get_macro.add_three_0.add_two_0> a prov:Activity ;
+            ns1:hasSourceFunction <add_two> .
+
+        <get_macro.add_three_0.add_two_0.outputs.output.value> rdf:value 4 .
+
+        <get_macro.inputs.c.value> rdf:value 1 .
+
+        <get_macro.add_three_0> a prov:Activity ;
+            ns1:hasNode <get_macro.add_three_0.add_one_0>,
+                <get_macro.add_three_0.add_two_0> .
+
+        <get_macro.add_three_0.add_one_0> a prov:Activity ;
+            ns1:hasSourceFunction <add_one> .\n\n""")
+        self.maxDiff = None
+        graph = get_knowledge_graph(get_macro.run())
+        self.assertEqual(graph.serialize(format="turtle"), txt)
 
     def test_wrong_order(self):
         graph = get_knowledge_graph(get_wrong_order._semantikon_workflow)


### PR DESCRIPTION
I unified `_nodes_to_triples` and `_parse_workflow` to `_parse_workflow`, because there should not be a difference between a node and a workflow.