### PR TITLE
Do not pass explicit `kwargs` into the function

### DIFF
--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -88,6 +88,7 @@ def return_dict(
 @units
 def test_kwargs(x: u(float, units="meter"), **kwargs) -> u(float, units="meter"):
     assert isinstance(x, float | int), type(x)
+    assert len(kwargs) == 0, kwargs
     return x
 
 


### PR DESCRIPTION
In [this PR](https://github.com/pyiron/semantikon/pull/121), I had fixed the problem that `kwargs` was literally (i.e. as "kwargs") in the converter. Now I remove it explicitly.