### PR TITLE
Use sparql for the missing triples

### DIFF
--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -217,14 +217,18 @@ class TestOntology(unittest.TestCase):
 
     def test_correct_analysis(self):
         graph = get_knowledge_graph(get_correct_analysis._semantikon_workflow)
-        missing_triples = validate_values(graph)
+        missing_triples = validate_values(graph, sparql=True)
         self.assertEqual(
             len(missing_triples),
             0,
             msg=f"{missing_triples} not found in {graph.serialize()}",
         )
         graph = get_knowledge_graph(get_wrong_analysis._semantikon_workflow)
-        self.assertEqual(len(validate_values(graph)), 1)
+        self.assertEqual(len(validate_values(graph, sparql=True)), 1)
+        self.assertEqual(
+            validate_values(graph, sparql=True),
+            validate_values(graph, sparql=False),
+        )
 
     def test_macro(self):
         graph = get_knowledge_graph(get_macro.run())


### PR DESCRIPTION
ChatGPT says SPARQL is probably more efficient especially when we start dealing with the SPARQL database, so I added the restriction check with SPARQL but in principle nothing should have changed.