### PR TITLE
[bug] Allow multiple occurrences of variables used in the input args

### DIFF
--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -120,7 +120,9 @@ class FunctionDictFlowAnalyzer:
         if source["_type"] != "Name":
             raise NotImplementedError(f"Only variable inputs supported, got: {source}")
         var_name = source["id"]
-        idx = self._var_index.get(var_name, 0)
+        if var_name not in self._var_index:
+            self._var_index[var_name] = 0
+        idx = self._var_index[var_name]
         versioned = f"{var_name}_{idx}"
         self.graph.add_edge(versioned, target, type="input", **kwargs)
 

--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -215,8 +215,7 @@ def _get_sorted_edges(graph):
 
 def _get_data_edges(graph, functions, func):
     input_dict = {
-        name: list(parse_input_args(func).keys())
-        for name, func in functions.items()
+        name: list(parse_input_args(func).keys()) for name, func in functions.items()
     }
     output_labels = list(_get_workflow_outputs(func).keys())
     data_edges = []
@@ -225,9 +224,7 @@ def _get_data_edges(graph, functions, func):
     for edge in ordered_edges:
         if edge[2]["type"] == "output":
             if hasattr(functions[edge[0]], "_semantikon_workflow"):
-                keys = list(
-                    functions[edge[0]]._semantikon_workflow["outputs"].keys()
-                )
+                keys = list(functions[edge[0]]._semantikon_workflow["outputs"].keys())
                 output_index = 0
                 if "output_index" in edge[2]:
                     output_index = edge[2]["output_index"]

--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -163,13 +163,22 @@ def _get_node_outputs(func, counts):
         return {"output": outputs}
 
 
-def _get_output_counts(data):
+def _get_output_counts(graph: nx.DiGraph) -> dict:
+    """
+    Get the number of outputs for each node in the graph.
+
+    Args:
+        graph (nx.DiGraph): The directed graph representing the function.
+
+    Returns:
+        dict: A dictionary mapping node names to the number of outputs.
+    """
     f_dict = {}
-    for edge in data:
+    for edge in graph.edges.data():
         if edge[2]["type"] != "output":
             continue
         f_name = "_".join(edge[0].split("_")[:-1])
-        if f_name not in f_dict or f_dict[f_name] < edge[2].get("output_index", 0) + 1:
+        if f_dict.get(f_name, -1) < edge[2].get("output_index", 0) + 1:
             f_dict[f_name] = edge[2].get("output_index", 0) + 1
     return f_dict
 
@@ -322,7 +331,7 @@ def separate_functions(data, function_dict=None):
 
 def get_workflow_dict(func):
     analyzer = analyze_function(func)
