### PR TITLE
Inherit types with `derive_from`

### DIFF
--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -248,7 +248,6 @@ def _inherit_properties(
         "    FILTER(?p != rdfs:label)",
         "    FILTER(?p != rdf:value)",
         "    FILTER(?p != ns:hasValue)",
-        "    FILTER(?p != rdf:type)",
         "    FILTER(?p != owl:sameAs)",
         "}",
     )
@@ -306,6 +305,21 @@ def _check_connections(graph: Graph, strict_typing: bool = False) -> list:
     return incompatible_types
 
 
+def _check_types(graph: Graph) -> list:
+    query = f"""
+    PREFIX rdfs: <{RDFS}>
+    PREFIX owl: <{OWL}>
+    
+    SELECT ?subject ?class1 ?class2 WHERE {{
+        ?subject rdfs:subClassOf ?class1 .
+        ?subject rdfs:subClassOf ?class2 .
+        ?class1 owl:disjointWith ?class2 .
+        FILTER(?class1 != ?class2)
+    }}
+    """
+    return list(graph.query(query))
+
+
 def validate_values(
     graph: Graph, run_reasoner: bool = True, strict_typing: bool = False
 ) -> dict[str, list]:
@@ -327,6 +341,7 @@ def validate_values(
         "incompatible_connections": _check_connections(
             graph, strict_typing=strict_typing
         ),
+        "inconsistent_types": _check_types(graph),
     }
 
 

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -221,6 +221,37 @@ def eat_pizza():
     return comment
 
 
+class Clothes:
+    pass
+
+
+def machine_wash(
+    clothes: u(
+        Clothes,
+        uri=EX.Garment,
+        triples=(EX.hasProperty, EX.MachineWashable),
+    ),
+) -> u(
+    Clothes,
+    uri=EX.SomethingElse,
+    triples=(EX.hasProperty, EX.Cleaned),
+    derived_from="inputs.clothes",
+):
+    return clothes
+
+
+@workflow
+def clothes_wf(
+    clothes: u(
+        Clothes,
+        uri=EX.Garment,
+        triples=(EX.hasProperty, EX.MachineWashable),
+    ),
+):
+    washed = machine_wash(clothes)
+    return washed
+
+
 def add_onetology(x: u(int, uri=EX.Input)) -> u(int, uri=EX.Output):
     y = x + 1
     return y
@@ -452,6 +483,77 @@ class TestOntology(unittest.TestCase):
                         ["http://example.org/Output"],
                     )
                 ],
+            )
+
+    def test_derive_from(self):
+        out_tag = URIRef(
+            f"{clothes_wf.__name__}.{machine_wash.__name__}_0.outputs.clothes"
+        )
+        inp_tag = URIRef(
+            f"{clothes_wf.__name__}.{machine_wash.__name__}_0.inputs.clothes"
+        )
+
+        with self.subTest("Inherit type"):
+            graph = get_knowledge_graph(clothes_wf._semantikon_workflow)
+            out_types = set(graph.objects(out_tag, RDF.type))
+            self.assertIn(
+                EX.Garment,
+                out_types,
+                msg="Should inherit from input",
+            )
+            self.assertIn(
+                EX.SomethingElse,
+                out_types,
+                msg="Should gain from u-specification",
+            )
+
+        with self.subTest("Inherit properties"):
+            graph = get_knowledge_graph(clothes_wf._semantikon_workflow)
+            out_properties = set(graph.objects(out_tag, EX.hasProperty))
+            self.assertIn(
+                EX.MachineWashable,
+                out_properties,
+                msg="Should inherit from input",
+            )
+            self.assertIn(
+                EX.Cleaned, out_properties, msg="Should retain from u-specification"
+            )
+
+        type_validation_conflict = [
+            (out_tag, inp_tag, [EX.SomethingElse, EX.Garment], [EX.Garment])
+        ]
+        with self.subTest("No other types"):
+            graph = get_knowledge_graph(clothes_wf._semantikon_workflow)
+            val = validate_values(graph)
+            self.assertListEqual(val["missing_triples"], [])
+            self.assertEqual(
+                val["incompatible_connections"],
+                type_validation_conflict,
+                msg="Completely unrelated types should be flagged",
+            )
+
+        with self.subTest("No type narrowing"):
+            g0 = Graph()
+            g0.add((EX.SomethingElse, RDFS.subClassOf, EX.Garment))
+            graph = get_knowledge_graph(clothes_wf._semantikon_workflow)
+            val = validate_values(graph)
+            self.assertListEqual(val["missing_triples"], [])
+            self.assertListEqual(
+                val["incompatible_connections"],
+                type_validation_conflict,
+                msg="Downstream having a broader type than upstream is disallowed",
+            )
+
+        with self.subTest("Type broadening OK"):
+            context = Graph()
+            context.add((EX.Garment, RDFS.subClassOf, EX.SomethingElse))
+            graph = get_knowledge_graph(clothes_wf._semantikon_workflow, graph=context)
+            val = validate_values(graph)
+            self.assertListEqual(val["missing_triples"], [])
+            self.assertListEqual(
+                val["incompatible_connections"],
+                [],
+                msg="Downstream having a narrower type than upstream is fine",
             )
 
     def test_macro(self):


### PR DESCRIPTION
The actual change is just a one-liner so `derive_from` also snags the  `rdflib.RDF.type` whence the field derives.

Closes #240 

Example:

```python
import rdflib

from semantikon import ontology as onto
from semantikon import workflow
from semantikon.metadata import u

EX = rdflib.Namespace("http://www.example.org/")

class Clothes: ...

def machine_wash(
    clothes: u(
        Clothes,
        uri=EX.Garment,
        triples=(EX.hasProperty, EX.MachineWashable),
    )
) -> u(
    Clothes,
    uri=EX.SomethingElse,
    triples=(EX.hasProperty, EX.Cleaned),
    derived_from="inputs.clothes",
):
    ...
    return clothes

@workflow.workflow
def wrap_in_wf(
    clothes: u(
        Clothes,
        uri=EX.Garment,
        triples=(EX.hasProperty, EX.MachineWashable),
    )
):
    washed = machine_wash(clothes)
    return washed
```

Then 

```python
g = onto.get_knowledge_graph(wf_dict=recipe)
onto.validate_values(g)
```

Is non-empty, because the output of `machine_wash` winds up with two completely unrelated types.

```python
g0 = rdflib.Graph()
g0.add((EX.SomethingElse, rdflib.RDFS.subClassOf, EX.Garment))

g = onto.get_knowledge_graph(
    wf_dict=recipe,
    graph=g0,
)
onto.validate_values(g)
```

Is non-empty, because the downstream (output) type is _narrower_ than the upstream (input) type.

```python
g0 = rdflib.Graph()
g0.add((EX.Garmant, rdflib.RDFS.subClassOf, EX.SomethingElse))

g = onto.get_knowledge_graph(
    wf_dict=recipe,
    graph=g0,
)
onto.validate_values(g)
```

Finally passes, since the downstream type is now _broader_ than the upstream type, and thus the upstream is always fulfilling the downstream requirement.