### PR TITLE
Parse dictionary output

### DIFF
--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -172,11 +172,8 @@ def _to_tag(item: Any, count=None, must_be_named: bool = False) -> str:
         return f"output_{count}"
 
 
-def get_return_expressions(
-    func: Callable, separate_tuple: bool = True, strict: bool = False
-) -> str | tuple[str, ...] | None:
-    source = inspect.getsource(func)
-    source = textwrap.dedent(source)
+def _get_return_list(func: Callable, strict: bool = False) -> list[str | tuple[str, ...]]:
+    source = textwrap.dedent(inspect.getsource(func))
     parsed = ast.parse(source)
 
     func_node = next(n for n in parsed.body if isinstance(n, ast.FunctionDef))
@@ -199,7 +196,13 @@ def get_return_expressions(
                 )
             else:
                 ret_list.append(_to_tag(value, must_be_named=strict))
+    return ret_list
 
+
+def get_return_expressions(
+    func: Callable, separate_tuple: bool = True, strict: bool = False
+) -> str | tuple[str, ...] | None:
+    ret_list = _get_return_list(func, strict=strict)
     if len(ret_list) == 0 and not strict:
         return None
     elif len(set(ret_list)) == 1 and (

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -238,6 +238,16 @@ class TestParser(unittest.TestCase):
         self.assertEqual(get_return_expressions(f, separate_tuple=False), "None")
         self.assertEqual(get_return_expressions(f, strict=True), "None")
 
+        def f(x):
+            return {"z": x}
+
+        self.assertEqual(get_return_expressions(f), ("z",))
+
+        def f(x):
+            return {"z + 1": x}
+
+        self.assertEqual(get_return_expressions(f), ("output_0",))
+
     def test_get_return_labels(self):
 
         def f(x):


### PR DESCRIPTION
I started feeling that we should give the possibility of returning `dict` and data classes, simply because it's the de facto standard for input and output parsers.

Before (this works just as well):

```python
def get_output(job_instance):
    ...
    return positions, forces, energy
```

After:

```python
def get_output(job_instance):
    ...
    return {"positions", x, "forces", f, "energy": E}
```

And these two should have the same output keys. This would imply that we would allow something like this:

```python
def my_workflow(some_inputs):
    ...
    output_dict = get_output(job)
    my_input = get_input_of_another_job(energy=output_dict["energy"])
    ...
```

In this case the parsing will be slightly more complicated, but I guess it's still a reasonable amount of work. What do you think of the overall idea? @jan-janssen @liamhuber 