### PR TITLE
Give scope to stringified function

### DIFF
--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -517,11 +517,15 @@ def separate_functions(
             function_dict.update(child_function_dict)
             data["nodes"][key] = child_node
     elif "function" in data and not isinstance(data["function"], str):
-        function_dict[data["function"].__name__] = data["function"]
-        data["function"] = data["function"].__name__
+        fnc_object = data["function"]
+        as_string = fnc_object.__module__ + "." + fnc_object.__qualname__
+        function_dict[as_string] = fnc_object
+        data["function"] = as_string
     if "test" in data and not isinstance(data["test"]["function"], str):
-        function_dict[data["test"]["function"].__name__] = data["test"]["function"]
-        data["test"]["function"] = data["test"]["function"].__name__
+        fnc_object = data["test"]["function"]
+        as_string = fnc_object.__module__ + fnc_object.__qualname__
+        function_dict[as_string] = fnc_object
+        data["test"]["function"] = as_string
     return data, function_dict
 
 

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -194,7 +194,7 @@ class TestWorkflow(unittest.TestCase):
                         "output_0": {"dtype": float},
                         "output_1": {"dtype": float},
                     },
-                    "function": "unit.test_workflow.operation",
+                    "function": f"{operation.__module__}.operation",
                 },
                 "add_0": {
                     "inputs": {
@@ -202,7 +202,7 @@ class TestWorkflow(unittest.TestCase):
                         "y": {"dtype": float, "default": 1},
                     },
                     "outputs": {"output": {"dtype": float}},
-                    "function": "unit.test_workflow.add",
+                    "function": f"{add.__module__}.add",
                     "uri": "add",
                 },
                 "multiply_0": {
@@ -211,7 +211,7 @@ class TestWorkflow(unittest.TestCase):
                         "y": {"dtype": float, "default": 5},
                     },
                     "outputs": {"output": {"dtype": float}},
