### PR TITLE
Add visualization function

### DIFF
--- a/semantikon/visualize.py
+++ b/semantikon/visualize.py
@@ -1,0 +1,12 @@
+import io
+import pydotplus
+from IPython.display import Image
+from rdflib.tools.rdf2dot import rdf2dot
+
+
+def visualize(graph):
+    stream = io.StringIO()
+    rdf2dot(graph, stream, opts={"rankdir=LR"})
+    dg = pydotplus.graph_from_dot_data(stream.getvalue())
+    png = dg.create_png()
+    return Image(png)

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -3,6 +3,7 @@ from textwrap import dedent
 from rdflib import Graph, OWL, Namespace, URIRef, Literal, RDF, RDFS, SH
 from owlrl import DeductiveClosure, OWLRL_Semantics
 from pyshacl import validate
+from IPython.display import Image
 from semantikon.typing import u
 from semantikon.converter import (
     parse_input_args,
@@ -21,6 +22,7 @@ from semantikon.ontology import (
     NS,
 )
 from semantikon.workflow import workflow, separate_types, separate_functions
+from semantikon.visualize import visualize
 from dataclasses import dataclass
 
 
@@ -454,6 +456,11 @@ class TestOntology(unittest.TestCase):
         for args in edges:
             self.assertIn(args[0], channels)
             self.assertIn(args[1], channels)
+
+    def test_visualize(self):
+        data = get_macro.run()
+        graph = get_knowledge_graph(data)
+        self.assertIsInstance(visualize(graph), Image)
 
 
 @dataclass


### PR DESCRIPTION
With this PR, you can visualize knowledge graphs via:

```python
graph = get_knowledge_graph(data)
visualize(graph)
```

It's very primitive, but since many people struggle to visualize knowledge graphs maybe it's better than nothing