### PR TITLE
Add ape export

### DIFF
--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -252,13 +252,13 @@ def _to_ape(data, func):
     return data
 
 
-def get_node_dict(func, format="semantikon"):
+def get_node_dict(func, data_format="semantikon"):
     """
     Get a dictionary representation of the function node.
 
     Args:
         func (callable): The function to be analyzed.
-        format (str): The format of the output. Options are "semantiokn" and
+        data_format (str): The format of the output. Options are "semantiokn" and
             "ape".
 
     Returns:
@@ -271,7 +271,7 @@ def get_node_dict(func, format="semantikon"):
     }
     if hasattr(func, "_semantikon_metadata"):
         data.update(func._semantikon_metadata)
-    if format.lower() == "ape":
+    if data_format.lower() == "ape":
         return _to_ape(data, func)
     return data
 

--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -219,9 +219,7 @@ def _get_data_edges(analyzer, func):
 
 
 def _dtype_to_ape_format(dtype):
-    standard_dict = {
-        str: "String", float: "Float", bool: "Bool", int: "Int"
-    }
+    standard_dict = {str: "String", float: "Float", bool: "Bool", int: "Int"}
     if isinstance(dtype, str):
         return dtype
     elif dtype in standard_dict:
@@ -243,7 +241,7 @@ def _to_ape(data, func):
                 io_data.append(
                     {
                         "Type": value["uri"],
-                        "Format": _dtype_to_ape_format(value["dtype"])
+                        "Format": _dtype_to_ape_format(value["dtype"]),
                     }
                 )
             except KeyError:

--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -220,9 +220,7 @@ def _get_data_edges(analyzer, func):
 
 def _dtype_to_ape_format(dtype):
     standard_dict = {str: "String", float: "Float", bool: "Bool", int: "Int"}
-    if isinstance(dtype, str):
-        return dtype
-    elif dtype in standard_dict:
+    if dtype in standard_dict:
         return standard_dict[dtype]
     else:
         return dtype.__module__ + "." + dtype.__name__

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -120,6 +120,7 @@ class TestWorkflow(unittest.TestCase):
             },
         )
         self.assertRaises(KeyError, get_node_dict, add, data_format="ape")
+        self.assertRaises(KeyError, get_node_dict, multiply, data_format="ape")
 
     def test_get_return_variables(self):
         self.assertEqual(get_return_variables(example_macro), ["f"])

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -119,6 +119,7 @@ class TestWorkflow(unittest.TestCase):
                 "taxonomyOperations": ["my_function"],
             },
         )
+        self.assertRaises(KeyError, get_node_dict, add, format="ape")
 
     def test_get_return_variables(self):
         self.assertEqual(get_return_variables(example_macro), ["f"])

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -9,6 +9,7 @@ from semantikon.workflow import (
     find_parallel_execution_levels,
     get_node_dict,
 )
+import numpy as np
 
 
 def operation(x: float, y: float) -> tuple[float, float]:
@@ -64,6 +65,13 @@ def example_invalid_local_var_def(a=10, b=20):
     return result
 
 
+@u(uri="my_function")
+def multiple_types_for_ape(
+    a: u(int, uri="a"), b: u(np.ndarray, uri="b")
+) -> u(np.ndarray, uri="output"):
+    return a + b
+
+
 class TestWorkflow(unittest.TestCase):
     def test_analyzer(self):
         analyzer = analyze_function(example_macro)
@@ -95,7 +103,21 @@ class TestWorkflow(unittest.TestCase):
                 "outputs": {"output": {"dtype": float}},
                 "label": "add",
                 "uri": "add",
-            }
+            },
+        )
+        node_dict = get_node_dict(multiple_types_for_ape, format="ape")
+        node_dict.pop("id")
+        self.assertEqual(
+            node_dict,
+            {
+                "inputs": [
+                    {"Type": "a", "Format": "Int"},
+                    {"Type": "b", "Format": "numpy.ndarray"},
+                ],
+                "outputs": [{"Type": "output", "Format": "numpy.ndarray"}],
+                "label": "multiple_types_for_ape",
+                "taxonomyOperations": ["my_function"],
+            },
         )
 
     def test_get_return_variables(self):

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -105,7 +105,7 @@ class TestWorkflow(unittest.TestCase):
                 "uri": "add",
             },
         )
-        node_dict = get_node_dict(multiple_types_for_ape, format="ape")
+        node_dict = get_node_dict(multiple_types_for_ape, data_format="ape")
         node_dict.pop("id")
         self.assertEqual(
             node_dict,
@@ -119,7 +119,7 @@ class TestWorkflow(unittest.TestCase):
                 "taxonomyOperations": ["my_function"],
             },
         )
-        self.assertRaises(KeyError, get_node_dict, add, format="ape")
+        self.assertRaises(KeyError, get_node_dict, add, data_format="ape")
 
     def test_get_return_variables(self):
         self.assertEqual(get_return_variables(example_macro), ["f"])


### PR DESCRIPTION
```python
from semantikon.typing import u
from semantikon.workflow import get_node_dict

@u(uri="my_function")
def multiple_types_for_ape(
    a: u(int, uri="a"), b: u(np.ndarray, uri="b")
) -> u(np.ndarray, uri="output"):
    return a + b 

node_dict = get_node_dict(multiple_types_for_ape, format="ape")
node_dict
```

Output:

```python
{
    "inputs": [
        {"Type": "a", "Format": "Int"},
        {"Type": "b", "Format": "numpy.ndarray"},
    ],
    "outputs": [{"Type": "output", "Format": "numpy.ndarray"}],
    "label": "multiple_types_for_ape",
    "taxonomyOperations": ["my_function"],
    "id": "multiple_types_for_ape_9beb33b8433beeafce5c15f38096c8d00264b27f8ca964435292b49f632447aa"
},
```

Comments:

- There is no `implementation`, because we agreed that APE is not going to run the actual code
- Format is given by either the class module + name, or built-in names (such as `String`, `Float`, etc.)
  - Conversion for the built-in types is done internally
  - Not sure if we should also support custom names with string (such as `u("MyFormat", uri="MyType")`)
- `id` is given by the label + hash of the function