### PR TITLE
Make it possible to deal with not imported classes with semantikon

### DIFF
--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -137,14 +137,7 @@ def parse_output_args(func: callable):
         `label`, `triples`, `uri` and `shape`. See `semantikon.typing.u` for
         more details.
     """
-    try:
-        ret = get_type_hints(func, include_extras=True).get(
-            "return", inspect.Parameter.empty
-        )
-    # NameError is raised if the type hint is a string with a lazy annotation
-    # and the class is not imported
-    except NameError:
-        ret = func.__annotations__.get("return", inspect.Parameter.empty)
+    ret = get_annotated_type_hints(func).get("return", inspect.Parameter.empty)
     multiple_output = get_origin(ret) is tuple
     if multiple_output:
         return tuple([meta_to_dict(ann) for ann in get_args(ret)])

--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -130,7 +130,7 @@ def get_annotated_type_hints(func):
         for key, value in func.__annotations__.items():
             hints[key] = _resolve_annotation(value, func.__globals__)
         if hasattr(func, "__return_annotation__"):
-            hints["return"] = f_resolve_annotation(
+            hints["return"] = _resolve_annotation(
                 func.__return_annotation__, func.__globals__
             )
         return hints

--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -57,7 +57,10 @@ def meta_to_dict(value, default=inspect.Parameter.empty):
     default_is_defined = default is not inspect.Parameter.empty
     if semantikon_was_used:
         result = {k: v for k, v in parse_metadata(value).items() if v is not None}
-        result["dtype"] = value.__args__[0]
+        if hasattr(value.__args__[0], "__forward_arg__"):
+            result["dtype"] = value.__args__[0].__forward_arg__
+        else:
+            result["dtype"] = value.__args__[0]
     else:
         result = {}
         if type_hint_was_present:

--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -16,7 +16,6 @@ import sys
 import re
 
 
-
 __author__ = "Sam Waseda"
 __copyright__ = (
     "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH "
@@ -92,9 +91,7 @@ def _resolve_annotation(annotation, func_globals=None):
         undefined_name = extract_undefined_name(str(e))
         if undefined_name == annotation:
             return annotation
-        new_annotations = eval(
-            annotation, func_globals | {undefined_name: object}
-        )
+        new_annotations = eval(annotation, func_globals | {undefined_name: object})
         return Annotated[undefined_name, *get_args(new_annotations)[1:]]
 
 

--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -92,7 +92,9 @@ def _resolve_annotation(annotation, func_globals=None):
         if undefined_name == annotation:
             return annotation
         new_annotations = eval(annotation, func_globals | {undefined_name: object})
-        return Annotated[undefined_name, *get_args(new_annotations)[1:]]
+        args = get_args(new_annotations)
+        assert len(args) == 2, "Invalid annotation format"
+        return Annotated[undefined_name, args[1]]
 
 
 def get_annotated_type_hints(func):

--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -123,7 +123,7 @@ def get_annotated_type_hints(func):
                     sig.return_annotation, func.__globals__
                 )
             return hints
-    except (NameError, TypeError):
+    except NameError:
         hints = {}
         for key, value in func.__annotations__.items():
             hints[key] = _resolve_annotation(value, func.__globals__)

--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -123,7 +123,7 @@ def get_annotated_type_hints(func):
                     sig.return_annotation, func.__globals__
                 )
             return hints
-    except NameError:
+    except (NameError, TypeError):
         hints = {}
         for key, value in func.__annotations__.items():
             hints[key] = _resolve_annotation(value, func.__globals__)

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -133,6 +133,7 @@ class TestParser(unittest.TestCase):
             return x
         input_args = parse_input_args(test_more_future)
         self.assertEqual(input_args["x"]["uri"], "metadata")
+        self.assertEqual(input_args["x"]["dtype"], "Atoms")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -131,6 +131,7 @@ class TestParser(unittest.TestCase):
         self.assertEqual(output_args["dtype"], "Atoms")
 
     def test_semantikon_and_future(self):
+        # This imitates a future import
         def test_more_future(x: "u(Atoms, uri='metadata')") -> "Atoms":
             return x
 

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -128,6 +128,12 @@ class TestParser(unittest.TestCase):
         output_args = parse_output_args(test_another_future)
         self.assertEqual(output_args["dtype"], "Atoms")
 
+    def test_semantikon_and_future(self):
+        def test_more_future(x: "u('Atoms', uri='atoms')") -> "Atoms":
+            return x
+        input_args = parse_input_args(test_more_future)
+        print(input_args)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -129,10 +129,10 @@ class TestParser(unittest.TestCase):
         self.assertEqual(output_args["dtype"], "Atoms")
 
     def test_semantikon_and_future(self):
-        def test_more_future(x: "u('Atoms', uri='atoms')") -> "Atoms":
+        def test_more_future(x: "u(Atoms, uri='metadata')") -> "Atoms":
             return x
         input_args = parse_input_args(test_more_future)
-        print(input_args)
+        self.assertEqual(input_args["x"]["uri"], "metadata")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -114,6 +114,7 @@ class TestParser(unittest.TestCase):
                 return distance / time
             else:
                 return distance / duration
+
         input_args = parse_input_args(get_speed_multiple_args)
         for value, key in zip(input_args.values(), ["meter", "second", "second"]):
             self.assertEqual(value["units"], key)
@@ -121,6 +122,7 @@ class TestParser(unittest.TestCase):
     def test_future(self):
         def test_another_future(x: "Atoms", y: "u(float, units='second')") -> "Atoms":
             return x
+
         input_args = parse_input_args(test_another_future)
         self.assertEqual(input_args["x"]["dtype"], "Atoms")
         self.assertIn("units", input_args["y"])
@@ -131,6 +133,7 @@ class TestParser(unittest.TestCase):
     def test_semantikon_and_future(self):
         def test_more_future(x: "u(Atoms, uri='metadata')") -> "Atoms":
             return x
+
         input_args = parse_input_args(test_more_future)
         self.assertEqual(input_args["x"]["uri"], "metadata")
         self.assertEqual(input_args["x"]["dtype"], "Atoms")


### PR DESCRIPTION
There was a special case that was not treated in #125 and #126 where a not imported class is used with semantikon, such as:

```python
from semantikon.typing import u

from typing import TYPE_CHECKING
if TYPE_CHECKING:
    from ase import Atoms

def f(x: u(Atoms, uri="Atoms")) -> Atoms:
    ....
```

This PR makes it possible to parse it correctly, where the metadata is read as the user defines it, and the class should be translated into a string.