### PR TITLE
Change the APE export output

### DIFF
--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -218,12 +218,8 @@ def _get_data_edges(analyzer, func):
     return data_edges
 
 
-def _dtype_to_ape_format(dtype):
-    standard_dict = {str: "String", float: "Float", bool: "Bool", int: "Int"}
-    if dtype in standard_dict:
-        return standard_dict[dtype]
-    else:
-        return dtype.__module__ + "." + dtype.__name__
+def _dtype_to_str(dtype):
+    return dtype.__module__
 
 
 def _to_ape(data, func):
@@ -233,7 +229,7 @@ def _to_ape(data, func):
         raise KeyError(f"uri not found in metadata of {func.__name__}")
     data["id"] = data["label"] + "_" + _hash_function(func)
     for io_ in ["inputs", "outputs"]:
-        data[io_] = [{"Type": value["dtype"]} for value in data[io_].values()]
+        data[io_] = [{"Type": _dtype_to_str(v["dtype"])} for v in data[io_].values()]
     return data
 
 

--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -219,7 +219,7 @@ def _get_data_edges(analyzer, func):
 
 
 def _dtype_to_str(dtype):
-    return dtype.__module__
+    return dtype.__name__
 
 
 def _to_ape(data, func):

--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -233,18 +233,7 @@ def _to_ape(data, func):
         raise KeyError(f"uri not found in metadata of {func.__name__}")
     data["id"] = data["label"] + "_" + _hash_function(func)
     for io_ in ["inputs", "outputs"]:
-        io_data = []
-        for key, value in data[io_].items():
-            try:
-                d = {"Type": value["uri"]}
-                if io_ == "outputs":
-                    d["Format"] = _dtype_to_ape_format(value["dtype"])
-                io_data.append(d)
-            except KeyError:
-                raise KeyError(
-                    f"uri not found in {io_} metadata of {func.__name__} {key}"
-                )
-        data[io_] = io_data
+        data[io_] = [{"Type": value["dtype"]} for value in data[io_].values()]
     return data
 
 

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -65,8 +65,12 @@ def example_invalid_local_var_def(a=10, b=20):
     return result
 
 
+class ApeClass:
+    pass
+
+
 @u(uri="my_function")
-def multiple_types_for_ape(a: int, b: int) -> np.ndarray:
+def multiple_types_for_ape(a: ApeClass, b: ApeClass) -> ApeClass:
     return a + b
 
 
@@ -109,10 +113,10 @@ class TestWorkflow(unittest.TestCase):
             node_dict,
             {
                 "inputs": [
-                    {"Type": "int"},
-                    {"Type": "int"},
+                    {"Type": "ApeClass"},
+                    {"Type": "ApeClass"},
                 ],
-                "outputs": [{"Type": "numpy.ndarray"}],
+                "outputs": [{"Type": "ApeClass"}],
                 "label": "multiple_types_for_ape",
                 "taxonomyOperations": ["my_function"],
             },

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -66,9 +66,7 @@ def example_invalid_local_var_def(a=10, b=20):
 
 
 @u(uri="my_function")
-def multiple_types_for_ape(
-    a: u(int, uri="a"), b: u(np.ndarray, uri="b")
-) -> u(np.ndarray, uri="output"):
+def multiple_types_for_ape(a: int, b: int) -> np.ndarray::
     return a + b
 
 
@@ -111,15 +109,14 @@ class TestWorkflow(unittest.TestCase):
             node_dict,
             {
                 "inputs": [
-                    {"Type": "a"},
-                    {"Type": "b"},
+                    {"Type": "int"},
+                    {"Type": "int"},
                 ],
-                "outputs": [{"Type": "output", "Format": "numpy.ndarray"}],
+                "outputs": [{"Type": "numpy.ndarray"}],
                 "label": "multiple_types_for_ape",
                 "taxonomyOperations": ["my_function"],
             },
         )
-        self.assertRaises(KeyError, get_node_dict, add, data_format="ape")
         self.assertRaises(KeyError, get_node_dict, multiply, data_format="ape")
 
     def test_get_return_variables(self):

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -66,7 +66,7 @@ def example_invalid_local_var_def(a=10, b=20):
 
 
 @u(uri="my_function")
-def multiple_types_for_ape(a: int, b: int) -> np.ndarray::
+def multiple_types_for_ape(a: int, b: int) -> np.ndarray:
     return a + b
 
 


### PR DESCRIPTION
Apparently the format is not used, so instead of using it, we now use the data type for the type.