### PR TITLE
Add a "type" field to workflow info dictionary

### DIFF
--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -447,6 +447,7 @@ def get_node_dict(func, data_format="semantikon"):
         "inputs": parse_input_args(func),
         "outputs": _get_workflow_outputs(func),
         "label": func.__name__,
+        "type": "Function",
     }
     if hasattr(func, "_semantikon_metadata"):
         data.update(func._semantikon_metadata)
@@ -532,7 +533,12 @@ def separate_functions(
 def _to_node_dict_entry(
     function: Callable, inputs: dict[str, dict], outputs: dict[str, dict]
 ) -> dict:
-    return {"function": function, "inputs": inputs, "outputs": outputs}
+    return {
+        "function": function,
+        "inputs": inputs,
+        "outputs": outputs,
+        "type": "Function",
+    }
 
 
 def _to_workflow_dict_entry(
@@ -554,6 +560,7 @@ def _to_workflow_dict_entry(
         "nodes": nodes,
         "edges": edges,
         "label": label,
+        "type": "Workflow",
     } | kwargs
 
 

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -161,6 +161,7 @@ class TestWorkflow(unittest.TestCase):
                 "outputs": {"output": {"dtype": float}},
                 "label": "add",
                 "uri": "add",
+                "type": "Function",
             },
         )
         node_dict = get_node_dict(multiple_types_for_ape, data_format="ape")
@@ -175,6 +176,7 @@ class TestWorkflow(unittest.TestCase):
                 "outputs": [{"Type": "ApeClass"}],
                 "label": "multiple_types_for_ape",
                 "taxonomyOperations": ["my_function"],
+                "type": "Function",
             },
         )
 
@@ -195,6 +197,7 @@ class TestWorkflow(unittest.TestCase):
                         "output_1": {"dtype": float},
                     },
                     "function": f"{operation.__module__}.operation",
+                    "type": "Function",
                 },
                 "add_0": {
                     "inputs": {
@@ -204,6 +207,7 @@ class TestWorkflow(unittest.TestCase):
                     "outputs": {"output": {"dtype": float}},
                     "function": f"{add.__module__}.add",
                     "uri": "add",
+                    "type": "Function",
                 },
                 "multiply_0": {
                     "inputs": {
@@ -212,6 +216,7 @@ class TestWorkflow(unittest.TestCase):
                     },
                     "outputs": {"output": {"dtype": float}},
                     "function": f"{multiply.__module__}.multiply",
+                    "type": "Function",
                 },
             },
             "edges": [
@@ -223,6 +228,7 @@ class TestWorkflow(unittest.TestCase):
                 ("multiply_0.outputs.output", "outputs.f"),
             ],
             "label": "example_macro",
+            "type": "Workflow",
         }
         self.assertEqual(
             separate_functions(example_macro._semantikon_workflow)[0], ref_data
@@ -245,6 +251,7 @@ class TestWorkflow(unittest.TestCase):
                                 "output_0": {"dtype": float},
                                 "output_1": {"dtype": float},
                             },
+                            "type": "Function",
                         },
                         "add_0": {
                             "function": f"{add.__module__}.add",
@@ -254,6 +261,7 @@ class TestWorkflow(unittest.TestCase):
                             },
                             "outputs": {"output": {"dtype": float}},
                             "uri": "add",
+                            "type": "Function",
                         },
                         "multiply_0": {
                             "function": f"{multiply.__module__}.multiply",
@@ -262,6 +270,7 @@ class TestWorkflow(unittest.TestCase):
                                 "y": {"dtype": float, "default": 5},
                             },
                             "outputs": {"output": {"dtype": float}},
+                            "type": "Function",
                         },
                     },
                     "edges": [
@@ -273,6 +282,7 @@ class TestWorkflow(unittest.TestCase):
                         ("multiply_0.outputs.output", "outputs.f"),
                     ],
                     "label": "example_macro_0",
+                    "type": "Workflow",
                 },
                 "add_0": {
                     "function": f"{add.__module__}.add",
@@ -282,6 +292,7 @@ class TestWorkflow(unittest.TestCase):
                     },
                     "outputs": {"output": {"dtype": float}},
                     "uri": "add",
+                    "type": "Function",
                 },
             },
             "edges": [
@@ -292,6 +303,7 @@ class TestWorkflow(unittest.TestCase):
                 ("add_0.outputs.output", "outputs.z"),
             ],
             "label": "example_workflow",
+            "type": "Workflow",
         }
         self.assertEqual(separate_functions(result)[0], ref_data, msg=result)
 


### PR DESCRIPTION
For alignment with a forthcoming dataclass implementation, and in anticipation of more interesting types like "While" and "For". As it is though, it doesn't really hurt and just makes explicit what sort of node you're looking at instead of needing to infer it from the presence of fields ("function" for "Function" types, "nodes", "edges" for "Workflow" types) -- i.e. at worst a little redundant.