### PR TITLE
Apply mypy to get rid of assertion tests

### DIFF
--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Install mypy
         run: pip install mypy
       - name: Test
-        run: mypy --install-types --non-interactive --ignore-missing-imports ${{ github.event.repository.name }}
+        run: mypy --install-types --non-interactive --strict-equality --ignore-missing-imports ${{ github.event.repository.name }}

--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -18,6 +18,8 @@ from pint.registry_helpers import (
     _to_units_container,
 )
 
+from semantikon.typing import FunctionWithMetadata
+
 __author__ = "Sam Waseda"
 __copyright__ = (
     "Copyright 2021, Max-Planck-Institut für Eisenforschung GmbH "
@@ -309,12 +311,11 @@ def units(func: Callable) -> Callable:
     return wrapper
 
 
-def get_function_dict(function: Callable | None = None) -> dict[str, Any]:
+def get_function_dict(function: Callable | FunctionWithMetadata) -> dict[str, Any]:
     result = {
         "label": function.__name__,
     }
-    function_has_metadata = hasattr(function, "_semantikon_metadata")
-    if function_has_metadata:
+    if hasattr(function, "_semantikon_metadata"):
         result.update(function._semantikon_metadata)
     return result
 

--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -30,7 +30,7 @@ __status__ = "development"
 __date__ = "Aug 21, 2021"
 
 
-def _get_ureg(args, kwargs):
+def _get_ureg(args: Any, kwargs: dict[str, Any]) -> UnitRegistry | None:
     for arg in args + tuple(kwargs.values()):
         if isinstance(arg, Quantity):
             return arg._REGISTRY
@@ -71,7 +71,7 @@ def meta_to_dict(value: Any, default=inspect.Parameter.empty) -> dict[str, Any]:
     return result
 
 
-def extract_undefined_name(error_message):
+def extract_undefined_name(error_message: str) -> str:
     match = re.search(r"name '(.+?)' is not defined", error_message)
     if match:
         return match.group(1)

--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -99,7 +99,7 @@ def _resolve_annotation(annotation, func_globals=None):
         return Annotated[undefined_name, args[1]]
 
 
-def _to_tag(item, count=None):
+def _to_tag(item: Any, count=None) -> str:
     if isinstance(item, ast.Name):
         return item.id
     elif count is None:
@@ -115,7 +115,7 @@ def get_return_expressions(func: Callable) -> str | tuple | None:
 
     func_node = next(n for n in parsed.body if isinstance(n, ast.FunctionDef))
 
-    ret_list = []
+    ret_list: list[str | tuple[str, ...]] = []
 
     for node in ast.walk(func_node):
         if isinstance(node, ast.Return):
@@ -244,9 +244,8 @@ def _get_ret_units(
 
 def _get_output_units(
     output: dict | tuple, ureg: UnitRegistry, names: dict[str, Any]
-) -> Quantity | tuple[Quantity, ...] | None:
-    multiple_output_args = isinstance(output, tuple)
-    if multiple_output_args:
+) -> Quantity | tuple[Quantity | None, ...] | None:
+    if isinstance(output, tuple):
         return tuple([_get_ret_units(oo, ureg, names) for oo in output])
     else:
         return _get_ret_units(output, ureg, names)
@@ -262,7 +261,7 @@ def _is_dimensionless(output: Quantity | tuple[Quantity, ...] | None) -> bool:
     return False
 
 
-def units(func: Callable | None = None) -> Callable:
+def units(func: Callable) -> Callable:
     """
     Decorator to convert the output of a function to a Quantity object with
     the specified units.

--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -181,7 +181,7 @@ def get_annotated_type_hints(func):
         return hints
 
 
-def parse_input_args(func: Callable):
+def parse_input_args(func: Callable) -> dict[str, dict]:
     """
     Parse the input arguments of a function.
 
@@ -199,7 +199,7 @@ def parse_input_args(func: Callable):
     }
 
 
