### PR TITLE
Make args keyword only

### DIFF
--- a/semantikon/metadata.py
+++ b/semantikon/metadata.py
@@ -87,6 +87,7 @@ def _function_metadata(
 def u(
     type_or_func=None,
     /,
+    *,
     uri: str | Missing = MISSING,
     triples: TriplesLike | Missing = MISSING,
     restrictions: RestrictionLike | Missing = MISSING,


### PR DESCRIPTION
I realized it in [this PR](https://github.com/pyiron/semantikon/issues/237)