### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   codeql:
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.0.2
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.0.8
     secrets: inherit

--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -6,5 +6,5 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/dependabot-pr.yml@actions-4.0.2
+    uses: pyiron/actions/.github/workflows/dependabot-pr.yml@actions-4.0.8
     secrets: inherit

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/pr-labeled.yml@actions-4.0.2
+    uses: pyiron/actions/.github/workflows/pr-labeled.yml@actions-4.0.8
     secrets: inherit

--- a/.github/workflows/pr-target-opened.yml
+++ b/.github/workflows/pr-target-opened.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/pr-target-opened.yml@actions-4.0.2
+    uses: pyiron/actions/.github/workflows/pr-target-opened.yml@actions-4.0.8
     secrets: inherit

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/pyproject-release.yml@actions-4.0.2
+    uses: pyiron/actions/.github/workflows/pyproject-release.yml@actions-4.0.8
     secrets: inherit
     with:
       runner: 'ubuntu-22.04' # with ubuntu > 22.04, pip is broken

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -19,4 +19,5 @@ jobs:
       do-codecov: true
       do-coveralls: false
       do-mypy: true
+      do-ruff-check: true
     secrets: inherit

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/push-pull.yml@actions-4.0.2
+    uses: pyiron/actions/.github/workflows/push-pull.yml@actions-4.0.8
     with:
       runner: 'ubuntu-22.04' # with ubuntu > 22.04, pip is broken
       python-version-alt1: 'exclude'

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -18,19 +18,5 @@ jobs:
       python-version-alt3: '3.13'
       do-codecov: true
       do-coveralls: false
+      do-mypy: true
     secrets: inherit
-
-  mypy:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          architecture: x64
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Install mypy
-        run: pip install mypy
-      - name: Test
-        run: mypy .

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   codeql:
-    uses: pyiron/actions/.github/workflows/codeql.yml@actions-4.0.2
+    uses: pyiron/actions/.github/workflows/codeql.yml@actions-4.0.8
     secrets: inherit


### PR DESCRIPTION
4.0.8 resolves a bug in channels for the conda setup (didn't impact us because  conda-forge shows up first and all our packages are there, but still), but while I'm here I'd like to run mypy via the flag and turn on ruff (since this repo is anyhow passing)