### PR TITLE
[nit] make some lines more efficient and safer

### DIFF
--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -141,8 +141,8 @@ class FunctionDictFlowAnalyzer:
         unique_func_name = self._parse_function_call(
             node["iter"], control_flow=f"{control_flow}-iter"
         )
-        self._add_output_edge(
-            unique_func_name, node["target"]["id"], control_flow=control_flow
+        self._parse_outputs(
+            [node["target"]], unique_func_name, control_flow=control_flow
         )
         for node in node["body"]:
             self._visit_node(node, control_flow=f"{control_flow}-body")


### PR DESCRIPTION
- Do not define `self._return_was_called` - it makes more sense to do it within `visit_node`
- Use `parse_outputs` inside the for loop, because it can also deal with multiple outputs