### PR TITLE
Use get_type_hints instead of inspect

### DIFF
--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -94,12 +94,14 @@ def parse_output_args(func: callable):
         `label`, `triples`, `uri` and `shape`. See `semantikon.typing.u` for
         more details.
     """
-    sig = inspect.signature(func)
-    multiple_output = get_origin(sig.return_annotation) is tuple
+    ret = get_type_hints(func, include_extras=True).get(
+        "return", inspect.Parameter.empty
+    )
+    multiple_output = get_origin(ret) is tuple
     if multiple_output:
-        return tuple([meta_to_dict(ann) for ann in get_args(sig.return_annotation)])
+        return tuple([meta_to_dict(ann) for ann in get_args(ret)])
     else:
-        return meta_to_dict(sig.return_annotation)
+        return meta_to_dict(ret)
 
 
 def _get_converter(func):

--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -11,7 +11,7 @@ from pint.registry_helpers import (
     _to_units_container,
     _replace_units,
 )
-from typing import get_origin, get_args
+from typing import get_origin, get_args, get_type_hints
 
 __author__ = "Sam Waseda"
 __copyright__ = (
@@ -74,8 +74,9 @@ def parse_input_args(func: callable):
         dictionary of the input arguments. Available keys are `units`, `label`,
         `triples`, `uri` and `shape`. See `semantikon.typing.u` for more details.
     """
+    type_hints = get_type_hints(func, include_extras=True)
     return {
-        key: meta_to_dict(value.annotation, value.default)
+        key: meta_to_dict(type_hints.get(key, value.annotation), value.default)
         for key, value in inspect.signature(func).parameters.items()
     }
 

--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -11,7 +11,7 @@ from pint.registry_helpers import (
     _to_units_container,
     _replace_units,
 )
-from typing import get_origin, get_args, get_type_hints, Annotated, _AnnotatedAlias
+from typing import get_origin, get_args, get_type_hints
 import sys
 
 __author__ = "Sam Waseda"
@@ -79,7 +79,7 @@ def get_annotated_type_hints(func):
                 annotation = eval(annotation, func.__globals__)
             hints[name] = annotation
         if sig.return_annotation is not inspect.Signature.empty:
-            hints['return'] = sig.return_annotation
+            hints["return"] = sig.return_annotation
         return hints
 
 

--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -65,6 +65,18 @@ def meta_to_dict(value, default=inspect.Parameter.empty):
 
 
 def get_annotated_type_hints(func):
+    """
+    Get the type hints of a function, including lazy annotations. The function
+    practically does the same as `get_type_hints` for Python 3.11 and later,
+
+    Args:
+        func: function to be parsed
+
+    Returns:
+        dictionary of the type hints. The keys are the names of the arguments
+        and the values are the type hints. The return type is stored under the
+        key "return".
+    """
     if sys.version_info >= (3, 11):
         # Use the official, public API
         return get_type_hints(func, include_extras=True)

--- a/semantikon/typing.py
+++ b/semantikon/typing.py
@@ -43,7 +43,7 @@ def _type_metadata(
     )
     if len(kwargs) == 0:
         raise TypeError("No metadata provided.")
-    items = [x for k, v in kwargs.items() for x in [k, v]]
+    items = tuple([x for k, v in kwargs.items() for x in [k, v]])
     return Annotated[type_, items]
 
 

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -104,6 +104,20 @@ class TestParser(unittest.TestCase):
             u(float)
         self.assertEqual(str(context.exception), "No metadata provided.")
 
+    def test_optional_args(self):
+        def get_speed_multiple_args(
+            distance: u(float, units="meter"),
+            time: u(float, units="second"),
+            duration: u(float | None, units="second") = None,
+        ) -> u(float, units="meter/second"):
+            if duration is None:
+                return distance / time
+            else:
+                return distance / duration
+        input_args = parse_input_args(get_speed_multiple_args)
+        for value, key in zip(input_args.values(), ["meter", "second", "second"]):
+            self.assertEqual(value["units"], key)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -33,6 +33,7 @@ def get_speed_multiple_args(
 ) -> u(float, units="meter/second"):
     assert isinstance(distance, float | int)
     assert isinstance(time, float | int)
