### PR TITLE
Make `derived_from` available in `u`

### DIFF
--- a/semantikon/datastructure.py
+++ b/semantikon/datastructure.py
@@ -75,6 +75,7 @@ class TypeMetadata(CoreMetadata):
     label: str | Missing = missing()
     units: str | Missing = missing()
     shape: ShapeType | Missing = missing()
+    derived_from: str | Missing = missing()
     extra: dict[str, Any] | Missing = missing()
 
 

--- a/semantikon/metadata.py
+++ b/semantikon/metadata.py
@@ -36,6 +36,7 @@ def _type_metadata(
     label: str | Missing = MISSING,
     units: str | Missing = MISSING,
     shape: ShapeType | Missing = MISSING,
+    derived_from: str | Missing = MISSING,
     **extra,
 ) -> Any:
     presently_requested_metadata = TypeMetadata(
@@ -45,6 +46,7 @@ def _type_metadata(
         label=label,
         units=units,
         shape=shape,
+        derived_from=derived_from,
     )
 
     kwargs = {"extra": extra} if len(extra) > 0 else {}
@@ -90,6 +92,7 @@ def u(
     label: str | Missing = MISSING,
     units: str | Missing = MISSING,
     shape: ShapeType | Missing = MISSING,
+    derived_from: str | Missing = MISSING,
     **kwargs,
 ) -> Callable[[Callable], FunctionWithMetadata] | Annotated[Any, object]:
     if isinstance(type_or_func, type) or get_origin(type_or_func) is not None:
@@ -101,6 +104,7 @@ def u(
             label=label,
             units=units,
             shape=shape,
+            derived_from=derived_from,
             **kwargs,
         )
     elif type_or_func is None:

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -106,6 +106,10 @@ def _get_triples_from_restrictions(data: dict) -> list:
         triples = _restriction_to_triple(data["restrictions"])
     if data.get("triples", None) is not None:
         triples.extend(_align_triples(data["triples"]))
+    if data.get("derived_from", None) is not None:
+        triples.append(
+            (SNS.inheritsPropertiesFrom, data["derived_from"])
+        )
     return triples
 
 

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -51,10 +51,8 @@ def add(a: float, b: float) -> u(float, triples=(EX.HasOperation, EX.Addition)):
 
 def multiply(a: float, b: float) -> u(
     float,
-    triples=(
-        (EX.HasOperation, EX.Multiplication),
-        (SNS.inheritsPropertiesFrom, "inputs.a"),
-    ),
+    triples=(EX.HasOperation, EX.Multiplication),
+    derived_from="inputs.a",
 ):
     return a * b
 
@@ -128,10 +126,8 @@ def create_vacancy(
     structure: str,
 ) -> u(
     str,
-    triples=(
-        (SNS.inheritsPropertiesFrom, "inputs.structure"),
-        (EX.hasDefect, EX.vacancy),
-    ),
+    triples=(EX.hasDefect, EX.vacancy),
+    derived_from="inputs.structure",
     cancel=(EX.hasState, EX.relaxed),
 ):
     return structure
@@ -141,10 +137,8 @@ def relax_structure(
     structure: str,
 ) -> u(
     str,
-    triples=(
-        (SNS.inheritsPropertiesFrom, "inputs.structure"),
-        (EX.hasState, EX.relaxed),
-    ),
+    triples=(EX.hasState, EX.relaxed),
+    derived_from="inputs.structure",
 ):
     return structure
 


### PR DESCRIPTION
The motivation is discussed [here](https://github.com/pyiron/semantikon/issues/219). Now instead of:

```python
def dye(clothes: Clothes, color="blue") -> u(
    Clothes,
    triples=((EX.hasProperty, EX.color), (SNS.inheritsPropertiesFrom, "inputs.clothes")),
):
    ...
    return clothes
```

you can write:


```python
def dye(clothes: Clothes, color="blue") -> u(
    Clothes,
    triples=(EX.hasProperty, EX.color),
    derived_from="inputs.clothes",
):
    ...
    return clothes
```