### PR TITLE
Do not run separate functions by default

### DIFF
--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -263,12 +263,12 @@ def get_node_dict(func, data_format="semantikon"):
     return data
 
 
-def _separate_types(data):
+def separate_types(data):
     if "class_dict" not in data:
         data["class_dict"] = {}
     if "nodes" in data:
         for key, node in data["nodes"].items():
-            child_node = _separate_types(node)
+            child_node = separate_types(node)
             data["class_dict"].update(child_node.pop("class_dict"))
             data["nodes"][key] = child_node
     for io_ in ["inputs", "outputs"]:
@@ -279,12 +279,12 @@ def _separate_types(data):
     return data
 
 
-def _separate_functions(data):
+def separate_functions(data):
     if "function_dict" not in data:
         data["function_dict"] = {}
     if "nodes" in data:
         for key, node in data["nodes"].items():
-            child_node = _separate_functions(node)
+            child_node = separate_functions(node)
             data["function_dict"].update(child_node.pop("function_dict"))
             data["nodes"][key] = child_node
     elif "function" in data and not isinstance(data["function"], str):
@@ -293,7 +293,7 @@ def _separate_functions(data):
     return data
 
 
-def get_workflow_dict(func, separate_functions=True, separate_types=True):
+def get_workflow_dict(func):
     analyzer = analyze_function(func)
     output_counts = _get_output_counts(analyzer.graph.edges.data())
     nodes = _get_nodes(analyzer.function_defs, output_counts)
@@ -304,10 +304,6 @@ def get_workflow_dict(func, separate_functions=True, separate_types=True):
         "data_edges": _get_data_edges(analyzer, func),
         "label": func.__name__,
     }
-    if separate_functions:
-        data = _separate_functions(data)
-    if separate_types:
-        data = _separate_types(data)
     return data
 
 

--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -265,6 +265,7 @@ def get_node_dict(func, data_format="semantikon"):
 
 
 def separate_types(data):
+    data = copy.deepcopy(data)
     if "class_dict" not in data:
         data["class_dict"] = {}
     if "nodes" in data:

--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -6,6 +6,7 @@ from collections import deque
 from functools import cached_property
 import warnings
 from hashlib import sha256
+import copy
 
 from semantikon.converter import parse_input_args, parse_output_args
 
@@ -280,6 +281,7 @@ def separate_types(data):
 
 
 def separate_functions(data):
+    data = copy.deepcopy(data)
     if "function_dict" not in data:
         data["function_dict"] = {}
     if "nodes" in data:

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -17,7 +17,7 @@ from semantikon.ontology import (
     validate_values,
     dataclass_to_knowledge_graph,
 )
-from semantikon.workflow import workflow
+from semantikon.workflow import workflow, separate_types, separate_functions
 from dataclasses import dataclass
 
 
@@ -409,7 +409,6 @@ class TestOntology(unittest.TestCase):
         self.maxDiff = None
         graph = get_knowledge_graph(get_macro.run())
         self.assertEqual(graph.serialize(format="turtle"), txt)
-        # print(graph.serialize(format="turtle"))
 
     def test_wrong_order(self):
         graph = get_knowledge_graph(get_wrong_order._semantikon_workflow)
@@ -424,6 +423,15 @@ class TestOntology(unittest.TestCase):
                 ]
             ],
         )
+
+    def test_separate(self):
+        wf = get_speed.run()
+        graph_normal = get_knowledge_graph(wf)
+        graph_sep = get_knowledge_graph(separate_types(separate_functions(wf)))
+        self.assertEqual(
+            len(graph_normal), len(graph_sep), msg="Graphs are not equal"
+        )
+
 
 
 @dataclass

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -8,6 +8,8 @@ from semantikon.workflow import (
     workflow,
     find_parallel_execution_levels,
     get_node_dict,
+    separate_types,
+    separate_functions,
 )
 import numpy as np
 import json
@@ -278,6 +280,17 @@ class TestWorkflow(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             workflow(example_invalid_local_var_def)
 
+    def test_separate_functions(self):
+        old_data = example_workflow._semantikon_workflow
+        data = separate_functions(old_data)
+        self.assertEqual(
+            data["function_dict"],
+            {"operation": operation, "add": add, "multiply": multiply},
+        )
+        self.assertEqual(
+            old_data["nodes"]["example_macro_0"]["nodes"]["operation_0"]["function"],
+            operation,
+        )
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -288,9 +288,18 @@ class TestWorkflow(unittest.TestCase):
             {"operation": operation, "add": add, "multiply": multiply},
         )
         self.assertEqual(
+            data["nodes"]["example_macro_0"]["nodes"]["operation_0"]["function"],
+            "operation",
+        )
+        self.assertEqual(
             old_data["nodes"]["example_macro_0"]["nodes"]["operation_0"]["function"],
             operation,
         )
