### PR TITLE
Remove format from inputs

### DIFF
--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -239,7 +239,7 @@ def _to_ape(data, func):
                 d = {"Type": value["uri"]}
                 if io_ == "outputs":
                     d["Format"] = _dtype_to_ape_format(value["dtype"])
-                )
+                io_data.append(d)
             except KeyError:
                 raise KeyError(
                     f"uri not found in {io_} metadata of {func.__name__} {key}"

--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -236,11 +236,9 @@ def _to_ape(data, func):
         io_data = []
         for key, value in data[io_].items():
             try:
-                io_data.append(
-                    {
-                        "Type": value["uri"],
-                        "Format": _dtype_to_ape_format(value["dtype"]),
-                    }
+                d = {"Type": value["uri"]}
+                if io_ == "outputs":
+                    d["Format"] = _dtype_to_ape_format(value["dtype"])
                 )
             except KeyError:
                 raise KeyError(

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -111,8 +111,7 @@ class TestWorkflow(unittest.TestCase):
             node_dict,
             {
                 "inputs": [
-                    {"Type": "a", "Format": "Int"},
-                    {"Type": "b", "Format": "numpy.ndarray"},
+                    {"Type": "a"}, {"Type": "b"},
                 ],
                 "outputs": [{"Type": "output", "Format": "numpy.ndarray"}],
                 "label": "multiple_types_for_ape",

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -111,7 +111,8 @@ class TestWorkflow(unittest.TestCase):
             node_dict,
             {
                 "inputs": [
-                    {"Type": "a"}, {"Type": "b"},
+                    {"Type": "a"},
+                    {"Type": "b"},
                 ],
                 "outputs": [{"Type": "output", "Format": "numpy.ndarray"}],
                 "label": "multiple_types_for_ape",


### PR DESCRIPTION
Apparently there is no `Format` in inputs so I removed it.