### PR TITLE
[bug] Allow reused args

### DIFF
--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -270,7 +270,8 @@ def _get_data_edges(graph, functions, func):
                 tag = f"{edge[0]}.outputs.output"
             if _remove_index(edge[1]) in output_labels:
                 output_candidate[_remove_index(edge[1])] = (
-                    tag, f"outputs.{_remove_index(edge[1])}"
+                    tag,
+                    f"outputs.{_remove_index(edge[1])}",
                 )
             output_dict[edge[1]] = tag
         else:

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -354,7 +354,7 @@ class TestWorkflow(unittest.TestCase):
         data = get_workflow_dict(reused_args)
         self.assertEqual(
             sorted(data["data_edges"]),
-            sorted(example_macro._semantikon_workflow["data_edges"])
+            sorted(example_macro._semantikon_workflow["data_edges"]),
         )
 
 


### PR DESCRIPTION
There was a problem with variable names which were used in the output args, when they are to be re-assigned before being returned such as:


```python
def my_function(x):
    y = f(x)
    y = g(y)
    return y
```

This is now fixed