### PR TITLE
Create export function for APE classes

### DIFF
--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -518,6 +518,16 @@ def _dataclass_to_knowledge_graph(parent, name_space, graph=None, parent_name=No
 
 
 def dataclass_to_knowledge_graph(class_name, name_space):
+    """
+    Convert a dataclass to a knowledge graph
+
+    Args:
+        class_name (dataclass): dataclass to be converted
+        name_space (rdflib.Namespace): namespace to be used
+
+    Returns:
+        (rdflib.Graph): knowledge graph
+    """
     return _dataclass_to_knowledge_graph(
         class_name, name_space, graph=None, parent_name=class_name.__name__
     )

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -498,9 +498,8 @@ def get_knowledge_graph(
 def _is_unique(tag, graph):
     return tag not in [h for g in graph.subject_objects(None, None) for h in g]
 
-def _dataclass_to_knowledge_graph(
-    parent, name_space, graph=None, parent_name=None
-):
+
+def _dataclass_to_knowledge_graph(parent, name_space, graph=None, parent_name=None):
     if graph is None:
         graph = Graph()
     for name, obj in vars(parent).items():
@@ -516,6 +515,7 @@ def _dataclass_to_knowledge_graph(
                 raise ValueError(f"{name} used multiple times")
             _dataclass_to_knowledge_graph(obj, name_space, graph, name)
     return graph
+
 
 def dataclass_to_knowledge_graph(class_name, name_space):
     return _dataclass_to_knowledge_graph(

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -15,6 +15,7 @@ from semantikon.ontology import (
     PNS,
     _inherit_properties,
     validate_values,
+    dataclass_to_knowledge_graph,
 )
 from semantikon.workflow import workflow
 from dataclasses import dataclass
@@ -448,6 +449,26 @@ def get_run_md(inp: Input):
     return result
 
 
+class Animal:
+    class Mammal:
+        class Dog:
+            pass
+        class Cat:
+            pass
+
+    class Reptile:
+        class Lizard:
+            pass
+
+        class Snake:
+            pass
+
+class ForbiddenAnimal:
+    class Mamal:
+        class ForbiddenAnimal:
+            pass
+
+
 class TestDataclass(unittest.TestCase):
     def test_dataclass(self):
         wf_dict = get_run_md.run(Input(T=300.0, n=100))
@@ -469,6 +490,22 @@ class TestDataclass(unittest.TestCase):
                     msg=f"{triple} not found",
                 )
         self.assertIsNone(graph.value(URIRef(f"{i_txt}.not_dataclass.b.value")))
+
+    def test_dataclass_to_knowledge_graph(self):
+        EX = Namespace("http://example.org/")
+        tags = [
+            ("Cat", "Mammal"),
+            ("Lizard", "Reptile"),
+            ("Mammal", "Animal"),
+            ("Dog", "Mammal"),
+            ("Snake", "Reptile"),
+            ("Reptile", "Animal"),
+        ]
+        doubles = [(EX[tag[0]], EX[tag[1]]) for tag in tags]
+        graph = dataclass_to_knowledge_graph(Animal, EX)
+        self.assertEqual(list(graph.subject_objects(None)), doubles)
+        self.assertRaises(ValueError):
+            graph = dataclass_to_knowledge_graph(ForbiddenAnimal, EX)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -453,6 +453,7 @@ class Animal:
     class Mammal:
         class Dog:
             pass
+
         class Cat:
             pass
 
@@ -462,6 +463,7 @@ class Animal:
 
         class Snake:
             pass
+
 
 class ForbiddenAnimal:
     class Mamal:

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -504,7 +504,7 @@ class TestDataclass(unittest.TestCase):
         doubles = [(EX[tag[0]], EX[tag[1]]) for tag in tags]
         graph = dataclass_to_knowledge_graph(Animal, EX)
         self.assertEqual(list(graph.subject_objects(None)), doubles)
-        self.assertRaises(ValueError):
+        with self.assertRaises(ValueError):
             graph = dataclass_to_knowledge_graph(ForbiddenAnimal, EX)
 
 

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -501,9 +501,10 @@ class TestDataclass(unittest.TestCase):
             ("Snake", "Reptile"),
             ("Reptile", "Animal"),
         ]
-        doubles = [(EX[tag[0]], EX[tag[1]]) for tag in tags]
+        doubles = sorted([(EX[tag[0]], EX[tag[1]]) for tag in tags])
         graph = dataclass_to_knowledge_graph(Animal, EX)
-        self.assertEqual(list(graph.subject_objects(None)), doubles)
+        self.maxDiff = None
+        self.assertEqual(sorted(graph.subject_objects(None)), doubles)
         with self.assertRaises(ValueError):
             graph = dataclass_to_knowledge_graph(ForbiddenAnimal, EX)
 


### PR DESCRIPTION
Example:

```python
BASE_URI = "http://example.org/"
EX = Namespace(BASE_URI)

class Animal:
    class Mammal:
        class Dog:
            pass
        class Cat:
            pass

    class Reptile:
        class Lizard:
            pass
        
        class Snake:
            pass

graph = dataclass_to_knowledge_graph(Animal, EX)
list(graph.subject_objects(None))
```

Output:

```python
[(rdflib.term.URIRef('http://example.org/Snake'),
  rdflib.term.URIRef('http://example.org/Reptile')),
 (rdflib.term.URIRef('http://example.org/Reptile'),
  rdflib.term.URIRef('http://example.org/Animal')),
 (rdflib.term.URIRef('http://example.org/Lizard'),
  rdflib.term.URIRef('http://example.org/Reptile')),
 (rdflib.term.URIRef('http://example.org/Dog'),
  rdflib.term.URIRef('http://example.org/Mammal')),
 (rdflib.term.URIRef('http://example.org/Mammal'),
  rdflib.term.URIRef('http://example.org/Animal')),
 (rdflib.term.URIRef('http://example.org/Cat'),
  rdflib.term.URIRef('http://example.org/Mammal'))]
```