### PR TITLE
Macro io ontology

### DIFF
--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -439,14 +439,8 @@ def _dot(*args) -> str:
     return ".".join([a for a in args if a is not None])
 
 
-def _convert_edge_triples(inp: str, out: str, ontology=SNS) -> tuple:
-    if inp.split(".")[-2] == "outputs" or out.split(".")[-2] == "inputs":
-        return (inp, OWL.sameAs, out)
-    return (inp, ontology.inheritsPropertiesFrom, out)
-
-
 def _edges_to_triples(edges: dict, ontology=SNS) -> list:
-    return [_convert_edge_triples(inp, out, ontology) for inp, out in edges.items()]
+    return [(inp, ontology.inheritsPropertiesFrom, out) for inp, out in edges.items()]
 
 
 def _parse_workflow(

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -4,7 +4,7 @@ from textwrap import dedent
 
 from graphviz import Digraph
 from pyshacl import validate
-from rdflib import Graph, OWL, PROV, RDF, RDFS, SH, Literal, Namespace, URIRef
+from rdflib import OWL, PROV, RDF, RDFS, SH, Graph, Literal, Namespace, URIRef
 
 from semantikon.metadata import u
 from semantikon.ontology import (

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -220,34 +220,31 @@ def eat_pizza():
     comment = eat(pizza)
     return comment
 
-# New helper functions for validation tests (using http://www.example.org/)
-EXW = Namespace("http://www.example.org/")
-
-def add_onetology(x: u(int, EXW.Input)) -> u(int, EXW.Output):
+def add_onetology(x: u(int, EX.Input)) -> u(int, EX.Output):
     y = x + 1
     return y
 
 @workflow
-def matching_wrapper(x_outer: u(int, EXW.Input)) -> u(int, EXW.Output):
+def matching_wrapper(x_outer: u(int, EX.Input)) -> u(int, EX.Output):
     add = add_onetology(x_outer)
     return add
 
 @workflow
-def mismatching_input(x_outer: u(int, EXW.NotInput)) -> u(int, EXW.Output):
+def mismatching_input(x_outer: u(int, EX.NotInput)) -> u(int, EX.Output):
     add = add_onetology(x_outer)
     return add
 
 @workflow
-def mismatching_output(x_outer: u(int, EXW.Input)) -> u(int, EXW.NotOutput):
+def mismatching_output(x_outer: u(int, EX.Input)) -> u(int, EX.NotOutput):
     add = add_onetology(x_outer)
     return add
 
-def dont_add_onetology(x: u(int, EXW.NotInput)) -> u(int, EXW.NotOutput):
+def dont_add_onetology(x: u(int, EX.NotInput)) -> u(int, EX.NotOutput):
     y = x
     return y
 
 @workflow
-def mismatching_internals(x_outer: u(int, EXW.Input)) -> u(int, EXW.NotOutput):
+def mismatching_internals(x_outer: u(int, EX.Input)) -> u(int, EX.NotOutput):
     add = add_onetology(x_outer)
     dont_add = dont_add_onetology(add)
     return dont_add
@@ -354,8 +351,8 @@ class TestOntology(unittest.TestCase):
                 (
                     "mismatching_input.add_onetology_0.inputs.x",
                     "mismatching_input.inputs.x_outer",
-                    ["http://www.example.org/Input"],
-                    ["http://www.example.org/NotInput"],
+                    ["http://example.org/Input"],
+                    ["http://example.org/NotInput"],
                 )
             ],
         )
@@ -378,8 +375,8 @@ class TestOntology(unittest.TestCase):
                 (
                     "mismatching_output.outputs.add",
                     "mismatching_output.add_onetology_0.outputs.y",
-                    ["http://www.example.org/NotOutput"],
-                    ["http://www.example.org/Output"],
+                    ["http://example.org/NotOutput"],
+                    ["http://example.org/Output"],
                 )
             ],
         )
