### PR TITLE
Add fallback in the case the type cannot be understood

### DIFF
--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -118,6 +118,14 @@ class TestParser(unittest.TestCase):
         for value, key in zip(input_args.values(), ["meter", "second", "second"]):
             self.assertEqual(value["units"], key)
 
+    def test_future(self):
+        def test_another_future(x: "Atoms", y: "u(float, units='second')") -> "Atoms":
+            return x
+        input_args = parse_input_args(test_another_future)
+        self.assertEqual(input_args["x"]["dtype"], "Atoms")
+        self.assertIn("units", input_args["y"]) 
+        self.assertEqual(input_args["y"]["units"], "second")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -123,7 +123,7 @@ class TestParser(unittest.TestCase):
             return x
         input_args = parse_input_args(test_another_future)
         self.assertEqual(input_args["x"]["dtype"], "Atoms")
-        self.assertIn("units", input_args["y"]) 
+        self.assertIn("units", input_args["y"])
         self.assertEqual(input_args["y"]["units"], "second")
 
 


### PR DESCRIPTION
Closes #124

I actually didn't expect to be able to solve this problem so quickly. Nevertheless, there is still the case when a class is used in a string together with semantikon, such as:

```python
def f(x: u("MyClass", uri="MyClass")):
    ...
```

(except if `MyClass` is actually imported)

I don't know for now how to make it work.