### PR TITLE
Use textwrap to be able to parse nested functions

### DIFF
--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -2,6 +2,7 @@ import ast
 import builtins
 import copy
 import inspect
+import textwrap
 from collections import deque
 from functools import cached_property, update_wrapper
 from hashlib import sha256
@@ -402,7 +403,7 @@ def _get_control_flow_graph(control_flows: list[str]) -> nx.DiGraph:
 
 def get_ast_dict(func: Callable) -> dict:
     """Get the AST dictionary representation of a function."""
-    source_code = inspect.getsource(func)
+    source_code = textwrap.dedent(inspect.getsource(func))
     tree = ast.parse(source_code)
     return _function_to_ast_dict(tree)
 

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -62,23 +62,6 @@ def parallel_execution(a=10, b=20):
     return e, f
 
 
-def example_invalid_operator(a=10, b=20):
-    y = example_macro(a, b)
-    z = add(y, b)
-    result = z + 1
-    return result
-
-
-def example_invalid_multiple_operation(a=10, b=20):
-    result = add(a, add(a, b))
-    return result
-
-
-def example_invalid_local_var_def(a=10, b=20):
-    result = add(a, 2)
-    return result
-
-
 def my_while_condition(a=10, b=20):
     return a < b
 
@@ -391,6 +374,23 @@ class TestWorkflow(unittest.TestCase):
         self.assertEqual(example_workflow(), data["outputs"]["z"]["value"])
 
     def test_not_implemented_error(self):
+        def example_invalid_operator(a=10, b=20):
+            y = example_macro(a, b)
+            z = add(y, b)
+            result = z + 1
+            return result
+
+
+        def example_invalid_multiple_operation(a=10, b=20):
+            result = add(a, add(a, b))
+            return result
+
+
+        def example_invalid_local_var_def(a=10, b=20):
+            result = add(a, 2)
+            return result
+
+
         with self.assertRaises(NotImplementedError):
             workflow(example_invalid_operator)
         with self.assertRaises(NotImplementedError):

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -380,16 +380,13 @@ class TestWorkflow(unittest.TestCase):
             result = z + 1
             return result
 
-
         def example_invalid_multiple_operation(a=10, b=20):
             result = add(a, add(a, b))
             return result
 
-
         def example_invalid_local_var_def(a=10, b=20):
             result = add(a, 2)
             return result
-
 
         with self.assertRaises(NotImplementedError):
             workflow(example_invalid_operator)


### PR DESCRIPTION
There's not much of a reason to parse local functions (e.g. functions inside another function), but there's also no reason to forbid it, so I included `textwrap` to get around it.