### PR TITLE
Allow functions without uri

### DIFF
--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -223,10 +223,7 @@ def _dtype_to_str(dtype):
 
 
 def _to_ape(data, func):
-    try:
-        data["taxonomyOperations"] = [data.pop("uri")]
-    except KeyError:
-        raise KeyError(f"uri not found in metadata of {func.__name__}")
+    data["taxonomyOperations"] = [data.pop("uri", func.__name__)]
     data["id"] = data["label"] + "_" + _hash_function(func)
     for io_ in ["inputs", "outputs"]:
         data[io_] = [{"Type": _dtype_to_str(v["dtype"])} for v in data[io_].values()]

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -121,7 +121,6 @@ class TestWorkflow(unittest.TestCase):
                 "taxonomyOperations": ["my_function"],
             },
         )
-        self.assertRaises(KeyError, get_node_dict, multiply, data_format="ape")
 
     def test_get_return_variables(self):
         self.assertEqual(get_return_variables(example_macro), ["f"])


### PR DESCRIPTION
Apparently it's not necessary that the function names are based on an ontology so I removed the restriction..