-def parse_output_args(func: Callable, separate_tuple: bool = True):
+def parse_output_args(func: Callable, separate_tuple: bool = True) -> dict | tuple:
     """
     Parse the output arguments of a function.
 
@@ -219,7 +219,7 @@ def parse_output_args(func: Callable, separate_tuple: bool = True):
         return meta_to_dict(ret)
 
 
-def _get_converter(func):
+def _get_converter(func: Callable) -> Callable | None:
     args = []
     for value in parse_input_args(func).values():
         if value is not None:

--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -8,7 +8,7 @@ import re
 import sys
 import textwrap
 from copy import deepcopy
-from functools import wraps, update_wrapper
+from functools import update_wrapper, wraps
 from typing import (
     Annotated,
     Any,

--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -9,7 +9,16 @@ import sys
 import textwrap
 from copy import deepcopy
 from functools import wraps, update_wrapper
-from typing import Annotated, Any, Callable, Generic, TypeVar, get_args, get_origin, get_type_hints
+from typing import (
+    Annotated,
+    Any,
+    Callable,
+    Generic,
+    TypeVar,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
 
 from pint import Quantity, UnitRegistry
 from pint.registry_helpers import (

--- a/semantikon/typing.py
+++ b/semantikon/typing.py
@@ -111,7 +111,7 @@ def u(
     shape: tuple[int] | None = None,
     restrictions: tuple[tuple[str, str]] | None = None,
     **kwargs,
-) -> Annotated | Callable
+) -> Annotated | Callable:
     is_type_hint = (
         isinstance(type_or_func, type) or get_origin(type_or_func) is not None
     )

--- a/semantikon/typing.py
+++ b/semantikon/typing.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Any, Callable, get_origin
 
-from semantikon.converter import parse_metadata, FunctionWithMetadata
+from semantikon.converter import FunctionWithMetadata, parse_metadata
 
 __author__ = "Sam Waseda"
 __copyright__ = (

--- a/semantikon/typing.py
+++ b/semantikon/typing.py
@@ -1,8 +1,6 @@
-from copy import deepcopy
-from functools import update_wrapper
-from typing import Annotated, Callable, Generic, Type, TypeVar, get_origin
+from typing import Annotated, Callable, Type, get_origin
 
-from semantikon.converter import parse_metadata
+from semantikon.converter import parse_metadata, FunctionWithMetadata
 
 __author__ = "Sam Waseda"
 __copyright__ = (
@@ -14,25 +12,6 @@ __maintainer__ = "Sam Waseda"
 __email__ = "waseda@mpie.de"
 __status__ = "development"
 __date__ = "Aug 21, 2021"
-
-F = TypeVar("F", bound=Callable[..., object])
-
-
-class FunctionWithMetadata(Generic[F]):
-    def __init__(self, func: F, metadata: dict[str, object]) -> None:
-        self.func = func
-        self._semantikon_metadata: dict[str, object] = metadata
-        update_wrapper(self, func)  # Copies __name__, __doc__, etc.
-
-    def __call__(self, *args, **kwargs):
-        return self.func(*args, **kwargs)
-
-    def __getattr__(self, item):
-        return getattr(self.func, item)
-
-    def __deepcopy__(self, memo=None):
-        new_func = deepcopy(self.func, memo)
-        return FunctionWithMetadata(new_func, self._semantikon_metadata)
 
 
 def _is_annotated(type_):

--- a/semantikon/typing.py
+++ b/semantikon/typing.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Callable, Type, get_origin
+from typing import Annotated, Any, Callable, get_origin
 
 from semantikon.converter import parse_metadata, FunctionWithMetadata
 
@@ -28,7 +28,7 @@ def _type_metadata(
     shape: tuple[int] | None = None,
     restrictions: tuple[tuple[str, str]] | None = None,
     **kwargs,
-) -> Type:
+) -> Any:
     if _is_annotated(type_):
         kwargs.update(parse_metadata(type_))
         type_ = type_.__origin__
@@ -90,7 +90,7 @@ def u(
     shape: tuple[int] | None = None,
     restrictions: tuple[tuple[str, str]] | None = None,
     **kwargs,
-) -> Type | Callable:
+) -> Any:
     kwargs.update(
         _kwargs_to_dict(
             units=units,

--- a/semantikon/typing.py
+++ b/semantikon/typing.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from functools import update_wrapper
-from typing import Annotated, Callable, Generic, TypeVar, get_origin
+from typing import Annotated, Callable, Generic, Type, TypeVar, get_origin
 
 from semantikon.converter import parse_metadata
 
@@ -49,7 +49,7 @@ def _type_metadata(
     shape: tuple[int] | None = None,
     restrictions: tuple[tuple[str, str]] | None = None,
     **kwargs,
-):
+) -> Type:
     if _is_annotated(type_):
         kwargs.update(parse_metadata(type_))
         type_ = type_.__origin__
@@ -111,11 +111,7 @@ def u(
     shape: tuple[int] | None = None,
     restrictions: tuple[tuple[str, str]] | None = None,
     **kwargs,
-) -> Annotated | Callable:
-    is_type_hint = (
-        isinstance(type_or_func, type) or get_origin(type_or_func) is not None
-    )
-    is_decorator = type_or_func is None
+) -> Type | Callable:
     kwargs.update(
         _kwargs_to_dict(
             units=units,
@@ -126,9 +122,9 @@ def u(
             restrictions=restrictions,
         )
     )
-    if is_type_hint:
+    if isinstance(type_or_func, type) or get_origin(type_or_func) is not None:
         return _type_metadata(type_or_func, **kwargs)
-    elif is_decorator:
+    elif type_or_func is None:
         return _function_metadata(**kwargs)
     else:
         raise TypeError(f"Unsupported type: {type(type_or_func)}")

--- a/semantikon/typing.py
+++ b/semantikon/typing.py
@@ -111,7 +111,7 @@ def u(
     shape: tuple[int] | None = None,
     restrictions: tuple[tuple[str, str]] | None = None,
     **kwargs,
-):
+) -> Annotated | Callable
     is_type_hint = (
         isinstance(type_or_func, type) or get_origin(type_or_func) is not None
     )

--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -5,7 +5,7 @@ import inspect
 from collections import deque
 from functools import cached_property, update_wrapper
 from hashlib import sha256
-from typing import Callable, Generic, TypeVar
+from typing import Callable, Generic, TypeVar, cast
 
 import networkx as nx
 from networkx.algorithms.dag import topological_sort

--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -5,7 +5,7 @@ import inspect
 from collections import deque
 from functools import cached_property, update_wrapper
 from hashlib import sha256
-from typing import Callable, Generic, TypeVar, cast
+from typing import Callable, Generic, TypeVar
 
 import networkx as nx
 from networkx.algorithms.dag import topological_sort
@@ -497,7 +497,7 @@ def _to_workflow_dict_entry(
     nodes: dict[str, dict],
     data_edges: list[tuple[str, str]],
     label: str,
-    **kwargs
+    **kwargs,
 ) -> dict[str, object]:
     assert all("inputs" in v for v in nodes.values())
     assert all("outputs" in v for v in nodes.values())

--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -271,7 +271,7 @@ def _get_workflow_outputs(func):
     return dict(zip(var_output, data_output))
 
 
-def _get_node_outputs(func, counts):
+def _get_node_outputs(func: Callable, counts: int) -> dict[str, dict]:
     output_hints = parse_output_args(func, separate_tuple=counts > 1)
     output_vars = get_return_expressions(func)
     if output_vars is None or len(output_vars) == 0:
@@ -306,7 +306,7 @@ def _get_output_counts(graph: nx.DiGraph) -> dict:
     return f_dict
 
 
-def _get_nodes(data, output_counts):
+def _get_nodes(data: dict[str, dict], output_counts: int) -> dict[str, dict]:
     result = {}
     for node, function in data.items():
         if function["type"] != "Assign":
@@ -485,30 +485,25 @@ def separate_functions(data, function_dict=None):
     return data, function_dict
 
 
-def _to_node_dict_entry(function: Callable, inputs: dict, outputs: dict) -> dict:
-    assert isinstance(inputs, dict)
-    assert all(isinstance(v, dict) for v in inputs.values())
-    assert isinstance(outputs, dict)
-    assert all(isinstance(v, dict) for v in outputs.values())
-    assert callable(function)
+def _to_node_dict_entry(
+    function: Callable, inputs: dict[str, dict], outputs: dict[str, dict]
+) -> dict:
     return {"function": function, "inputs": inputs, "outputs": outputs}
 
 
-def _to_workflow_dict_entry(inputs, outputs, nodes, data_edges, label, **kwargs):
-    assert isinstance(inputs, dict)
-    assert all(isinstance(v, dict) for v in inputs.values())
-    assert isinstance(outputs, dict)
-    assert all(isinstance(v, dict) for v in outputs.values())
-    assert isinstance(nodes, dict)
-    assert all(isinstance(v, dict) for v in nodes.values())
+def _to_workflow_dict_entry(
+    inputs: dict[str, dict],
+    outputs: dict[str, dict],
+    nodes: dict[str, dict],
+    data_edges: list[tuple[str, str]],
+    label: str,
+    **kwargs
+) -> dict[str, object]:
     assert all("inputs" in v for v in nodes.values())
     assert all("outputs" in v for v in nodes.values())
     assert all(
         "function" in v or ("nodes" in v and "data_edges" in v) for v in nodes.values()
     )
-    assert isinstance(data_edges, list)
-    assert all(isinstance(edge, tuple) and len(edge) == 2 for edge in data_edges)
-    assert isinstance(label, str)
     return {
         "inputs": inputs,
         "outputs": outputs,

--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -5,7 +5,7 @@ import inspect
 from collections import deque
 from functools import cached_property, update_wrapper
 from hashlib import sha256
-from typing import Callable, Generic, TypeVar
+from typing import Callable, Generic, TypeVar, cast
 
 import networkx as nx
 from networkx.algorithms.dag import topological_sort
@@ -272,7 +272,7 @@ def _get_workflow_outputs(func):
 
 
 def _get_node_outputs(func: Callable, counts: int) -> dict[str, dict]:
-    output_hints = parse_output_args(func, separate_tuple=counts > 1)
+    output_hints = cast(dict, parse_output_args(func, separate_tuple=counts > 1))
     output_vars = get_return_expressions(func)
     if output_vars is None or len(output_vars) == 0:
         return {}
@@ -282,10 +282,8 @@ def _get_node_outputs(func: Callable, counts: int) -> dict[str, dict]:
         else:
             return {"output": output_hints}
     assert isinstance(output_vars, tuple) and len(output_vars) == counts
-    if output_hints == {}:
-        output_hints = counts * [{}]
-    assert len(output_vars) == len(output_hints)
-    return {key: value for key, value in zip(output_vars, output_hints)}
+    assert len(output_vars) == counts
+    return {key: {} for key in output_vars}
 
 
 def _get_output_counts(graph: nx.DiGraph) -> dict:

--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -272,18 +272,22 @@ def _get_workflow_outputs(func):
 
 
 def _get_node_outputs(func: Callable, counts: int) -> dict[str, dict]:
-    output_hints = cast(dict, parse_output_args(func, separate_tuple=counts > 1))
+    output_hints = parse_output_args(func, separate_tuple=counts > 1)
     output_vars = get_return_expressions(func)
     if output_vars is None or len(output_vars) == 0:
         return {}
     if counts == 1:
         if isinstance(output_vars, str):
-            return {output_vars: output_hints}
+            return {output_vars: cast(dict, output_hints)}
         else:
-            return {"output": output_hints}
+            return {"output": cast(dict, output_hints)}
     assert isinstance(output_vars, tuple) and len(output_vars) == counts
     assert len(output_vars) == counts
-    return {key: {} for key in output_vars}
+    if output_hints == {}:
+        return {key: {} for key in output_vars}
+    else:
+        assert len(output_hints) == counts
+        return {key: hint for key, hint in zip(output_vars, output_hints)}
 
 
 def _get_output_counts(graph: nx.DiGraph) -> dict:

--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -306,7 +306,7 @@ def _get_output_counts(graph: nx.DiGraph) -> dict:
     return f_dict
 
 
-def _get_nodes(data: dict[str, dict], output_counts: int) -> dict[str, dict]:
+def _get_nodes(data: dict[str, dict], output_counts: dict[str, int]) -> dict[str, dict]:
     result = {}
     for node, function in data.items():
         if function["type"] != "Assign":


### PR DESCRIPTION
Since `mypy` is applied now, there's no need to run assertion tests inside the private functions anymore, since they are only connected internally.