+    assert isinstance(duration, float | int | None)
     if duration is None:
         return distance / time
     else:

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -1,6 +1,6 @@
 import unittest
 from semantikon.typing import u
-from semantikon.converter import units
+from semantikon.converter import units, _get_output_units, parse_output_args
 from pint import UnitRegistry
 
 
@@ -10,9 +10,9 @@ def get_speed_multiple_outputs(
     time: u(float, units="second"),
     duration: u(float, units="second"),
 ) -> tuple[u(float, units="meter/second"), u(float, units="meter/second")]:
-    assert isinstance(distance, float | int)
-    assert isinstance(time, float | int)
-    assert isinstance(duration, float | int)
+    assert isinstance(distance, float | int), type(distance)
+    assert isinstance(time, float | int), type(time)
+    assert isinstance(duration, float | int), type(duration)
     return distance / time, distance / duration
 
 
@@ -20,8 +20,8 @@ def get_speed_multiple_outputs(
 def get_speed_no_output_type(
     distance: u(float, units="meter"), time: u(float, units="second")
 ):
-    assert isinstance(distance, float | int)
-    assert isinstance(time, float | int)
+    assert isinstance(distance, float | int), type(distance)
+    assert isinstance(time, float | int), type(time)
     return distance / time
 
 
@@ -31,9 +31,9 @@ def get_speed_multiple_args(
     time: u(float, units="second"),
     duration: u(float | None, units="second") = None,
 ) -> u(float, units="meter/second"):
-    assert isinstance(distance, float | int)
-    assert isinstance(time, float | int)
-    assert isinstance(duration, float | int | None)
+    assert isinstance(distance, float | int), type(distance)
+    assert isinstance(time, float | int), type(time)
+    assert isinstance(duration, float | int | None), type(duration)
     if duration is None:
         return distance / time
     else:
@@ -44,8 +44,8 @@ def get_speed_multiple_args(
 def get_speed_optional_args(
     distance: u(float, units="meter"), time: u(float, units="second") = 1
 ) -> u(float, units="meter/second"):
-    assert isinstance(distance, float | int)
-    assert isinstance(time, float | int)
+    assert isinstance(distance, float | int), type(distance)
+    assert isinstance(time, float | int), type(time)
     return distance / time
 
 
@@ -53,8 +53,8 @@ def get_speed_optional_args(
 def get_speed_ints(
     distance: u(int, units="meter"), time: u(int, units="second")
 ) -> u(int, units="meter/second"):
-    assert isinstance(distance, float | int)
-    assert isinstance(time, float | int)
+    assert isinstance(distance, float | int), type(distance)
+    assert isinstance(time, float | int), type(time)
     return distance / time
 
 
@@ -62,8 +62,8 @@ def get_speed_ints(
 def get_speed_floats(
     distance: u(float, units="meter"), time: u(float, units="second")
 ) -> u(float, units="meter/second"):
-    assert isinstance(distance, float | int)
-    assert isinstance(time, float | int)
+    assert isinstance(distance, float | int), type(distance)
+    assert isinstance(time, float | int), type(time)
     return distance / time
 
 
@@ -71,8 +71,8 @@ def get_speed_floats(
 def get_speed_relative(
     distance: u(float, units="=A"), time: u(float, units="=B")
 ) -> u(float, units="=A/B"):
-    assert isinstance(distance, float | int)
-    assert isinstance(time, float | int)
+    assert isinstance(distance, float | int), type(distance)
+    assert isinstance(time, float | int), type(time)
     return distance / time
 
 
@@ -80,21 +80,21 @@ def get_speed_relative(
 def return_dict(
     distance: u(float, units="meter"), time: u(float, units="second")
 ) -> dict:
-    assert isinstance(distance, float | int)
-    assert isinstance(time, float | int)
+    assert isinstance(distance, float | int), type(distance)
+    assert isinstance(time, float | int), type(time)
     return {"distance": distance, "time": time}
 
 
 @units
 def test_kwargs(x: u(float, units="meter"), **kwargs) -> u(float, units="meter"):
-    assert isinstance(x, float | int)
+    assert isinstance(x, float | int), type(x)
     return x
 
 
 # Imitate effects of from __future__ import annotations
 @units
 def test_future(x: 'u(float, units="meter")') -> 'u(float, units="meter")':
-    assert isinstance(x, float | int)
+    assert isinstance(x, float | int), type(x)
     return x
 
 
@@ -137,6 +137,10 @@ class TestUnits(unittest.TestCase):
         self.assertEqual(
             get_speed_multiple_args(1 * ureg.meter, 1 * ureg.second),
             1 * ureg.meter / ureg.second,
+        )
+        self.assertEqual(
+            _get_output_units(parse_output_args(get_speed_multiple_args), ureg, {}),
+            ureg.Quantity(1, ureg.meter / ureg.second),
         )
         self.assertEqual(
             get_speed_multiple_args(1 * ureg.meter, 1 * ureg.second, 1 * ureg.second),

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -1,6 +1,6 @@
 import unittest
 from semantikon.typing import u
-from semantikon.converter import units, _get_output_units, parse_output_args
+from semantikon.converter import units
 from pint import UnitRegistry
 
 
@@ -137,10 +137,6 @@ class TestUnits(unittest.TestCase):
         self.assertEqual(
             get_speed_multiple_args(1 * ureg.meter, 1 * ureg.second),
             1 * ureg.meter / ureg.second,
-        )
-        self.assertEqual(
-            _get_output_units(parse_output_args(get_speed_multiple_args), ureg, {}),
-            ureg.Quantity(1, ureg.meter / ureg.second),
         )
         self.assertEqual(
             get_speed_multiple_args(1 * ureg.meter, 1 * ureg.second, 1 * ureg.second),

--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -90,6 +90,13 @@ def test_kwargs(x: u(float, units="meter"), **kwargs) -> u(float, units="meter")
     return x
 
 
+# Imitate effects of from __future__ import annotations
+@units
+def test_future(x: 'u(float, units="meter")') -> 'u(float, units="meter")':
+    assert isinstance(x, float | int)
+    return x
+
+
 class TestUnits(unittest.TestCase):
     def test_relative(self):
         self.assertEqual(get_speed_relative(1, 1), 1)
@@ -222,6 +229,18 @@ class TestUnits(unittest.TestCase):
         )
         self.assertEqual(
             test_kwargs(1 * ureg.millimeter, a=1, b=2),
+            1 / 1000 * ureg.meter,
+        )
+
+    def test_future(self):
+        self.assertEqual(test_future(1), 1)
+        ureg = UnitRegistry()
+        self.assertEqual(
+            test_future(1 * ureg.meter),
+            1 * ureg.meter,
+        )
+        self.assertEqual(
+            test_future(1 * ureg.millimeter),
             1 / 1000 * ureg.meter,
         )
 


### PR DESCRIPTION
`get_type_hints` can deal with future annotations, although forward referencing anyway does not work.

What works:

```python
from __future__ import annotations
from typing import TYPE_CHECKING

if TYPE_CHECKING:
    from path_to_my_class import MyClass

def f(x: MyClass):
    return x
```

What does not work:

```python
from __future__ import annotations
from typing import TYPE_CHECKING, Annotated, get_type_hints

if TYPE_CHECKING:
    from path_to_my_class import MyClass

def f(x: Annotated[MyClass, "test"]):
    return x


get_type_hints(f)
```

-> `NameError: name 'MyClass' is not defined`