-    output_counts = _get_output_counts(analyzer.graph.edges.data())
+    output_counts = _get_output_counts(analyzer)
     nodes = _get_nodes(analyzer.function_defs, output_counts)
     data = {
         "inputs": parse_input_args(func),

--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -331,7 +331,7 @@ def separate_functions(data, function_dict=None):
 
 def get_workflow_dict(func):
     analyzer = analyze_function(func)
-    output_counts = _get_output_counts(analyzer)
+    output_counts = _get_output_counts(analyzer.graph)
     nodes = _get_nodes(analyzer.function_defs, output_counts)
     data = {
         "inputs": parse_input_args(func),

--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -93,14 +93,14 @@ class FunctionDictFlowAnalyzer:
 
         self.function_defs[called_func] = self.scope[func_name]
 
-        # Parse outputs
-        self._parse_outputs(node["targets"], called_func)
-
         # Parse inputs (positional + keyword)
         for i, arg in enumerate(value.get("args", [])):
             self._add_input_edge(arg, called_func, input_index=i)
         for kw in value.get("keywords", []):
             self._add_input_edge(kw["value"], called_func, input_name=kw["arg"])
+
+        # Parse outputs
+        self._parse_outputs(node["targets"], called_func)
 
     def _parse_outputs(self, targets, called_func):
         if len(targets) == 1 and targets[0]["_type"] == "Tuple":

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -78,7 +78,7 @@ def multiple_types_for_ape(a: ApeClass, b: ApeClass) -> ApeClass:
 
 class TestWorkflow(unittest.TestCase):
     def test_analyzer(self):
-        analyzer = analyze_function(example_macro)
+        graph = analyze_function(example_macro)[0]
         all_data = [
             ("operation_0", "c_0", {"type": "output", "output_index": 0}),
             ("operation_0", "d_0", {"type": "output", "output_index": 1}),
@@ -91,7 +91,7 @@ class TestWorkflow(unittest.TestCase):
             ("multiply_0", "f_0", {"type": "output"}),
         ]
         self.assertEqual(
-            [data for data in analyzer.graph.edges.data()],
+            [data for data in graph.edges.data()],
             all_data,
         )
 
@@ -131,8 +131,8 @@ class TestWorkflow(unittest.TestCase):
         self.assertRaises(ValueError, get_return_variables, operation)
 
     def test_get_output_counts(self):
-        analyzer = analyze_function(example_macro)
-        output_counts = _get_output_counts(analyzer.graph)
+        graph = analyze_function(example_macro)[0]
+        output_counts = _get_output_counts(graph)
         self.assertEqual(output_counts, {"operation": 2, "add": 1, "multiply": 1})
 
     def test_get_workflow_dict(self):
@@ -247,9 +247,9 @@ class TestWorkflow(unittest.TestCase):
         self.assertEqual(result, ref_data, msg=result)
 
     def test_parallel_execution(self):
-        analyzer = analyze_function(parallel_execution)
+        graph = analyze_function(parallel_execution)[0]
         self.assertEqual(
-            find_parallel_execution_levels(analyzer.graph),
+            find_parallel_execution_levels(graph),
             [
                 ["a_0", "b_0"],
                 ["add_0", "multiply_0"],

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -80,6 +80,7 @@ def seemingly_cyclic_workflow(a=10, b=20):
     a = add(a, b)
     return a
 
+
 class TestWorkflow(unittest.TestCase):
     def test_analyzer(self):
         graph = analyze_function(example_macro)[0]
@@ -308,6 +309,7 @@ class TestWorkflow(unittest.TestCase):
         data = get_workflow_dict(seemingly_cyclic_workflow)
         self.assertIn("a", data["inputs"])
         self.assertIn("a", data["outputs"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -95,9 +95,10 @@ class TestWorkflow(unittest.TestCase):
             ("e_0", "multiply_0", {"type": "input", "input_index": 0}),
             ("multiply_0", "f_0", {"type": "output"}),
         ]
+        self.maxDiff = None
         self.assertEqual(
-            [data for data in graph.edges.data()],
-            all_data,
+            sorted([data for data in graph.edges.data()]),
+            sorted(all_data),
         )
 
     def test_get_node_dict(self):

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -76,6 +76,10 @@ def multiple_types_for_ape(a: ApeClass, b: ApeClass) -> ApeClass:
     return a + b
 
 
+def seemingly_cyclic_workflow(a=10, b=20):
+    a = add(a, b)
+    return a
+
 class TestWorkflow(unittest.TestCase):
     def test_analyzer(self):
         graph = analyze_function(example_macro)[0]
@@ -300,6 +304,10 @@ class TestWorkflow(unittest.TestCase):
         class_dict = separate_types(old_data)[1]
         self.assertEqual(class_dict, {"float": float})
 
+    def test_seemingly_cyclic_workflow(self):
+        data = get_workflow_dict(seemingly_cyclic_workflow)
+        self.assertIn("a", data["inputs"])
+        self.assertIn("a", data["outputs"])
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -132,7 +132,7 @@ class TestWorkflow(unittest.TestCase):
 
     def test_get_output_counts(self):
         analyzer = analyze_function(example_macro)
-        output_counts = _get_output_counts(analyzer.graph.edges.data())
+        output_counts = _get_output_counts(analyzer.graph)
         self.assertEqual(output_counts, {"operation": 2, "add": 1, "multiply": 1})
 
     def test_get_workflow_dict(self):


### PR DESCRIPTION
While testing the code I realized that the following function could not be correctly parsed:

```python
def f(x):
    x = some_function(x)
    return x
```

The reason is because the counting of variables was done only when they were assigned, i.e. the following case was already correctly working:

```python
def f(x):
    y = some_function(x)
    y = some_other_function(y)
    return y
```

Now both cases should work.