### PR TITLE
Raise `NotImplementedError` for all invalid operations

### DIFF
--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -66,6 +66,8 @@ class FunctionFlowAnalyzer(ast.NodeVisitor):
             else:
                 tag = f"{source.id}_{self._var_index[source.id]}"
             self.graph.add_edge(tag, target, type="input", **kwargs)
+        else:
+            raise NotImplementedError(f"Invalid input: {ast.dump(source)}")
 
     def _get_func_name(self, node):
         for ii in range(100):

--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -96,6 +96,8 @@ class FunctionFlowAnalyzer(ast.NodeVisitor):
                 self._add_input_edge(arg, called_func, input_index=index)
             for kw in node.value.keywords:
                 self._add_input_edge(kw.value, called_func, input_name=kw.arg)
+        else:
+            raise SyntaxError("Only function calls are allowed in assignments")
 
         self.generic_visit(node)
 

--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -97,7 +97,7 @@ class FunctionFlowAnalyzer(ast.NodeVisitor):
             for kw in node.value.keywords:
                 self._add_input_edge(kw.value, called_func, input_name=kw.arg)
         else:
-            raise SyntaxError("Only function calls are allowed in assignments")
+            raise NotImplementedError("Only function calls are allowed in assignments")
 
         self.generic_visit(node)
 

--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -81,11 +81,11 @@ class FunctionFlowAnalyzer(ast.NodeVisitor):
                 raise ValueError(f"Function {node.value.func.id} not defined")
             self.function_defs[called_func] = self.scope[node.value.func.id]
 
-            is_multi_assignment = len(node.targets) == 1 and isinstance(
+            is_multi_outputs = len(node.targets) == 1 and isinstance(
                 node.targets[0], ast.Tuple
             )
 
-            if is_multi_assignment:
+            if is_multi_outputs:
                 for index, target in enumerate(node.targets[0].elts):
                     self._add_output_edge(called_func, target, output_index=index)
             else:

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -207,6 +207,17 @@ class TestWorkflow(unittest.TestCase):
         data = example_workflow.run()
         self.assertEqual(example_workflow(), data["outputs"]["z"]["value"])
 
+    def test_syntax_error(self):
+
+        def example_syntax_error(a=10, b=20):
+            y = example_macro(a, b)
+            z = add(y, b)
+            result = z + 1
+            return result
+
+        with self.assertRaises(SyntaxError):
+            workflow(example_syntax_error)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -44,6 +44,13 @@ def parallel_execution(a=10, b=20):
     return e, f
 
 
+def example_not_implemented_error(a=10, b=20):
+    y = example_macro(a, b)
+    z = add(y, b)
+    result = z + 1
+    return result
+
+
 class TestWorkflow(unittest.TestCase):
     def test_analyzer(self):
         analyzer = analyze_function(example_macro)
@@ -207,16 +214,9 @@ class TestWorkflow(unittest.TestCase):
         data = example_workflow.run()
         self.assertEqual(example_workflow(), data["outputs"]["z"]["value"])
 
-    def test_syntax_error(self):
-
-        def example_syntax_error(a=10, b=20):
-            y = example_macro(a, b)
-            z = add(y, b)
-            result = z + 1
-            return result
-
-        with self.assertRaises(SyntaxError):
-            workflow(example_syntax_error)
+    def test_not_implemented_error(self):
+        with self.assertRaises(NotImplementedError):
+            workflow(example_not_implemented_error)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -44,10 +44,20 @@ def parallel_execution(a=10, b=20):
     return e, f
 
 
-def example_not_implemented_error(a=10, b=20):
+def example_invalid_operator(a=10, b=20):
     y = example_macro(a, b)
     z = add(y, b)
     result = z + 1
+    return result
+
+
+def example_invalid_multiple_operation(a=10, b=20):
+    result = add(a, add(a, b))
+    return result
+
+
+def example_invalid_local_var_def(a=10, b=20):
+    result = add(a, 2)
     return result
 
 
@@ -216,7 +226,11 @@ class TestWorkflow(unittest.TestCase):
 
     def test_not_implemented_error(self):
         with self.assertRaises(NotImplementedError):
-            workflow(example_not_implemented_error)
+            workflow(example_invalid_operator)
+        with self.assertRaises(NotImplementedError):
+            workflow(example_invalid_multiple_operation)
+        with self.assertRaises(NotImplementedError):
+            workflow(example_invalid_local_var_def)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently, we cannot allow for an operation such as:

```python
def my_workflow(x):
    result = f(g(x))
    return result
```

or

```python
def my_workflow(x):
    result = f(x, 1)
    return result
```

So I made the errors explicit.