### PR TITLE
[patch] Modify output parser to include the output names

### DIFF
--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -121,7 +121,7 @@ def get_return_expressions(func):
         if isinstance(node, ast.Return):
             value = node.value
             if value is None:
-                ret_list.append(['None'])
+                ret_list.append(["None"])
             elif isinstance(value, ast.Tuple):
                 ret_list.append(
                     tuple([_to_tag(elt, ii) for ii, elt in enumerate(value.elts)])
@@ -129,9 +129,14 @@ def get_return_expressions(func):
             else:
                 ret_list.append(_to_tag(value))
 
-    if len(set(ret_list)) == 1:
+    if len(ret_list) == 0:
+        return None
+    elif len(set(ret_list)) == 1:
         return ret_list[0]
-    elif all(isinstance(exp, tuple) for exp in ret_list) and len(set(len(r) for r in ret_list)) == 1:
+    elif (
+        all(isinstance(exp, tuple) for exp in ret_list)
+        and len(set(len(r) for r in ret_list)) == 1
+    ):
         return tuple([f"output_{i}" for i in range(len(ret_list[0]))])
     else:
         return "output"

--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -115,22 +115,24 @@ def get_return_expressions(func):
 
     func_node = next(n for n in parsed.body if isinstance(n, ast.FunctionDef))
 
-    return_expressions = []
+    ret_list = []
 
     for node in ast.walk(func_node):
         if isinstance(node, ast.Return):
             value = node.value
             if value is None:
-                return_expressions.append(['None'])
+                ret_list.append(['None'])
             elif isinstance(value, ast.Tuple):
-                return_expressions.append(
+                ret_list.append(
                     tuple([_to_tag(elt, ii) for ii, elt in enumerate(value.elts)])
                 )
             else:
-                return_expressions.append(_to_tag(value))
+                ret_list.append(_to_tag(value))
 
-    if len(set(return_expressions)) == 1:
-        return return_expressions[0]
+    if len(set(ret_list)) == 1:
+        return ret_list[0]
+    elif all(isinstance(exp, tuple) for exp in ret_list) and len(set(len(r) for r in ret_list)) == 1:
+        return tuple([f"output_{i}" for i in range(len(ret_list[0]))])
     else:
         return "output"
 

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -148,12 +148,33 @@ class TestParser(unittest.TestCase):
         self.assertEqual(input_args["x"]["dtype"], "Atoms")
 
     def test_get_return_expressions(self):
+        def f(x):
+            return x
+        self.assertEqual(get_return_expressions(f), "x")
         def f(x, y):
             return x, y
         self.assertEqual(get_return_expressions(f), ("x", "y"))
         def f(x, y):
             return x, -y
         self.assertEqual(get_return_expressions(f), ("x", "output_1"))
+        def f(x, y):
+            if x < 0:
+                return x, y
+            else:
+                return x, y
+        self.assertEqual(get_return_expressions(f), ("x", "y"))
+        def f(x, y):
+            if x < 0:
+                return x, y
+            else:
+                return y, x
+        self.assertEqual(get_return_expressions(f), ("output_0", "output_1"))
+        def f(x, y):
+            if x < 0:
+                return x
+            else:
+                return y, x
+        self.assertEqual(get_return_expressions(f), "output")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -6,6 +6,7 @@ from semantikon.converter import (
     parse_input_args,
     parse_metadata,
     parse_output_args,
+    get_return_expressions,
 )
 from semantikon.typing import u
 
@@ -145,6 +146,11 @@ class TestParser(unittest.TestCase):
         input_args = parse_input_args(test_more_future)
         self.assertEqual(input_args["x"]["uri"], "metadata")
         self.assertEqual(input_args["x"]["dtype"], "Atoms")
+
+    def test_get_return_expressions(self):
+        def f(x, y):
+            return x, y
+        self.assertEqual(get_return_expressions(f), ("x", "y"))
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -151,6 +151,9 @@ class TestParser(unittest.TestCase):
         def f(x, y):
             return x, y
         self.assertEqual(get_return_expressions(f), ("x", "y"))
+        def f(x, y):
+            return x, -y
+        self.assertEqual(get_return_expressions(f), ("x", "output_1"))
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -150,31 +150,47 @@ class TestParser(unittest.TestCase):
     def test_get_return_expressions(self):
         def f(x):
             return x
+
         self.assertEqual(get_return_expressions(f), "x")
+
         def f(x, y):
             return x, y
+
         self.assertEqual(get_return_expressions(f), ("x", "y"))
+
         def f(x, y):
             return x, -y
+
         self.assertEqual(get_return_expressions(f), ("x", "output_1"))
+
         def f(x, y):
             if x < 0:
                 return x, y
             else:
                 return x, y
+
         self.assertEqual(get_return_expressions(f), ("x", "y"))
+
         def f(x, y):
             if x < 0:
                 return x, y
             else:
                 return y, x
+
         self.assertEqual(get_return_expressions(f), ("output_0", "output_1"))
+
         def f(x, y):
             if x < 0:
                 return x
             else:
                 return y, x
+
         self.assertEqual(get_return_expressions(f), "output")
+
+        def f(x):
+            print("hello")
+
+        self.assertIsNone(get_return_expressions(f))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In the PR (which I haven't opened), I realized that the current output parser, which relies on the output type hints, cannot detect whether the function actually has a return statement or not, so with `get_return_expressions` I check whether there is a return statement or not.