### PR TITLE
Add SHACL support for the restrictions

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -8,3 +8,4 @@ dependencies:
 - rdflib =7.1.1
 - owlrl =7.1.2
 - networkx =3.4.2
+- pyshacl =0.30.0

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -8,3 +8,4 @@ dependencies:
 - rdflib =7.1.1
 - owlrl =7.1.2
 - networkx =3.4.2
+- pyshacl =0.30.0

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -14,3 +14,4 @@ dependencies:
 - rdflib =7.1.1
 - owlrl =7.1.2
 - networkx =3.4.2
+- pyshacl =0.30.0

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -1,7 +1,7 @@
 from typing import TypeAlias, Any
 import warnings
 
-from rdflib import Graph, Literal, RDF, RDFS, URIRef, OWL, PROV, Namespace, BNode
+from rdflib import Graph, Literal, RDF, RDFS, URIRef, OWL, PROV, Namespace, BNode, SH
 from dataclasses import is_dataclass
 from semantikon.converter import meta_to_dict, get_function_dict
 from owlrl import DeductiveClosure, OWLRL_Semantics
@@ -97,6 +97,32 @@ def _validate_restriction_format(
         raise ValueError("Restrictions must be tuples of URIRefs")
 
 
+def _get_restriction_type(restriction: tuple[_rest_type]) -> URIRef:
+    if restriction[0][0].startswith(OWL):
+        return "OWL"
+    elif restriction[0][0].startswith(SH):
+        return "SH"
+    raise ValueError(f"Unknown restriction type {restriction}")
+
+
+def _owl_restriction_to_triple(restriction: tuple[_rest_type]) -> list:
+    label = BNode()
+    triples = [(None, RDF.type, label), (label, RDF.type, OWL.Restriction)]
+    triples.extend([(label, r[0], r[1]) for r in restriction])
+    return triples
+
+
+def _sh_restriction_to_triple(restrictions: tuple[_rest_type]) -> list:
+    label = BNode()
+    triples = [
+        (None, RDF.type, SH.NodeShape),
+        (None, SH.targetClass, None),
+        (None, SH.property, label),
+    ]
+    triples.extend([(label, r[0], r[1]) for r in restrictions])
+    return triples
+
+
 def _restriction_to_triple(
     restrictions: _rest_type | tuple[_rest_type] | list[_rest_type],
 ) -> list[tuple[URIRef | None, URIRef, URIRef]]:
@@ -126,13 +152,13 @@ def _restriction_to_triple(
     >>> )
     """
     restrictions_collection = _validate_restriction_format(restrictions)
-    triples: list[tuple[URIRef | None, URIRef, URIRef]] = []
+    triples = []
     for r in restrictions_collection:
-        label = BNode()
-        triples.append((label, RDF.type, OWL.Restriction))
-        for rr in r:
-            triples.append((label, rr[0], rr[1]))
-        triples.append((None, RDF.type, label))
+        restriction_type = _get_restriction_type(r)
+        if restriction_type == "OWL":
+            triples.extend(_owl_restriction_to_triple(r))
+        else:
+            triples.extend(_sh_restriction_to_triple(r))
     return triples
 
 

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -114,10 +114,12 @@ def _owl_restriction_to_triple(restriction: tuple[_rest_type]) -> list:
 
 def _sh_restriction_to_triple(restrictions: tuple[_rest_type]) -> list:
     label = BNode()
+    node = restrictions[0][0] + "Node"
     triples = [
-        (None, RDF.type, SH.NodeShape),
-        (None, SH.targetClass, None),
-        (None, SH.property, label),
+        (None, RDF.type, node),
+        (node, RDF.type, SH.NodeShape),
+        (node, SH.targetClass, node),
+        (node, SH.property, label),
     ]
     triples.extend([(label, r[0], r[1]) for r in restrictions])
     return triples


### PR DESCRIPTION
Now you can write something like this:

```python
def calculate_energy(
    structure: u(
        Atoms, restrictions=(((SH.path, EX.hasDefect), (SH.hasValue, EX.vacancy)), ((OWL.onProperty, EX.isState), (OWL.someValuesFrom, EX.relaxed)))
    )
):
    ...
```

The two restrictions are equivalent, i.e. instead of writing `((SH.path, EX.hasDefect), (SH.hasValue, EX.vacancy))`, I could also write `((OWL.onProperty, EX.hasDefect), (OWL.someValuesFrom, EX.vacancy))` and equally instead of `((OWL.onProperty, EX.isState), (OWL.someValuesFrom, EX.relaxed))` I can write `((SH.path, EX.isState), (SH.hasValue, EX.relaxed))`