### PR TITLE
Separate data types from the dict representation

### DIFF
--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -488,11 +488,11 @@ def _restore_types(wf_dict: dict, class_dict=None) -> dict:
     elif class_dict is None:
         class_dict = wf_dict.pop("class_dict")
     for io_ in ["inputs", "outputs"]:
-        for key, channel_dict in wf_dict[io_].items():
+        for channel_dict in wf_dict[io_].values():
             if "dtype" in channel_dict and isinstance(channel_dict["dtype"], str):
                 channel_dict["dtype"] = class_dict[channel_dict["dtype"]]
     if "nodes" in wf_dict:
-        for n_label, node in wf_dict["nodes"].items():
+        for node in wf_dict["nodes"].values():
             node = _restore_types(node, class_dict)
     return wf_dict
 

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -145,7 +145,7 @@ class TestWorkflow(unittest.TestCase):
                         "output_0": {"dtype": float},
                         "output_1": {"dtype": float},
                     },
-                    "function": operation.__name__,
+                    "function": "operation",
                 },
                 "add_0": {
                     "inputs": {
@@ -153,7 +153,7 @@ class TestWorkflow(unittest.TestCase):
                         "y": {"dtype": float, "default": 1},
                     },
                     "outputs": {"output": {"dtype": float}},
-                    "function": add.__name__,
+                    "function": "add",
                     "uri": "add",
                 },
                 "multiply_0": {
@@ -162,7 +162,7 @@ class TestWorkflow(unittest.TestCase):
                         "y": {"dtype": float, "default": 5},
                     },
                     "outputs": {"output": {"dtype": float}},
-                    "function": multiply.__name__,
+                    "function": "multiply",
                 },
             },
             "data_edges": [
@@ -175,9 +175,9 @@ class TestWorkflow(unittest.TestCase):
             ],
             "label": "example_macro",
             "function_dict": {
-                operation.__name__: operation,
-                add.__name__: add,
-                multiply.__name__: multiply,
+                "operation": operation,
+                "add": add,
+                "multiply": multiply,
             },
         }
         self.assertEqual(get_workflow_dict(example_macro), ref_data)
