### PR TITLE
Configure mypy in the pyproject

### DIFF
--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Install mypy
         run: pip install mypy
       - name: Test
-        run: mypy --install-types --non-interactive --strict-equality --ignore-missing-imports ${{ github.event.repository.name }}
+        run: mypy .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,3 +57,13 @@ include = [ "semantikon*",]
 
 [tool.setuptools.dynamic.version]
 attr = "semantikon.__version__"
+
+[tool.mypy]
+exclude = [
+    "^docs/conf\\.py$",
+    "^tests/",
+]
+ignore_missing_imports = true
+strict_equality = true
+non-interactive = true
+install-types = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,5 +65,5 @@ exclude = [
 ]
 ignore_missing_imports = true
 strict_equality = true
-non-interactive = true
-install-types = true
+non_interactive = true
+install_types = true


### PR DESCRIPTION
And rely on that configuration when you invoke it.

I got tired of the failures when running mypy with my "mypy ${cwd}" shortcut. We should definitely turn it back on for `test/` in the near(ish) future, but only in the process of actually getting those to be compliant.