### PR TITLE
[bug] Allow referencing to inputs and outputs for function triples

### DIFF
--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -209,13 +209,15 @@ def _parse_triple(
     else:
         raise ValueError("Triple must have 2 or 3 elements")
     assert pred is not None, "Predicate must not be None"
-    if subj is None:
-        subj = label
-    if obj is None:
-        obj = label
-    if obj.startswith("inputs.") or obj.startswith("outputs."):
-        assert ns is not None, "Namespace must not be None"
-        obj = _dot(ns, obj)
+    def _set_tag(tag, ns=None, label=None):
+        if tag is None:
+            return label
+        elif tag.startswith("inputs.") or tag.startswith("outputs."):
+            assert ns is not None, "Namespace must not be None"
+            return _dot(ns, tag)
+        return tag
+    subj = _set_tag(subj, ns, label)
+    obj = _set_tag(obj, ns, label)
     return subj, pred, obj
 
 

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -342,7 +342,7 @@ def _function_to_triples(function: callable, node_label: str, ontology=SNS) -> l
         triples.append((node_label, RDF.type, f_dict["uri"]))
     if f_dict.get("triples", None) is not None:
         for t in _align_triples(f_dict["triples"]):
-            triples.append(_parse_triple(t, label=node_label))
+            triples.append(_parse_triple(t, ns=node_label, label=node_label))
     triples.append((node_label, ontology.hasSourceFunction, f_dict["label"]))
     return triples
 

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -209,6 +209,7 @@ def _parse_triple(
     else:
         raise ValueError("Triple must have 2 or 3 elements")
     assert pred is not None, "Predicate must not be None"
+
     def _set_tag(tag, ns=None, label=None):
         if tag is None:
             return label
@@ -216,6 +217,7 @@ def _parse_triple(
             assert ns is not None, "Namespace must not be None"
             return _dot(ns, tag)
         return tag
+
     subj = _set_tag(subj, ns, label)
     obj = _set_tag(obj, ns, label)
     return subj, pred, obj

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -340,8 +340,9 @@ def _function_to_triples(function: callable, node_label: str, ontology=SNS) -> l
     triples = []
     if f_dict.get("uri", None) is not None:
         triples.append((node_label, RDF.type, f_dict["uri"]))
-    for t in _get_triples_from_restrictions(f_dict):
-        triples.append(_parse_triple(t, label=node_label))
+    if f_dict.get("triples", None) is not None:
+        for t in _align_triples(f_dict["triples"]):
+            triples.append(_parse_triple(t, label=node_label))
     triples.append((node_label, ontology.hasSourceFunction, f_dict["label"]))
     return triples
 

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -1,6 +1,6 @@
 import unittest
 from textwrap import dedent
-from rdflib import Graph, OWL, Namespace, URIRef, Literal, RDF, RDFS, SH
+from rdflib import Graph, OWL, Namespace, URIRef, Literal, RDF, RDFS, SH, PROV
 from owlrl import DeductiveClosure, OWLRL_Semantics
 from pyshacl import validate
 from graphviz import Digraph
@@ -51,7 +51,7 @@ def get_speed(distance=10.0, time=2.0):
     return speed
 
 
-@u(uri=EX.Addition)
+@u(uri=EX.Addition, triples=("inputs.a", PROV.wasGeneratedBy, None))
 def add(a: float, b: float) -> u(float, triples=(EX.HasOperation, EX.Addition)):
     return a + b
 
@@ -461,6 +461,16 @@ class TestOntology(unittest.TestCase):
         data = get_macro.run()
         graph = get_knowledge_graph(data)
         self.assertIsInstance(visualize(graph), Digraph)
+
+    def test_function_referencing(self):
+        graph = get_knowledge_graph(get_correct_analysis._semantikon_workflow)
+        self.assertEqual(
+            list(graph.subject_objects(PROV.wasGeneratedBy))[0],
+            (
+                URIRef("get_correct_analysis.add_0.inputs.a"),
+                URIRef("get_correct_analysis.add_0"),
+            ),
+        )
 
 
 @dataclass


### PR DESCRIPTION
While trying to reproduce [this KG](https://github.com/pyscal/atomRDF/blob/main/examples/workflow_examples/01_lammps_pyiron.ipynb), I realized that it was not possible to reference to the input structure for the function annotation. In particular, the following function annotation will be accepted with this PR:


```python
@u(triples=("inputs.structure", PROV.wasGeneratedBy, None))
def run_md(structure: Atoms) -> dict:
    ...
    return data
```