### PR TITLE
[nit] Separate func to dict part

### DIFF
--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -129,12 +129,17 @@ class FunctionDictFlowAnalyzer:
         return f"{base_name}_{i}"
 
 
+def get_ast_dict(func: callable) -> dict:
+    """Get the AST dictionary representation of a function. """
+    source_code = inspect.getsource(func)
+    tree = ast.parse(source_code)
+    return _function_to_ast_dict(tree)
+
+
 def analyze_function(func):
     """Extracts the variable flow graph from a function"""
-    source_code = inspect.getsource(func)
+    ast_dict = get_ast_dict(func)
     scope = inspect.getmodule(func).__dict__
-    tree = ast.parse(source_code)
-    ast_dict = _function_to_ast_dict(tree)
     analyzer = FunctionDictFlowAnalyzer(ast_dict["body"][0], scope)
     analyzer.analyze()
     return analyzer

--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -130,7 +130,7 @@ class FunctionDictFlowAnalyzer:
 
 
 def get_ast_dict(func: callable) -> dict:
-    """Get the AST dictionary representation of a function. """
+    """Get the AST dictionary representation of a function."""
     source_code = inspect.getsource(func)
     tree = ast.parse(source_code)
     return _function_to_ast_dict(tree)


### PR DESCRIPTION
In the discussion with @jan-janssen I realized that the functionality to translate a function to a dictionary should be separated out from the function analysis.