@@ -402,8 +399,8 @@ class TestOntology(unittest.TestCase):
                 (
                     "mismatching_internals.dont_add_onetology_0.inputs.x",
                     "mismatching_internals.add_onetology_0.outputs.y",
-                    ["http://www.example.org/NotInput"],
-                    ["http://www.example.org/Output"],
+                    ["http://example.org/NotInput"],
+                    ["http://example.org/Output"],
                 )
             ],
         )

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -354,83 +354,88 @@ class TestOntology(unittest.TestCase):
         txt = dedent(
             """\
         @prefix ns1: <http://pyiron.org/ontology/> .
-        @prefix owl: <http://www.w3.org/2002/07/owl#> .
         @prefix prov: <http://www.w3.org/ns/prov#> .
         @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
         @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-
+        
         <get_macro.add_one_0.inputs.a> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_two_0.outputs.result.value> ;
             ns1:inheritsPropertiesFrom <get_macro.add_three_0.outputs.w> ;
             ns1:inputOf <get_macro.add_one_0> ;
-            ns1:outputOf <get_macro.add_three_0> .
-
+            ns1:outputOf <get_macro.add_three_0>,
+                <get_macro.add_three_0.add_two_0> .
+        
         <get_macro.add_three_0.add_one_0.inputs.a> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_one_0.inputs.a.value> ;
-            ns1:inputOf <get_macro.add_three_0.add_one_0> ;
-            owl:sameAs <get_macro.add_three_0.inputs.c> .
-
+            ns1:inheritsPropertiesFrom <get_macro.add_three_0.inputs.c> ;
+            ns1:inputOf <get_macro>,
+                <get_macro.add_three_0>,
+                <get_macro.add_three_0.add_one_0> .
+        
         <get_macro.add_three_0.add_two_0.inputs.b> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_one_0.outputs.result.value> ;
             ns1:inheritsPropertiesFrom <get_macro.add_three_0.add_one_0.outputs.result> ;
             ns1:inputOf <get_macro.add_three_0.add_two_0> ;
             ns1:outputOf <get_macro.add_three_0.add_one_0> .
-
+        
         <get_macro.outputs.result> a prov:Entity ;
             ns1:hasValue <get_macro.add_one_0.outputs.result.value> ;
-            ns1:outputOf <get_macro> ;
-            owl:sameAs <get_macro.add_one_0.outputs.result> .
-
+            ns1:inheritsPropertiesFrom <get_macro.add_one_0.outputs.result> ;
+            ns1:outputOf <get_macro>,
+                <get_macro.add_one_0> .
+        
         <get_macro.add_one_0.outputs.result> a prov:Entity ;
             ns1:hasValue <get_macro.add_one_0.outputs.result.value> ;
             ns1:outputOf <get_macro.add_one_0> .
-
+        
         <get_macro.add_three_0.add_one_0.outputs.result> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_one_0.outputs.result.value> ;
             ns1:outputOf <get_macro.add_three_0.add_one_0> .
-
+        
         <get_macro.add_three_0.add_two_0.outputs.result> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_two_0.outputs.result.value> ;
             ns1:outputOf <get_macro.add_three_0.add_two_0> .
-
+        
         <get_macro.add_three_0.inputs.c> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_one_0.inputs.a.value> ;
-            ns1:inputOf <get_macro.add_three_0> ;
-            owl:sameAs <get_macro.inputs.c> .
-
+            ns1:inheritsPropertiesFrom <get_macro.inputs.c> ;
+            ns1:inputOf <get_macro>,
+                <get_macro.add_three_0> .
+        
         <get_macro.add_three_0.outputs.w> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_two_0.outputs.result.value> ;
-            ns1:outputOf <get_macro.add_three_0> ;
-            owl:sameAs <get_macro.add_three_0.add_two_0.outputs.result> .
-
+            ns1:inheritsPropertiesFrom <get_macro.add_three_0.add_two_0.outputs.result> ;
+            ns1:outputOf <get_macro.add_three_0>,
+                <get_macro.add_three_0.add_two_0> .
+        
         <get_macro.inputs.c> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_one_0.inputs.a.value> ;
             ns1:inputOf <get_macro> .
-
+        
+        <get_macro.add_one_0.outputs.result.value> rdf:value 5 .
+        
+        <get_macro.add_three_0.add_one_0.outputs.result.value> rdf:value 2 .
+        
+        <get_macro.add_three_0.add_one_0.inputs.a.value> rdf:value 1 .
+        
+        <get_macro.add_three_0.add_two_0.outputs.result.value> rdf:value 4 .
+        
         <get_macro> a prov:Activity ;
             ns1:hasNode <get_macro.add_one_0>,
                 <get_macro.add_three_0> .
-
-        <get_macro.add_one_0.outputs.result.value> rdf:value 5 .
-
-        <get_macro.add_three_0.add_one_0.outputs.result.value> rdf:value 2 .
-
+        
         <get_macro.add_one_0> a prov:Activity ;
             ns1:hasSourceFunction <add_one> .
-
-        <get_macro.add_three_0.add_one_0.inputs.a.value> rdf:value 1 .
-
-        <get_macro.add_three_0.add_two_0> a prov:Activity ;
-            ns1:hasSourceFunction <add_two> .
-
-        <get_macro.add_three_0.add_two_0.outputs.result.value> rdf:value 4 .
-
+        
+        <get_macro.add_three_0.add_one_0> a prov:Activity ;
+            ns1:hasSourceFunction <add_one> .
+        
         <get_macro.add_three_0> a prov:Activity ;
             ns1:hasNode <get_macro.add_three_0.add_one_0>,
                 <get_macro.add_three_0.add_two_0> .
-
-        <get_macro.add_three_0.add_one_0> a prov:Activity ;
-            ns1:hasSourceFunction <add_one> .\n\n"""
+        
+        <get_macro.add_three_0.add_two_0> a prov:Activity ;
+            ns1:hasSourceFunction <add_two> .\n\n"""
         )
         ref_data = txt.splitlines()
         graph = get_knowledge_graph(get_macro.run())

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -325,17 +325,30 @@ class TestOntology(unittest.TestCase):
                 self.assertIn(
                     URIRef("get_macro." + tag), subj, msg=f"{tag} not in {subj}"
                 )
-        same_as = [(str(g[0]), str(g[1])) for g in graph.subject_objects(OWL.sameAs)]
+        inherits_from = [
+            (str(g[0]), str(g[1]))
+            for g in graph.subject_objects(SNS.inheritsPropertiesFrom)
+        ]
+        get_macro_io_passing = 2
+        get_three_io_passing = 2
+        get_three_internal = 1
+        get_macro_internal = 1
+        expected_inheritance = (
+            get_macro_io_passing
+            + get_three_io_passing
+            + get_three_internal
+            + get_macro_internal
+        )
         prefix = "get_macro.add_three_0"
         sub_obj = [
             ("add_one_0.inputs.a", "inputs.c"),
             ("outputs.w", "add_two_0.outputs.result"),
         ]
         sub_obj = [(prefix + "." + s, prefix + "." + o) for s, o in sub_obj]
-        self.assertEqual(len(same_as), 4)
+        self.assertEqual(len(inherits_from), expected_inheritance)
         for ii, pair in enumerate(sub_obj):
             with self.subTest(i=ii):
-                self.assertIn(pair, same_as)
+                self.assertIn(pair, inherits_from)
 
     def test_macro_full_comparison(self):
         txt = dedent(

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -221,36 +221,36 @@ def eat_pizza():
     return comment
 
 
-def add_onetology(x: u(int, EX.Input)) -> u(int, EX.Output):
+def add_onetology(x: u(int, uri=EX.Input)) -> u(int, uri=EX.Output):
     y = x + 1
     return y
 
 
 @workflow
-def matching_wrapper(x_outer: u(int, EX.Input)) -> u(int, EX.Output):
+def matching_wrapper(x_outer: u(int, uri=EX.Input)) -> u(int, uri=EX.Output):
     add = add_onetology(x_outer)
     return add
 
 
 @workflow
-def mismatching_input(x_outer: u(int, EX.NotInput)) -> u(int, EX.Output):
+def mismatching_input(x_outer: u(int, uri=EX.NotInput)) -> u(int, uri=EX.Output):
     add = add_onetology(x_outer)
     return add
 
 
 @workflow
-def mismatching_output(x_outer: u(int, EX.Input)) -> u(int, EX.NotOutput):
+def mismatching_output(x_outer: u(int, uri=EX.Input)) -> u(int, uri=EX.NotOutput):
     add = add_onetology(x_outer)
     return add
 
 
-def dont_add_onetology(x: u(int, EX.NotInput)) -> u(int, EX.NotOutput):
+def dont_add_onetology(x: u(int, uri=EX.NotInput)) -> u(int, uri=EX.NotOutput):
     y = x
     return y
 
 
 @workflow
-def mismatching_peers(x_outer: u(int, EX.Input)) -> u(int, EX.NotOutput):
+def mismatching_peers(x_outer: u(int, uri=EX.Input)) -> u(int, uri=EX.NotOutput):
     add = add_onetology(x_outer)
     dont_add = dont_add_onetology(add)
     return dont_add

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -326,7 +326,7 @@ class TestOntology(unittest.TestCase):
         graph.add((EX.Pizza, RDFS.subClassOf, EX.Meal))
         self.assertEqual(validate_values(graph)["incompatible_connections"], [])
 
-    def test_value_validation_examples(self):
+    def test_workflow_edge_validation(self):
         # matching
         graph = get_knowledge_graph(matching_wrapper._semantikon_workflow)
         result = validate_values(graph)

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -220,34 +220,41 @@ def eat_pizza():
     comment = eat(pizza)
     return comment
 
+
 def add_onetology(x: u(int, EX.Input)) -> u(int, EX.Output):
     y = x + 1
     return y
+
 
 @workflow
 def matching_wrapper(x_outer: u(int, EX.Input)) -> u(int, EX.Output):
     add = add_onetology(x_outer)
     return add
 
+
 @workflow
 def mismatching_input(x_outer: u(int, EX.NotInput)) -> u(int, EX.Output):
     add = add_onetology(x_outer)
     return add
+
 
 @workflow
 def mismatching_output(x_outer: u(int, EX.Input)) -> u(int, EX.NotOutput):
     add = add_onetology(x_outer)
     return add
 
+
 def dont_add_onetology(x: u(int, EX.NotInput)) -> u(int, EX.NotOutput):
     y = x
     return y
+
 
 @workflow
 def mismatching_internals(x_outer: u(int, EX.Input)) -> u(int, EX.NotOutput):
     add = add_onetology(x_outer)
     dont_add = dont_add_onetology(add)
     return dont_add
+
 
 class TestOntology(unittest.TestCase):
     @classmethod
@@ -327,83 +334,83 @@ class TestOntology(unittest.TestCase):
         self.assertEqual(validate_values(graph)["incompatible_connections"], [])
 
     def test_workflow_edge_validation(self):
-        # matching
-        graph = get_knowledge_graph(matching_wrapper._semantikon_workflow)
-        result = validate_values(graph)
-        self.assertEqual(result["missing_triples"], [])
-        self.assertEqual(result["incompatible_connections"], [])
+        with self.subTest("Matching"):
+            graph = get_knowledge_graph(matching_wrapper._semantikon_workflow)
+            result = validate_values(graph)
+            self.assertEqual(result["missing_triples"], [])
+            self.assertEqual(result["incompatible_connections"], [])
 
-        # mismatching input
-        graph = get_knowledge_graph(mismatching_input._semantikon_workflow)
-        result = validate_values(graph)
-        incompatible = [
-            (
-                str(a),
-                str(b),
-                [str(x) for x in expected],
-                [str(x) for x in provided],
-            )
-            for (a, b, expected, provided) in result["incompatible_connections"]
-        ]
-        self.assertEqual(
-            incompatible,
-            [
+        with self.subTest("Mismatching input"):
+            graph = get_knowledge_graph(mismatching_input._semantikon_workflow)
+            result = validate_values(graph)
+            incompatible = [
                 (
-                    "mismatching_input.add_onetology_0.inputs.x",
-                    "mismatching_input.inputs.x_outer",
-                    ["http://example.org/Input"],
-                    ["http://example.org/NotInput"],
+                    str(a),
+                    str(b),
+                    [str(x) for x in expected],
+                    [str(x) for x in provided],
                 )
-            ],
-        )
+                for (a, b, expected, provided) in result["incompatible_connections"]
+            ]
+            self.assertEqual(
+                incompatible,
+                [
+                    (
+                        "mismatching_input.add_onetology_0.inputs.x",
+                        "mismatching_input.inputs.x_outer",
+                        ["http://example.org/Input"],
+                        ["http://example.org/NotInput"],
+                    )
+                ],
+            )
 
-        # mismatching output
-        graph = get_knowledge_graph(mismatching_output._semantikon_workflow)
-        result = validate_values(graph)
-        incompatible = [
-            (
-                str(a),
-                str(b),
-                [str(x) for x in expected],
-                [str(x) for x in provided],
-            )
-            for (a, b, expected, provided) in result["incompatible_connections"]
-        ]
-        self.assertEqual(
-            incompatible,
-            [
+        with self.subTest("Mismatching output"):
+            graph = get_knowledge_graph(mismatching_output._semantikon_workflow)
+            result = validate_values(graph)
+            incompatible = [
                 (
-                    "mismatching_output.outputs.add",
-                    "mismatching_output.add_onetology_0.outputs.y",
-                    ["http://example.org/NotOutput"],
-                    ["http://example.org/Output"],
+                    str(a),
+                    str(b),
+                    [str(x) for x in expected],
+                    [str(x) for x in provided],
                 )
-            ],
-        )
+                for (a, b, expected, provided) in result["incompatible_connections"]
+            ]
+            self.assertEqual(
+                incompatible,
+                [
+                    (
+                        "mismatching_output.outputs.add",
+                        "mismatching_output.add_onetology_0.outputs.y",
+                        ["http://example.org/NotOutput"],
+                        ["http://example.org/Output"],
+                    )
+                ],
+            )
 
-        # mismatching internals
-        graph = get_knowledge_graph(mismatching_internals._semantikon_workflow)
-        result = validate_values(graph)
-        incompatible = [
-            (
-                str(a),
-                str(b),
-                [str(x) for x in expected],
-                [str(x) for x in provided],
-            )
-            for (a, b, expected, provided) in result["incompatible_connections"]
-        ]
-        self.assertEqual(
-            incompatible,
-            [
+        with self.subTest("Mismatching peers"):
+            graph = get_knowledge_graph(mismatching_internals._semantikon_workflow)
+            result = validate_values(graph)
+            incompatible = [
                 (
-                    "mismatching_internals.dont_add_onetology_0.inputs.x",
-                    "mismatching_internals.add_onetology_0.outputs.y",
-                    ["http://example.org/NotInput"],
-                    ["http://example.org/Output"],
+                    str(a),
+                    str(b),
+                    [str(x) for x in expected],
+                    [str(x) for x in provided],
                 )
-            ],
-        )
+                for (a, b, expected, provided) in result["incompatible_connections"]
+            ]
+            self.assertEqual(
+                incompatible,
+                [
+                    (
+                        "mismatching_internals.dont_add_onetology_0.inputs.x",
+                        "mismatching_internals.add_onetology_0.outputs.y",
+                        ["http://example.org/NotInput"],
+                        ["http://example.org/Output"],
+                    )
+                ],
+            )
 
     def test_macro(self):
         graph = get_knowledge_graph(get_macro.run())

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -250,7 +250,7 @@ def dont_add_onetology(x: u(int, EX.NotInput)) -> u(int, EX.NotOutput):
 
 
 @workflow
-def mismatching_internals(x_outer: u(int, EX.Input)) -> u(int, EX.NotOutput):
+def mismatching_peers(x_outer: u(int, EX.Input)) -> u(int, EX.NotOutput):
     add = add_onetology(x_outer)
     dont_add = dont_add_onetology(add)
     return dont_add
@@ -389,7 +389,7 @@ class TestOntology(unittest.TestCase):
             )
 
         with self.subTest("Mismatching peers"):
-            graph = get_knowledge_graph(mismatching_internals._semantikon_workflow)
+            graph = get_knowledge_graph(mismatching_peers._semantikon_workflow)
             result = validate_values(graph)
             incompatible = [
                 (
@@ -404,8 +404,8 @@ class TestOntology(unittest.TestCase):
                 incompatible,
                 [
                     (
-                        "mismatching_internals.dont_add_onetology_0.inputs.x",
-                        "mismatching_internals.add_onetology_0.outputs.y",
+                        "mismatching_peers.dont_add_onetology_0.inputs.x",
+                        "mismatching_peers.add_onetology_0.outputs.y",
                         ["http://example.org/NotInput"],
                         ["http://example.org/Output"],
                     )


### PR DESCRIPTION
Modifies the conversion of edges to triples, which currently formulates the input->input and output->output edges as `OWL.sameAs`

https://github.com/pyiron/semantikon/blob/66f11fafb488f594157506948903ac0c715364a5/semantikon/ontology.py#L442-L449

To simply always treat edges as `SNS.inheritsPropertiesFrom` (or non-SNS ontology):

https://github.com/pyiron/semantikon/blob/402d8d6eebeb46dbf22695d1fb70ae20ee7b5570/semantikon/ontology.py#L442-L443

Closes #237 

@samwaseda, the only tests this impacted were the ones that were explicitly testing the resulting formulation of the graph. I don't anticipate any negative side effects from this change, and indeed it makes conceptual sense to me -- but my ontology-fu is weak. Please let me know if this looks like trouble.