### PR TITLE
[bug] Tuple output

### DIFF
--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -268,6 +268,9 @@ def _get_workflow_outputs(func):
     data_output = parse_output_args(func)
     if isinstance(data_output, dict):
         data_output = [data_output]
+    if len(var_output) > 1 and len(data_output) == 1:
+        assert len(data_output[0]) == 0
+        return {var: {} for var in var_output}
     return dict(zip(var_output, data_output))
 
 

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -313,7 +313,9 @@ class TestWorkflow(unittest.TestCase):
 
     def test_run_parallel_execution(self):
         data = parallel_execution.run()
-        self.assertEqual(parallel_execution()[0], data["outputs"]["e"]["value"])
+        results = parallel_execution()
+        self.assertEqual(results[0], data["outputs"]["e"]["value"])
+        self.assertEqual(results[1], data["outputs"]["f"]["value"])
 
     def test_run_nested(self):
         data = example_workflow.run()

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -313,7 +313,7 @@ class TestWorkflow(unittest.TestCase):
 
     def test_run_parallel_execution(self):
         data = parallel_execution.run()
-        self.assertEqual(parallel_execution(), data["outputs"]["e"]["value"])
+        self.assertEqual(parallel_execution()[0], data["outputs"]["e"]["value"])
 
     def test_run_nested(self):
         data = example_workflow.run()


### PR DESCRIPTION
It turned out that when there were multiple outputs from a workflow (e.g. `return x, y`), they were considered as one return. This PR corrects it.