### PR TITLE
Make sure that all args are defined

### DIFF
--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -68,6 +68,9 @@ class FunctionDictFlowAnalyzer:
         self._call_counter = {}
 
     def analyze(self):
+        for arg in self.ast_dict.get("args", {}).get("args", []):
+            if arg["_type"] == "arg":
+                self._var_index[arg["arg"]] = 0
         for node in self.ast_dict.get("body", []):
             self._visit_node(node)
         return self.graph, self.function_defs
@@ -121,7 +124,7 @@ class FunctionDictFlowAnalyzer:
             raise NotImplementedError(f"Only variable inputs supported, got: {source}")
         var_name = source["id"]
         if var_name not in self._var_index:
-            self._var_index[var_name] = 0
+            raise ValueError(f"Variable {var_name} not found in scope")
         idx = self._var_index[var_name]
         versioned = f"{var_name}_{idx}"
         self.graph.add_edge(versioned, target, type="input", **kwargs)

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -81,6 +81,11 @@ def seemingly_cyclic_workflow(a=10, b=20):
     return a
 
 
+def workflow_to_use_undefined_variable(a=10, b=20):
+    result = add(a, u)
+    return result
+
+
 class TestWorkflow(unittest.TestCase):
     def test_analyzer(self):
         graph = analyze_function(example_macro)[0]
@@ -310,6 +315,10 @@ class TestWorkflow(unittest.TestCase):
         data = get_workflow_dict(seemingly_cyclic_workflow)
         self.assertIn("a", data["inputs"])
         self.assertIn("a", data["outputs"])
+
+    def test_workflow_to_use_undefined_variable(self):
+        with self.assertRaises(ValueError):
+            workflow(workflow_to_use_undefined_variable)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In #136, I made it possible to reuse variables defined in the input args, but I realized that it would allow an operation with undefined variables like:

```python
def f(x):
    y = some_operation(z)
    return y
```

This PR makes sure that in this case an error is raised.