### PR TITLE
Implement ast_from_dict to convert ast dict to code

### DIFF
--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -12,6 +12,18 @@ from networkx.algorithms.dag import topological_sort
 from semantikon.converter import parse_input_args, parse_output_args
 
 
+def ast_from_dict(d):
+    """Recursively convert a dict to an ast.AST node"""
+    if isinstance(d, dict):
+        node_type = getattr(ast, d["_type"])
+        fields = {k: ast_from_dict(v) for k, v in d.items() if k != "_type"}
+        return node_type(**fields)
+    elif isinstance(d, list):
+        return [ast_from_dict(x) for x in d]
+    else:
+        return d
+
+
 def _function_to_ast_dict(node):
     if isinstance(node, ast.AST):
         result = {"_type": type(node).__name__}

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -1,9 +1,11 @@
+import ast
 import unittest
 
 from semantikon.typing import u
 from semantikon.workflow import (
     _get_output_counts,
     analyze_function,
+    ast_from_dict,
     find_parallel_execution_levels,
     get_node_dict,
     get_return_variables,
@@ -319,6 +321,15 @@ class TestWorkflow(unittest.TestCase):
     def test_workflow_to_use_undefined_variable(self):
         with self.assertRaises(ValueError):
             workflow(workflow_to_use_undefined_variable)
+
+    def test_ast_from_dict(self):
+        d = {
+            "_type": "Compare",
+            "left": {"_type": "Name", "id": "x", "ctx": {"_type": "Load"}},
+            "ops": [{"_type": "Lt"}],
+            "comparators": [{"_type": "Constant", "value": 0, "kind": None}],
+        }
+        self.assertEqual(ast.unparse(ast_from_dict(d)), "x < 0")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Since we are now looking into injecting python code into the dictionary representation, I implemented `ast_to_dict`. Following the AST representation, `x < 0` is given by:

```python
{
    "_type": "Compare",
    "left": {"_type": "Name", "id": "x", "ctx": {"_type": "Load"}},
    "ops": [{"_type": "Lt"}],
    "comparators": [{"_type": "Constant", "value": 0, "kind": None}],
}
```

And by running `ast.unparse(ast_from_dict(my_dict))`, we get `x < 0`