-                    "function": "unit.test_workflow.multiply",
+                    "function": f"{multiply.__module__}.multiply",
                 },
             },
             "edges": [
@@ -239,7 +239,7 @@ class TestWorkflow(unittest.TestCase):
                     "outputs": {"f": {}},
                     "nodes": {
                         "operation_0": {
-                            "function": "unit.test_workflow.operation",
+                            "function": f"{operation.__module__}.operation",
                             "inputs": {"x": {"dtype": float}, "y": {"dtype": float}},
                             "outputs": {
                                 "output_0": {"dtype": float},
@@ -247,7 +247,7 @@ class TestWorkflow(unittest.TestCase):
                             },
                         },
                         "add_0": {
-                            "function": "unit.test_workflow.add",
+                            "function": f"{add.__module__}.add",
                             "inputs": {
                                 "x": {"dtype": float, "default": 2.0},
                                 "y": {"dtype": float, "default": 1},
@@ -256,7 +256,7 @@ class TestWorkflow(unittest.TestCase):
                             "uri": "add",
                         },
                         "multiply_0": {
-                            "function": "unit.test_workflow.multiply",
+                            "function": f"{multiply.__module__}.multiply",
                             "inputs": {
                                 "x": {"dtype": float},
                                 "y": {"dtype": float, "default": 5},
@@ -275,7 +275,7 @@ class TestWorkflow(unittest.TestCase):
                     "label": "example_macro_0",
                 },
                 "add_0": {
-                    "function": "unit.test_workflow.add",
+                    "function": f"{add.__module__}.add",
                     "inputs": {
                         "x": {"dtype": float, "default": 2.0},
                         "y": {"dtype": float, "default": 1},
@@ -334,17 +334,17 @@ class TestWorkflow(unittest.TestCase):
         old_data = example_workflow._semantikon_workflow
         data, function_dict = separate_functions(old_data)
         # add is deep copied due to the decorator
-        del function_dict["unit.test_workflow.add"]
+        del function_dict[f"{add.__module__}.add"]
         self.assertEqual(
             function_dict,
             {
-                "unit.test_workflow.operation": operation,
-                "unit.test_workflow.multiply": multiply,
+                f"{operation.__module__}.operation": operation,
+                f"{multiply.__module__}.multiply": multiply,
             },
         )
         self.assertEqual(
             data["nodes"]["example_macro_0"]["nodes"]["operation_0"]["function"],
-            "unit.test_workflow.operation",
+            f"{operation.__module__}.operation",
         )
         self.assertEqual(
             old_data["nodes"]["example_macro_0"]["nodes"]["operation_0"]["function"],

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -194,7 +194,7 @@ class TestWorkflow(unittest.TestCase):
                         "output_0": {"dtype": float},
                         "output_1": {"dtype": float},
                     },
-                    "function": "operation",
+                    "function": "unit.test_workflow.operation",
                 },
                 "add_0": {
                     "inputs": {
@@ -202,7 +202,7 @@ class TestWorkflow(unittest.TestCase):
                         "y": {"dtype": float, "default": 1},
                     },
                     "outputs": {"output": {"dtype": float}},
-                    "function": "add",
+                    "function": "unit.test_workflow.add",
                     "uri": "add",
                 },
                 "multiply_0": {
@@ -211,7 +211,7 @@ class TestWorkflow(unittest.TestCase):
                         "y": {"dtype": float, "default": 5},
                     },
                     "outputs": {"output": {"dtype": float}},
-                    "function": "multiply",
+                    "function": "unit.test_workflow.multiply",
                 },
             },
             "edges": [
@@ -239,7 +239,7 @@ class TestWorkflow(unittest.TestCase):
                     "outputs": {"f": {}},
                     "nodes": {
                         "operation_0": {
-                            "function": "operation",
+                            "function": "unit.test_workflow.operation",
                             "inputs": {"x": {"dtype": float}, "y": {"dtype": float}},
                             "outputs": {
                                 "output_0": {"dtype": float},
@@ -247,7 +247,7 @@ class TestWorkflow(unittest.TestCase):
                             },
                         },
                         "add_0": {
-                            "function": "add",
+                            "function": "unit.test_workflow.add",
                             "inputs": {
                                 "x": {"dtype": float, "default": 2.0},
                                 "y": {"dtype": float, "default": 1},
@@ -256,7 +256,7 @@ class TestWorkflow(unittest.TestCase):
                             "uri": "add",
                         },
                         "multiply_0": {
-                            "function": "multiply",
+                            "function": "unit.test_workflow.multiply",
                             "inputs": {
                                 "x": {"dtype": float},
                                 "y": {"dtype": float, "default": 5},
@@ -275,7 +275,7 @@ class TestWorkflow(unittest.TestCase):
                     "label": "example_macro_0",
                 },
                 "add_0": {
-                    "function": "add",
+                    "function": "unit.test_workflow.add",
                     "inputs": {
                         "x": {"dtype": float, "default": 2.0},
                         "y": {"dtype": float, "default": 1},
@@ -334,14 +334,17 @@ class TestWorkflow(unittest.TestCase):
         old_data = example_workflow._semantikon_workflow
         data, function_dict = separate_functions(old_data)
         # add is deep copied due to the decorator
-        del function_dict["add"]
+        del function_dict["unit.test_workflow.add"]
         self.assertEqual(
             function_dict,
-            {"operation": operation, "multiply": multiply},
+            {
+                "unit.test_workflow.operation": operation,
+                "unit.test_workflow.multiply": multiply,
+            },
         )
         self.assertEqual(
             data["nodes"]["example_macro_0"]["nodes"]["operation_0"]["function"],
-            "operation",
+            "unit.test_workflow.operation",
         )
         self.assertEqual(
             old_data["nodes"]["example_macro_0"]["nodes"]["operation_0"]["function"],


### PR DESCRIPTION
Closes #163  

I tried doing a test for the qualname functionality too by hiding one of the test functions:

```python
class HideInAQual:
    def multiply(x: float, y: float = 5) -> float:
        return x * y
```

But actually this caused trouble elsewhere

https://github.com/pyiron/semantikon/blob/54b3f5597a821f7b8b1b5d54cdc9a85fe8d0cfa4/semantikon/workflow.py#L191-L192

So for now this functionality is not tested.