@@ -194,7 +194,7 @@ class TestWorkflow(unittest.TestCase):
                     "outputs": {"f": {}},
                     "nodes": {
                         "operation_0": {
-                            "function": operation.__name__,
+                            "function": "operation",
                             "inputs": {"x": {"dtype": float}, "y": {"dtype": float}},
                             "outputs": {
                                 "output_0": {"dtype": float},
@@ -202,7 +202,7 @@ class TestWorkflow(unittest.TestCase):
                             },
                         },
                         "add_0": {
-                            "function": add.__name__,
+                            "function": "add",
                             "inputs": {
                                 "x": {"dtype": float, "default": 2.0},
                                 "y": {"dtype": float, "default": 1},
@@ -211,7 +211,7 @@ class TestWorkflow(unittest.TestCase):
                             "uri": "add",
                         },
                         "multiply_0": {
-                            "function": multiply.__name__,
+                            "function": "multiply",
                             "inputs": {
                                 "x": {"dtype": float},
                                 "y": {"dtype": float, "default": 5},
@@ -230,7 +230,7 @@ class TestWorkflow(unittest.TestCase):
                     "label": "example_macro_0",
                 },
                 "add_0": {
-                    "function": add.__name__,
+                    "function": "add",
                     "inputs": {
                         "x": {"dtype": float, "default": 2.0},
                         "y": {"dtype": float, "default": 1},
@@ -248,9 +248,9 @@ class TestWorkflow(unittest.TestCase):
             ],
             "label": "example_workflow",
             "function_dict": {
-                operation.__name__: operation,
-                add.__name__: add,
-                multiply.__name__: multiply,
+                "operation": operation,
+                "add": add,
+                "multiply": multiply,
             },
         }
         self.assertEqual(result, ref_data, msg=result)

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -140,28 +140,28 @@ class TestWorkflow(unittest.TestCase):
             "outputs": {"f": {}},
             "nodes": {
                 "operation_0": {
-                    "inputs": {"x": {"dtype": float}, "y": {"dtype": float}},
+                    "inputs": {"x": {"dtype": "float"}, "y": {"dtype": "float"}},
                     "outputs": {
-                        "output_0": {"dtype": float},
-                        "output_1": {"dtype": float},
+                        "output_0": {"dtype": "float"},
+                        "output_1": {"dtype": "float"},
                     },
                     "function": "operation",
                 },
                 "add_0": {
                     "inputs": {
-                        "x": {"dtype": float, "default": 2.0},
-                        "y": {"dtype": float, "default": 1},
+                        "x": {"dtype": "float", "default": 2.0},
+                        "y": {"dtype": "float", "default": 1},
                     },
-                    "outputs": {"output": {"dtype": float}},
+                    "outputs": {"output": {"dtype": "float"}},
                     "function": "add",
                     "uri": "add",
                 },
                 "multiply_0": {
                     "inputs": {
-                        "x": {"dtype": float},
-                        "y": {"dtype": float, "default": 5},
+                        "x": {"dtype": "float"},
+                        "y": {"dtype": "float", "default": 5},
                     },
-                    "outputs": {"output": {"dtype": float}},
+                    "outputs": {"output": {"dtype": "float"}},
                     "function": "multiply",
                 },
             },
@@ -179,6 +179,9 @@ class TestWorkflow(unittest.TestCase):
                 "add": add,
                 "multiply": multiply,
             },
+            "class_dict": {
+                "float": float,
+            },
         }
         self.assertEqual(get_workflow_dict(example_macro), ref_data)
         self.assertEqual(example_macro._semantikon_workflow, ref_data)
@@ -195,28 +198,28 @@ class TestWorkflow(unittest.TestCase):
                     "nodes": {
                         "operation_0": {
                             "function": "operation",
-                            "inputs": {"x": {"dtype": float}, "y": {"dtype": float}},
+                            "inputs": {"x": {"dtype": "float"}, "y": {"dtype": "float"}},
                             "outputs": {
-                                "output_0": {"dtype": float},
-                                "output_1": {"dtype": float},
+                                "output_0": {"dtype": "float"},
+                                "output_1": {"dtype": "float"},
                             },
                         },
                         "add_0": {
                             "function": "add",
                             "inputs": {
-                                "x": {"dtype": float, "default": 2.0},
-                                "y": {"dtype": float, "default": 1},
+                                "x": {"dtype": "float", "default": 2.0},
+                                "y": {"dtype": "float", "default": 1},
                             },
-                            "outputs": {"output": {"dtype": float}},
+                            "outputs": {"output": {"dtype": "float"}},
                             "uri": "add",
                         },
                         "multiply_0": {
                             "function": "multiply",
                             "inputs": {
-                                "x": {"dtype": float},
-                                "y": {"dtype": float, "default": 5},
+                                "x": {"dtype": "float"},
+                                "y": {"dtype": "float", "default": 5},
                             },
-                            "outputs": {"output": {"dtype": float}},
+                            "outputs": {"output": {"dtype": "float"}},
                         },
                     },
                     "data_edges": [
@@ -232,10 +235,10 @@ class TestWorkflow(unittest.TestCase):
                 "add_0": {
                     "function": "add",
                     "inputs": {
-                        "x": {"dtype": float, "default": 2.0},
-                        "y": {"dtype": float, "default": 1},
+                        "x": {"dtype": "float", "default": 2.0},
+                        "y": {"dtype": "float", "default": 1},
                     },
-                    "outputs": {"output": {"dtype": float}},
+                    "outputs": {"output": {"dtype": "float"}},
                     "uri": "add",
                 },
             },
@@ -251,6 +254,9 @@ class TestWorkflow(unittest.TestCase):
                 "operation": operation,
                 "add": add,
                 "multiply": multiply,
+            },
+            "class_dict": {
+                "float": float,
             },
         }
         self.assertEqual(result, ref_data, msg=result)


### PR DESCRIPTION
Similarly to the last PRs (#93, #94, #95), I separated data types from the dict representation