### PR TITLE
No topo inheritance

### DIFF
--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -248,6 +248,8 @@ def _inherit_properties(
         FILTER(?p != rdfs:label)
         FILTER(?p != rdf:value)
         FILTER(?p != ns:hasValue)
+        FILTER(?p != ns:inputOf)
+        FILTER(?p != ns:outputOf)
         FILTER(?p != owl:sameAs)
     }}
     """

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -15,7 +15,6 @@ class SNS:
     hasNode: URIRef = BASE["hasNode"]
     hasSourceFunction: URIRef = BASE["hasSourceFunction"]
     hasUnits: URIRef = BASE["hasUnits"]
-    inheritsPropertiesFrom: URIRef = BASE["inheritsPropertiesFrom"]
     inputOf: URIRef = BASE["inputOf"]
     outputOf: URIRef = BASE["outputOf"]
     hasValue: URIRef = BASE["hasValue"]
@@ -107,7 +106,7 @@ def _get_triples_from_restrictions(data: dict) -> list:
     if data.get("triples", None) is not None:
         triples.extend(_align_triples(data["triples"]))
     if data.get("derived_from", None) is not None:
-        triples.append(("self", SNS.inheritsPropertiesFrom, data["derived_from"]))
+        triples.append(("self", PROV.wasDerivedFrom, data["derived_from"]))
     return triples
 
 
@@ -234,6 +233,7 @@ def _inherit_properties(
 ):
     update_query = f"""\
     PREFIX ns: <{ontology.BASE}>
+    PREFIX prov: <{PROV}>
     PREFIX rdfs: <{RDFS}>
     PREFIX rdf: <{RDF}>
     PREFIX owl: <{OWL}>
@@ -242,9 +242,9 @@ def _inherit_properties(
         ?subject ?p ?o .
     }}
     WHERE {{
-        ?subject ns:inheritsPropertiesFrom ?target .
+        ?subject prov:wasDerivedFrom ?target .
         ?target ?p ?o .
-        FILTER(?p != ns:inheritsPropertiesFrom)
+        FILTER(?p != prov:wasDerivedFrom)
         FILTER(?p != rdfs:label)
         FILTER(?p != rdf:value)
         FILTER(?p != ns:hasValue)
@@ -294,7 +294,7 @@ def _check_connections(graph: Graph, strict_typing: bool = False) -> list:
         (list): list of incompatible connections
     """
     incompatible_types = []
-    for inp_out in graph.subject_objects(SNS.inheritsPropertiesFrom):
+    for inp_out in graph.subject_objects(PROV.wasDerivedFrom):
         i_type, o_type = [
             [g for g in graph.objects(tag, RDF.type) if g != PROV.Entity]
             for tag in inp_out
@@ -441,7 +441,7 @@ def _dot(*args) -> str:
 
 
 def _edges_to_triples(edges: dict, ontology=SNS) -> list:
-    return [(inp, ontology.inheritsPropertiesFrom, out) for inp, out in edges.items()]
+    return [(inp, PROV.wasDerivedFrom, out) for inp, out in edges.items()]
 
 
 def _parse_workflow(

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -619,28 +619,22 @@ class TestOntology(unittest.TestCase):
         <get_macro.add_one_0.inputs.a> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_two_0.outputs.result.value> ;
             ns1:inheritsPropertiesFrom <get_macro.add_three_0.outputs.w> ;
-            ns1:inputOf <get_macro.add_one_0> ;
-            ns1:outputOf <get_macro.add_three_0>,
-                <get_macro.add_three_0.add_two_0> .
+            ns1:inputOf <get_macro.add_one_0> .
         
         <get_macro.add_three_0.add_one_0.inputs.a> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_one_0.inputs.a.value> ;
             ns1:inheritsPropertiesFrom <get_macro.add_three_0.inputs.c> ;
-            ns1:inputOf <get_macro>,
-                <get_macro.add_three_0>,
-                <get_macro.add_three_0.add_one_0> .
+            ns1:inputOf <get_macro.add_three_0.add_one_0> .
         
         <get_macro.add_three_0.add_two_0.inputs.b> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_one_0.outputs.result.value> ;
             ns1:inheritsPropertiesFrom <get_macro.add_three_0.add_one_0.outputs.result> ;
-            ns1:inputOf <get_macro.add_three_0.add_two_0> ;
-            ns1:outputOf <get_macro.add_three_0.add_one_0> .
+            ns1:inputOf <get_macro.add_three_0.add_two_0> .
         
         <get_macro.outputs.result> a prov:Entity ;
             ns1:hasValue <get_macro.add_one_0.outputs.result.value> ;
             ns1:inheritsPropertiesFrom <get_macro.add_one_0.outputs.result> ;
-            ns1:outputOf <get_macro>,
-                <get_macro.add_one_0> .
+            ns1:outputOf <get_macro> .
         
         <get_macro.add_one_0.outputs.result> a prov:Entity ;
             ns1:hasValue <get_macro.add_one_0.outputs.result.value> ;
@@ -657,14 +651,12 @@ class TestOntology(unittest.TestCase):
         <get_macro.add_three_0.inputs.c> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_one_0.inputs.a.value> ;
             ns1:inheritsPropertiesFrom <get_macro.inputs.c> ;
-            ns1:inputOf <get_macro>,
-                <get_macro.add_three_0> .
+            ns1:inputOf <get_macro.add_three_0> .
         
         <get_macro.add_three_0.outputs.w> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_two_0.outputs.result.value> ;
             ns1:inheritsPropertiesFrom <get_macro.add_three_0.add_two_0.outputs.result> ;
-            ns1:outputOf <get_macro.add_three_0>,
-                <get_macro.add_three_0.add_two_0> .
+            ns1:outputOf <get_macro.add_three_0> .
         
         <get_macro.inputs.c> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_one_0.inputs.a.value> ;


### PR DESCRIPTION
Don't inherit topological properties `inputOf` and `outputOf` when you `inheritsProperties`.

@samwaseda, this makes a lot of sense to me -- it feels rational that an input of a node should only ever be an input of that node, never an output of anyone, and not an input of anyone else, regardless of who it's connected to. However, I created the bug in the first place, so I may be missing something critical.

Closes #244 