+
+    def test_separate_types(self):
+        old_data = example_workflow._semantikon_workflow
+        data = separate_types(old_data)
+        self.assertEqual(data["class_dict"], {"float": float})
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -140,29 +140,29 @@ class TestWorkflow(unittest.TestCase):
             "outputs": {"f": {}},
             "nodes": {
                 "operation_0": {
-                    "inputs": {"x": {"dtype": "float"}, "y": {"dtype": "float"}},
+                    "inputs": {"x": {"dtype": float}, "y": {"dtype": float}},
                     "outputs": {
-                        "output_0": {"dtype": "float"},
-                        "output_1": {"dtype": "float"},
+                        "output_0": {"dtype": float},
+                        "output_1": {"dtype": float},
                     },
-                    "function": "operation",
+                    "function": operation,
                 },
                 "add_0": {
                     "inputs": {
-                        "x": {"dtype": "float", "default": 2.0},
-                        "y": {"dtype": "float", "default": 1},
+                        "x": {"dtype": float, "default": 2.0},
+                        "y": {"dtype": float, "default": 1},
                     },
-                    "outputs": {"output": {"dtype": "float"}},
-                    "function": "add",
+                    "outputs": {"output": {"dtype": float}},
+                    "function": add,
                     "uri": "add",
                 },
                 "multiply_0": {
                     "inputs": {
-                        "x": {"dtype": "float"},
-                        "y": {"dtype": "float", "default": 5},
+                        "x": {"dtype": float},
+                        "y": {"dtype": float, "default": 5},
                     },
-                    "outputs": {"output": {"dtype": "float"}},
-                    "function": "multiply",
+                    "outputs": {"output": {"dtype": float}},
+                    "function": multiply,
                 },
             },
             "data_edges": [
@@ -174,14 +174,6 @@ class TestWorkflow(unittest.TestCase):
                 ["multiply_0.outputs.output", "outputs.f"],
             ],
             "label": "example_macro",
-            "function_dict": {
-                "operation": operation,
-                "add": add,
-                "multiply": multiply,
-            },
-            "class_dict": {
-                "float": float,
-            },
         }
         self.assertEqual(get_workflow_dict(example_macro), ref_data)
         self.assertEqual(example_macro._semantikon_workflow, ref_data)
@@ -197,29 +189,29 @@ class TestWorkflow(unittest.TestCase):
                     "outputs": {"f": {}},
                     "nodes": {
                         "operation_0": {
-                            "function": "operation",
-                            "inputs": {"x": {"dtype": "float"}, "y": {"dtype": "float"}},
+                            "function": operation,
+                            "inputs": {"x": {"dtype": float}, "y": {"dtype": float}},
                             "outputs": {
-                                "output_0": {"dtype": "float"},
-                                "output_1": {"dtype": "float"},
+                                "output_0": {"dtype": float},
+                                "output_1": {"dtype": float},
                             },
                         },
                         "add_0": {
-                            "function": "add",
+                            "function": add,
                             "inputs": {
-                                "x": {"dtype": "float", "default": 2.0},
-                                "y": {"dtype": "float", "default": 1},
+                                "x": {"dtype": float, "default": 2.0},
+                                "y": {"dtype": float, "default": 1},
                             },
-                            "outputs": {"output": {"dtype": "float"}},
+                            "outputs": {"output": {"dtype": float}},
                             "uri": "add",
                         },
                         "multiply_0": {
-                            "function": "multiply",
+                            "function": multiply,
                             "inputs": {
-                                "x": {"dtype": "float"},
-                                "y": {"dtype": "float", "default": 5},
+                                "x": {"dtype": float},
+                                "y": {"dtype": float, "default": 5},
                             },
-                            "outputs": {"output": {"dtype": "float"}},
+                            "outputs": {"output": {"dtype": float}},
                         },
                     },
                     "data_edges": [
@@ -233,12 +225,12 @@ class TestWorkflow(unittest.TestCase):
                     "label": "example_macro_0",
                 },
                 "add_0": {
-                    "function": "add",
+                    "function": add,
                     "inputs": {
-                        "x": {"dtype": "float", "default": 2.0},
-                        "y": {"dtype": "float", "default": 1},
+                        "x": {"dtype": float, "default": 2.0},
+                        "y": {"dtype": float, "default": 1},
                     },
-                    "outputs": {"output": {"dtype": "float"}},
+                    "outputs": {"output": {"dtype": float}},
                     "uri": "add",
                 },
             },
@@ -250,14 +242,6 @@ class TestWorkflow(unittest.TestCase):
                 ["add_0.outputs.output", "outputs.z"],
             ],
             "label": "example_workflow",
-            "function_dict": {
-                "operation": operation,
-                "add": add,
-                "multiply": multiply,
-            },
-            "class_dict": {
-                "float": float,
-            },
         }
         self.assertEqual(result, ref_data, msg=result)
 


### PR DESCRIPTION
In the end, I think it's better to return the dictionary without separating functions and data types.