### PR TITLE
Function to issue warning if default value is used

### DIFF
--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -462,7 +462,29 @@ def semantikon_class(cls: type) -> type:
     return cls
 
 
-def with_explicit_defaults(func):
+def with_explicit_defaults(func: Callable) -> Callable:
+    """
+    Decorator to marks a value as an explicit default, which can be used to
+    indicate that a value should be replaced with a default value in the
+    context of serialization or processing.
+
+    Args:
+        func: function to be decorated
+
+    Returns:
+        decorated function that replaces explicit defaults with the actual default
+        value and issues a warning if the default is used.
+
+    Example:
+
+    >>> @with_explicit_defaults
+    >>> def f(x=use_default(3)):
+    ...     return x
+
+    >>> f()  # This will return 3, and a warning will be issued.
+
+    >>> f(3)  # This will also return 3 but without any warning.
+    """
     sig = inspect.signature(func)
 
     @wraps(func)

--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -7,6 +7,7 @@ import inspect
 import re
 import sys
 import textwrap
+import warnings
 from copy import deepcopy
 from functools import update_wrapper, wraps
 from typing import (
@@ -28,7 +29,7 @@ from pint.registry_helpers import (
     _to_units_container,
 )
 
-from semantikon.datastructure import TypeMetadata
+from semantikon.datastructure import ExplicitDefault, TypeMetadata
 
 __author__ = "Sam Waseda"
 __copyright__ = (
@@ -459,3 +460,51 @@ def semantikon_class(cls: type) -> type:
         pass
     setattr(cls, "_is_semantikon_class", True)
     return cls
+
+
+def with_explicit_defaults(func):
+    sig = inspect.signature(func)
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        bound = sig.bind_partial(*args, **kwargs)
+        bound.apply_defaults()
+
+        # Track updated arguments
+        new_args = list(args)
+        new_kwargs = dict(kwargs)
+
+        for name, param in sig.parameters.items():
+            default_val = param.default
+
+            if not isinstance(default_val, ExplicitDefault):
+                continue  # Only handle sentinel-wrapped defaults
+
+            # Determine if argument was passed
+            was_explicit = (
+                name in bound.arguments
+                and name in kwargs
+                or (
+                    param.kind in [param.POSITIONAL_ONLY, param.POSITIONAL_OR_KEYWORD]
+                    and list(sig.parameters).index(name) < len(args)
+                )
+            )
+
+            if not was_explicit:
+                # Not passed: Replace sentinel with real default
+                if default_val.msg:
+                    warnings.warn(default_val.msg)
+                else:
+                    warnings.warn(f"'{name}' not provided, using default: {default_val.default}")
+                if param.kind in [param.POSITIONAL_ONLY, param.POSITIONAL_OR_KEYWORD]:
+                    idx = list(sig.parameters).index(name)
+                    if idx < len(new_args):
+                        new_args[idx] = default_val.default
+                    else:
+                        new_kwargs[name] = default_val.default
+                else:
+                    new_kwargs[name] = default_val.default
+
+        return func(*new_args, **new_kwargs)
+
+    return wrapper

--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -495,7 +495,9 @@ def with_explicit_defaults(func):
                 if default_val.msg:
                     warnings.warn(default_val.msg)
                 else:
-                    warnings.warn(f"'{name}' not provided, using default: {default_val.default}")
+                    warnings.warn(
+                        f"'{name}' not provided, using default: {default_val.default}"
+                    )
                 if param.kind in [param.POSITIONAL_ONLY, param.POSITIONAL_OR_KEYWORD]:
                     idx = list(sig.parameters).index(name)
                     if idx < len(new_args):

--- a/semantikon/datastructure.py
+++ b/semantikon/datastructure.py
@@ -201,3 +201,9 @@ class For(Workflow): ...  # TODO
 
 @dataclasses.dataclass(slots=True)
 class If(Workflow): ...  # TODO
+
+
+class ExplicitDefault:
+    def __init__(self, default, msg=None):
+        self.default = default
+        self.msg = msg

--- a/semantikon/metadata.py
+++ b/semantikon/metadata.py
@@ -118,5 +118,30 @@ def u(
         raise TypeError(f"Unsupported type: {type(type_or_func)}")
 
 
-def use_default(default, msg=None):
+def use_default(default: Any, msg: str | None = None) -> ExplicitDefault:
+    """
+    Marks a value as an explicit default, which can be used to indicate that
+    a value should be replaced with a default value in the context of
+    serialization or processing.
+
+    Args:
+        default (Any): The default value to be used.
+        msg (str | None): An optional warning message. If not provided, the
+            default message "'{arg}' not provided, using default: {value}" is
+            used.
+
+    Returns:
+        ExplicitDefault: An instance of ExplicitDefault containing the default
+        value and the message.
+
+    Example:
+
+    >>> @with_explicit_defaults
+    >>> def f(x=use_default(3)):
+    ...     return x
+
+    >>> f()  # This will return 3, and a warning will be issued.
+
+    >>> f(3)  # This will also return 3 but without any warning.
+    """
     return ExplicitDefault(default, msg)

--- a/semantikon/metadata.py
+++ b/semantikon/metadata.py
@@ -4,6 +4,7 @@ from semantikon.converter import FunctionWithMetadata, parse_metadata
 from semantikon.datastructure import (
     MISSING,
     CoreMetadata,
+    ExplicitDefault,
     Missing,
     RestrictionLike,
     ShapeType,
@@ -115,3 +116,7 @@ def u(
         return _function_metadata(uri=uri, triples=triples, restrictions=restrictions)
     else:
         raise TypeError(f"Unsupported type: {type(type_or_func)}")
+
+
+def use_default(default, msg=None):
+    return ExplicitDefault(default, msg)

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -253,7 +253,6 @@ class TestParser(unittest.TestCase):
             ):
                 get_return_labels(f)
 
-
     def test_use_default(self):
 
         @with_explicit_defaults
@@ -267,15 +266,11 @@ class TestParser(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             self.assertEqual(f(), 3)
             self.assertEqual(len(w), 1)
-            self.assertEqual(
-                w[0].message.args[0], "'x' not provided, using default: 3"
-            )
+            self.assertEqual(w[0].message.args[0], "'x' not provided, using default: 3")
             self.assertEqual(f(4), 4)
             self.assertEqual(len(w), 1)
             self.assertEqual(g(), 2)
-            self.assertEqual(
-                w[-1].message.args[0], "hello"
-            )
+            self.assertEqual(w[-1].message.args[0], "hello")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -1,4 +1,5 @@
 import unittest
+import warnings
 from typing import TYPE_CHECKING
 from unittest import mock
 
@@ -10,8 +11,9 @@ from semantikon.converter import (
     parse_input_args,
     parse_metadata,
     parse_output_args,
+    with_explicit_defaults,
 )
-from semantikon.metadata import u
+from semantikon.metadata import u, use_default
 
 if TYPE_CHECKING:
 
@@ -250,6 +252,30 @@ class TestParser(unittest.TestCase):
                 TypeError, msg="expected None, a string, or a tuple of strings"
             ):
                 get_return_labels(f)
+
+
+    def test_use_default(self):
+
+        @with_explicit_defaults
+        def f(x=use_default(3)):
+            return x
+
+        @with_explicit_defaults
+        def g(x=use_default(2, msg="hello")):
+            return x
+
+        with warnings.catch_warnings(record=True) as w:
+            self.assertEqual(f(), 3)
+            self.assertEqual(len(w), 1)
+            self.assertEqual(
+                w[0].message.args[0], "'x' not provided, using default: 3"
+            )
+            self.assertEqual(f(4), 4)
+            self.assertEqual(len(w), 1)
+            self.assertEqual(g(), 2)
+            self.assertEqual(
+                w[-1].message.args[0], "hello"
+            )
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -260,8 +260,8 @@ class TestParser(unittest.TestCase):
             return x
 
         @with_explicit_defaults
-        def g(x=use_default(2, msg="hello")):
-            return x
+        def g(x=use_default(2, msg="hello"), y=1):
+            return x + y
 
         with warnings.catch_warnings(record=True) as w:
             self.assertEqual(f(), 3)
@@ -269,8 +269,11 @@ class TestParser(unittest.TestCase):
             self.assertEqual(w[0].message.args[0], "'x' not provided, using default: 3")
             self.assertEqual(f(4), 4)
             self.assertEqual(len(w), 1)
-            self.assertEqual(g(), 2)
+            self.assertEqual(g(), 3)
+            self.assertEqual(len(w), 2)
             self.assertEqual(w[-1].message.args[0], "hello")
+            self.assertEqual(g(x=2), 3)
+            self.assertEqual(len(w), 2)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -260,8 +260,8 @@ class TestParser(unittest.TestCase):
             return x
 
         @with_explicit_defaults
-        def g(x=use_default(2, msg="hello"), y=1):
-            return x + y
+        def g(a, x=use_default(2, msg="hello"), y=1):
+            return a + x + y
 
         with warnings.catch_warnings(record=True) as w:
             self.assertEqual(f(), 3)
@@ -269,10 +269,10 @@ class TestParser(unittest.TestCase):
             self.assertEqual(w[0].message.args[0], "'x' not provided, using default: 3")
             self.assertEqual(f(4), 4)
             self.assertEqual(len(w), 1)
-            self.assertEqual(g(), 3)
+            self.assertEqual(g(1), 4)
             self.assertEqual(len(w), 2)
             self.assertEqual(w[-1].message.args[0], "hello")
-            self.assertEqual(g(x=2), 3)
+            self.assertEqual(g(a=2, x=2), 5)
             self.assertEqual(len(w), 2)
 
 


### PR DESCRIPTION
Closes #227 

While developing the [DAMASK example](https://github.com/samwaseda/damask_local), I strongly felt the need to warn the user if the default values are used, because some of them are not intuitively clear. With this PR, you can write a function like this:

```python
@with_explicit_defaults
def f(x=use_default(3)):
    return x
```

This is largely equivalent to:

```python
def f(x=3):
    return x
```

The only difference is that if the user runs `f()`, it issues a warning, but if it's explicitly set by `f(3)` or `f(x=3)` (or any other value), then it doesn't say anything. You can also find the actual use [in this notebook](https://github.com/samwaseda/damask_local/blob/main/notebooks/tensile_test.ipynb)