### PR TITLE
Make output safe against lazy annotation

### DIFF
--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -141,6 +141,8 @@ def parse_output_args(func: callable):
         ret = get_type_hints(func, include_extras=True).get(
             "return", inspect.Parameter.empty
         )
+    # NameError is raised if the type hint is a string with a lazy annotation
+    # and the class is not imported
     except NameError:
         ret = func.__annotations__.get("return", inspect.Parameter.empty)
     multiple_output = get_origin(ret) is tuple

--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -137,9 +137,12 @@ def parse_output_args(func: callable):
         `label`, `triples`, `uri` and `shape`. See `semantikon.typing.u` for
         more details.
     """
-    ret = get_type_hints(func, include_extras=True).get(
-        "return", inspect.Parameter.empty
-    )
+    try:
+        ret = get_type_hints(func, include_extras=True).get(
+            "return", inspect.Parameter.empty
+        )
+    except NameError:
+        ret = func.__annotations__.get("return", inspect.Parameter.empty)
     multiple_output = get_origin(ret) is tuple
     if multiple_output:
         return tuple([meta_to_dict(ann) for ann in get_args(ret)])

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -126,7 +126,7 @@ class TestParser(unittest.TestCase):
         self.assertIn("units", input_args["y"])
         self.assertEqual(input_args["y"]["units"], "second")
         output_args = parse_output_args(test_another_future)
-        print(output_args)
+        self.assertEqual(output_args["dtype"], "Atoms")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -125,6 +125,8 @@ class TestParser(unittest.TestCase):
         self.assertEqual(input_args["x"]["dtype"], "Atoms")
         self.assertIn("units", input_args["y"])
         self.assertEqual(input_args["y"]["units"], "second")
+        output_args = parse_output_args(test_another_future)
+        print(output_args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I had fixed [this issue](https://github.com/pyiron/semantikon/issues/124) in [this PR](https://github.com/pyiron/semantikon/pull/125), but I had forgot to do the same for the output. This PR should fix it now.