### PR TITLE
Node

### DIFF
--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -213,6 +213,17 @@ def _get_data_edges(analyzer, func):
     return data_edges
 
 
+def get_node_dict(func):
+    data = {
+        "inputs": parse_input_args(func),
+        "outputs": _get_workflow_outputs(func),
+        "label": func.__name__,
+    }
+    if hasattr(func, "_semantikon_metadata"):
+        data.update(func._semantikon_metadata)
+    return data
+
+
 def get_workflow_dict(func):
     analyzer = analyze_function(func)
     output_counts = _get_output_counts(analyzer.graph.edges.data())

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -6,6 +6,7 @@ from semantikon.workflow import (
     get_workflow_dict,
     workflow,
     find_parallel_execution_levels,
+    get_node_dict,
 )
 
 
@@ -78,6 +79,20 @@ class TestWorkflow(unittest.TestCase):
         self.assertEqual(
             [data for data in analyzer.graph.edges.data()],
             all_data,
+        )
+
+    def test_get_node_dict(self):
+        node_dict = get_node_dict(add)
+        self.assertEqual(
+            node_dict,
+            {
+                "inputs": {
+                    "x": {"dtype": float, "default": 2.0},
+                    "y": {"dtype": float, "default": 1},
+                },
+                "outputs": {"output": {"dtype": float}},
+                "label": "add",
+            }
         )
 
     def test_get_return_variables(self):

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -1,4 +1,5 @@
 import unittest
+from semantikon.typing import u
 from semantikon.workflow import (
     analyze_function,
     get_return_variables,
@@ -14,6 +15,7 @@ def operation(x: float, y: float) -> tuple[float, float]:
     return x + y, x - y
 
 
+@u(uri="add")
 def add(x: float = 2.0, y: float = 1) -> float:
     return x + y
 
@@ -92,6 +94,7 @@ class TestWorkflow(unittest.TestCase):
                 },
                 "outputs": {"output": {"dtype": float}},
                 "label": "add",
+                "uri": "add",
             }
         )
 


### PR DESCRIPTION
Define `get_node_dict` to get node info:

```python
def add(x: float = 2.0, y: float = 1) -> float:
    return x + y 

get_node_dict(add)
```

Output

```python
{
    "inputs": {
        "x": {"dtype": float, "default": 2.0},
        "y": {"dtype": float, "default": 1},
    },
    "outputs": {"output": {"dtype": float}},
    "label": "add",
}

```