### PR TITLE
Enable output replacement

### DIFF
--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -10,12 +10,11 @@ from semantikon.converter import parse_input_args, parse_output_args
 
 
 def _check_node(node):
-    if isinstance(
-        node.value, (ast.BinOp, ast.Call, ast.Attribute, ast.Subscript)
-    ):
+    if isinstance(node.value, (ast.BinOp, ast.Call, ast.Attribute, ast.Subscript)):
         warnings.warn(
             "Return statement contains an operation or function call, replaced"
-            " by `output`", SyntaxWarning
+            " by `output`",
+            SyntaxWarning,
         )
         return ["output"]
     elif isinstance(node.value, ast.Tuple):  # If returning multiple values

--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -4,13 +4,31 @@ from networkx.algorithms.dag import topological_sort
 import inspect
 from collections import deque
 from functools import cached_property
+import warnings
 
 from semantikon.converter import parse_input_args, parse_output_args
 
 
 def _check_node(node):
-    if isinstance(node.value, (ast.BinOp, ast.Call, ast.Attribute, ast.Subscript)):
-        raise ValueError("Return statement contains an operation or function call.")
+    if isinstance(
+        node.value, (ast.BinOp, ast.Call, ast.Attribute, ast.Subscript)
+    ):
+        warnings.warn(
+            "Return statement contains an operation or function call, replaced"
+            " by `output`", SyntaxWarning
+        )
+        return ["output"]
+    elif isinstance(node.value, ast.Tuple):  # If returning multiple values
+        for elt in node.value.elts:
+            if not isinstance(elt, ast.Name):
+                raise ValueError(f"Invalid return value: {ast.dump(elt)}")
+        return [elt.id for elt in node.value.elts if isinstance(elt, ast.Name)]
+
+    elif isinstance(node.value, ast.Name):  # If returning a single variable
+        return [node.value.id]
+
+    else:
+        raise ValueError(f"Invalid return value: {ast.dump(node.value)}")
 
 
 def get_return_variables(func):
@@ -18,19 +36,7 @@ def get_return_variables(func):
     for node in ast.walk(source):
         if not isinstance(node, ast.Return):
             continue
-        _check_node(node)
-        if isinstance(node.value, ast.Tuple):  # If returning multiple values
-            for elt in node.value.elts:
-                if not isinstance(elt, ast.Name):
-                    raise ValueError(f"Invalid return value: {ast.dump(elt)}")
-            return [elt.id for elt in node.value.elts if isinstance(elt, ast.Name)]
-
-        elif isinstance(node.value, ast.Name):  # If returning a single variable
-            return [node.value.id]
-
-        else:
-            raise ValueError(f"Invalid return value: {ast.dump(node.value)}")
-
+        return _check_node(node)
     return []
 
 

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -65,7 +65,8 @@ class TestWorkflow(unittest.TestCase):
 
     def test_get_return_variables(self):
         self.assertEqual(get_return_variables(example_macro), ["f"])
-        self.assertRaises(ValueError, get_return_variables, add)
+        with self.assertWarns(SyntaxWarning):
+            self.assertEqual(get_return_variables(add), ["output"])
         self.assertRaises(ValueError, get_return_variables, operation)
 
     def test_get_output_counts(self):


### PR DESCRIPTION
In order to check compatibility between nodes, I allow more complex output, which would be replaced by `output`, such as

```python
def add(x: float = 2.0, y: float = 1) -> float:
    return x + y 
```

Then the output is replaced by `add.output`.