### PR TITLE
Allow kwargs in function arguments

### DIFF
--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -162,9 +162,11 @@ def units(func):
         args, kwargs = _apply_defaults(sig, args, kwargs)
 
         # Extend kwargs to account for **kwargs
-        ext_kwargs = {key: kwargs.get(key, 0) for key in sig.parameters.keys()}
+        ext_kwargs = {
+            key: kwargs.get(key, 0) for key in list(sig.parameters.keys())[len(args) :]
+        }
 
-        args, filtered_kwargs, names = converter(
+        args, kwargs, names = converter(
             ureg, sig, args, ext_kwargs, strict=False
         )
 

--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -164,7 +164,9 @@ def units(func):
         # Extend kwargs to account for **kwargs
         ext_kwargs = {key: kwargs.get(key, 0) for key in sig.parameters.keys()}
 
-        args, filtered_kwargs, names = converter(ureg, sig, args, ext_kwargs, strict=False)
+        args, filtered_kwargs, names = converter(
+            ureg, sig, args, ext_kwargs, strict=False
+        )
 
         try:
             output_units = _get_output_units(parse_output_args(func), ureg, names)

--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -166,9 +166,7 @@ def units(func):
             key: kwargs.get(key, 0) for key in list(sig.parameters.keys())[len(args) :]
         }
 
-        args, kwargs, names = converter(
-            ureg, sig, args, ext_kwargs, strict=False
-        )
+        args, kwargs, names = converter(ureg, sig, args, ext_kwargs, strict=False)
 
         try:
             output_units = _get_output_units(parse_output_args(func), ureg, names)

--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -160,11 +160,17 @@ def units(func):
         if converter is None or ureg is None:
             return func(*args, **kwargs)
         args, kwargs = _apply_defaults(sig, args, kwargs)
-        args, kwargs, names = converter(ureg, sig, args, kwargs, strict=False)
+
+        # Extend kwargs to account for **kwargs
+        ext_kwargs = {key: kwargs.get(key, 0) for key in sig.parameters.keys()}
+
+        args, filtered_kwargs, names = converter(ureg, sig, args, ext_kwargs, strict=False)
+
         try:
             output_units = _get_output_units(parse_output_args(func), ureg, names)
         except AttributeError:
             output_units = None
+
         if _is_dimensionless(output_units):
             return func(*args, **kwargs)
         elif isinstance(output_units, tuple):

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -69,6 +69,7 @@ def return_dict(
 
 @units
 def test_kwargs(x: u(float, units="meter"), **kwargs) -> u(float, units="meter"):
+    assert isinstance(x, float | int)
     return x
 
 

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -10,6 +10,9 @@ def get_speed_multiple_outputs(
     time: u(float, units="second"),
     duration: u(float, units="second"),
 ) -> tuple[u(float, units="meter/second"), u(float, units="meter/second")]:
+    assert isinstance(distance, float | int)
+    assert isinstance(time, float | int)
+    assert isinstance(duration, float | int)
     return distance / time, distance / duration
 
 
@@ -17,6 +20,8 @@ def get_speed_multiple_outputs(
 def get_speed_no_output_type(
     distance: u(float, units="meter"), time: u(float, units="second")
 ):
+    assert isinstance(distance, float | int)
+    assert isinstance(time, float | int)
     return distance / time
 
 
@@ -26,6 +31,8 @@ def get_speed_multiple_args(
     time: u(float, units="second"),
     duration: u(float | None, units="second") = None,
 ) -> u(float, units="meter/second"):
+    assert isinstance(distance, float | int)
+    assert isinstance(time, float | int)
     if duration is None:
         return distance / time
     else:
@@ -36,6 +43,8 @@ def get_speed_multiple_args(
 def get_speed_optional_args(
     distance: u(float, units="meter"), time: u(float, units="second") = 1
 ) -> u(float, units="meter/second"):
+    assert isinstance(distance, float | int)
+    assert isinstance(time, float | int)
     return distance / time
 
 
@@ -43,6 +52,8 @@ def get_speed_optional_args(
 def get_speed_ints(
     distance: u(int, units="meter"), time: u(int, units="second")
 ) -> u(int, units="meter/second"):
+    assert isinstance(distance, float | int)
+    assert isinstance(time, float | int)
     return distance / time
 
 
@@ -50,6 +61,8 @@ def get_speed_ints(
 def get_speed_floats(
     distance: u(float, units="meter"), time: u(float, units="second")
 ) -> u(float, units="meter/second"):
+    assert isinstance(distance, float | int)
+    assert isinstance(time, float | int)
     return distance / time
 
 
@@ -57,6 +70,8 @@ def get_speed_floats(
 def get_speed_relative(
     distance: u(float, units="=A"), time: u(float, units="=B")
 ) -> u(float, units="=A/B"):
+    assert isinstance(distance, float | int)
+    assert isinstance(time, float | int)
     return distance / time
 
 
@@ -64,6 +79,8 @@ def get_speed_relative(
 def return_dict(
     distance: u(float, units="meter"), time: u(float, units="second")
 ) -> dict:
+    assert isinstance(distance, float | int)
+    assert isinstance(time, float | int)
     return {"distance": distance, "time": time}
 
 

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -67,6 +67,11 @@ def return_dict(
     return {"distance": distance, "time": time}
 
 
+@units
+def test_kwargs(x: u(float, units="meter"), **kwargs) -> u(float, units="meter"):
+    return x
+
+
 class TestUnits(unittest.TestCase):
     def test_relative(self):
         self.assertEqual(get_speed_relative(1, 1), 1)
@@ -181,6 +186,26 @@ class TestUnits(unittest.TestCase):
         self.assertEqual(return_dict(1, 1), {"distance": 1, "time": 1})
         ureg = UnitRegistry()
         self.assertIsInstance(return_dict(1 * ureg.meter, 1 * ureg.second), dict)
+
+    def test_kwargs(self):
+        self.assertEqual(test_kwargs(1), 1)
+        ureg = UnitRegistry()
+        self.assertEqual(
+            test_kwargs(1 * ureg.meter),
+            1 * ureg.meter,
+        )
+        self.assertEqual(
+            test_kwargs(1 * ureg.millimeter),
+            1 / 1000 * ureg.meter,
+        )
+        self.assertEqual(
+            test_kwargs(1 * ureg.millimeter, a=1),
+            1 / 1000 * ureg.meter,
+        )
+        self.assertEqual(
+            test_kwargs(1 * ureg.millimeter, a=1, b=2),
+            1 / 1000 * ureg.meter,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
While implementing atomistics stuff I realized that `**kwargs` did not work, such as:

```python
@units
def f(x: u(float, units="meter") = 0.001, **kwargs):
    return x
```

This should be fixed with this PR.