### PR TITLE
Accommodate restrictions

### DIFF
--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -294,16 +294,16 @@ def _check_connections(graph: Graph, strict_typing: bool = False) -> list:
         (list): list of incompatible connections
     """
     incompatible_types = []
-    for inp_out in graph.subject_objects(SNS.inheritsPropertiesFrom):
+    for (inp, out) in graph.subject_objects(SNS.inheritsPropertiesFrom):
         i_type, o_type = [
             [g for g in graph.objects(tag, RDF.type) if g != PROV.Entity]
-            for tag in inp_out
+            for tag in (inp, out)
         ]
         if not strict_typing and (i_type == [] or o_type == []):
             continue
         diff = set(i_type).difference(o_type)
         if len(diff) > 0:
-            incompatible_types.append(inp_out + (i_type, o_type))
+            incompatible_types.append((inp, out) + (i_type, o_type))
     return incompatible_types
 
 

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -279,7 +279,7 @@ def _check_missing_triples(graph: Graph) -> list:
             ?instance ?onProperty ?someValuesFrom .
         }
     }"""
-    return list(graph.query(query))
+    return list(set(graph.query(query)))
 
 
 def _check_connections(graph: Graph, strict_typing: bool = False) -> list:
@@ -299,9 +299,20 @@ def _check_connections(graph: Graph, strict_typing: bool = False) -> list:
             [g for g in graph.objects(tag, RDF.type) if g != PROV.Entity]
             for tag in (inp, out)
         ]
-        if not strict_typing and (i_type == [] or o_type == []):
+        # Exclude any i_type that is an OWL restriction or a subclass of OWL.Restriction
+        # (What about SH restrictions?)
+        # This is because we handle restrictions in _check_missing_triples
+        i_type_filtered = [
+            t
+            for t in i_type
+            if (
+                (t, RDFS.subClassOf, OWL.Restriction) not in graph
+                and (t, RDF.type, OWL.Restriction) not in graph
+            )
+        ]
+        if not strict_typing and (i_type_filtered == [] or o_type == []):
             continue
-        diff = set(i_type).difference(o_type)
+        diff = set(i_type_filtered).difference(o_type)
         if len(diff) > 0:
             incompatible_types.append((inp, out) + (i_type, o_type))
     return incompatible_types

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -308,6 +308,8 @@ def _check_connections(graph: Graph, strict_typing: bool = False) -> list:
             if (
                 (t, RDFS.subClassOf, OWL.Restriction) not in graph
                 and (t, RDF.type, OWL.Restriction) not in graph
+                and (t, RDFS.subClassOf, SH.NodeShape) not in graph
+                and (t, RDF.type, SH.NodeShape) not in graph
             )
         ]
         if not strict_typing and (i_type_filtered == [] or o_type == []):

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -248,6 +248,8 @@ def _inherit_properties(
         FILTER(?p != rdfs:label)
         FILTER(?p != rdf:value)
         FILTER(?p != ns:hasValue)
+        FILTER(?p != ns:inputOf)
+        FILTER(?p != ns:outputOf)
         FILTER(?p != owl:sameAs)
     }}
     """

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -232,30 +232,30 @@ def _parse_triple(
 def _inherit_properties(
     graph: Graph, triples_to_cancel: list | None = None, n_max: int = 1000, ontology=SNS
 ):
-    update_query = (
-        f"PREFIX ns: <{ontology.BASE}>",
-        f"PREFIX rdfs: <{RDFS}>",
-        f"PREFIX rdf: <{RDF}>",
-        f"PREFIX owl: <{OWL}>",
-        "",
-        "INSERT {",
-        "    ?subject ?p ?o .",
-        "}",
-        "WHERE {",
-        "    ?subject ns:inheritsPropertiesFrom ?target .",
-        "    ?target ?p ?o .",
-        "    FILTER(?p != ns:inheritsPropertiesFrom)",
-        "    FILTER(?p != rdfs:label)",
-        "    FILTER(?p != rdf:value)",
-        "    FILTER(?p != ns:hasValue)",
-        "    FILTER(?p != owl:sameAs)",
-        "}",
-    )
+    update_query = f"""\
+    PREFIX ns: <{ontology.BASE}>
+    PREFIX rdfs: <{RDFS}>
+    PREFIX rdf: <{RDF}>
+    PREFIX owl: <{OWL}>
+    
+    INSERT {{
+        ?subject ?p ?o .
+    }}
+    WHERE {{
+        ?subject ns:inheritsPropertiesFrom ?target .
+        ?target ?p ?o .
+        FILTER(?p != ns:inheritsPropertiesFrom)
+        FILTER(?p != rdfs:label)
+        FILTER(?p != rdf:value)
+        FILTER(?p != ns:hasValue)
+        FILTER(?p != owl:sameAs)
+    }}
+    """
     if triples_to_cancel is None:
         triples_to_cancel = []
     n = 0
     for _ in range(n_max):
-        graph.update("\n".join(update_query))
+        graph.update(update_query)
         for t in triples_to_cancel:
             if t in graph:
                 graph.remove(t)

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -294,7 +294,7 @@ def _check_connections(graph: Graph, strict_typing: bool = False) -> list:
         (list): list of incompatible connections
     """
     incompatible_types = []
-    for (inp, out) in graph.subject_objects(SNS.inheritsPropertiesFrom):
+    for inp, out in graph.subject_objects(SNS.inheritsPropertiesFrom):
         i_type, o_type = [
             [g for g in graph.objects(tag, RDF.type) if g != PROV.Entity]
             for tag in (inp, out)

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -292,7 +292,7 @@ class Foo: ...
 
 
 def upstream(
-    foo: u(Foo, uri=EX.Foo, triples=(EX.alsoHas, EX.Bar))
+    foo: u(Foo, uri=EX.Foo, triples=(EX.alsoHas, EX.Bar)),
 ) -> u(Foo, derived_from="inputs.foo"):
     return foo
 
@@ -598,7 +598,7 @@ class TestOntology(unittest.TestCase):
             self.assertFalse(
                 val["missing_triples"] or val["incompatible_connections"],
                 msg=f"URI specification, restrictions, and derived_from should all play"
-                    f"well together. Expected no validation problems, but got {val}"
+                f"well together. Expected no validation problems, but got {val}",
             )
 
         with self.subTest("Chain steps"):
@@ -607,7 +607,7 @@ class TestOntology(unittest.TestCase):
             self.assertFalse(
                 val["missing_triples"] or val["incompatible_connections"],
                 msg=f"URI specification, restrictions, and derived_from should all play"
-                    f"well together. Expected no validation problems, but got {val}"
+                f"well together. Expected no validation problems, but got {val}",
             )
 
     def test_macro(self):

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -619,28 +619,22 @@ class TestOntology(unittest.TestCase):
         <get_macro.add_one_0.inputs.a> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_two_0.outputs.result.value> ;
             ns1:inheritsPropertiesFrom <get_macro.add_three_0.outputs.w> ;
-            ns1:inputOf <get_macro.add_one_0> ;
-            ns1:outputOf <get_macro.add_three_0>,
-                <get_macro.add_three_0.add_two_0> .
+            ns1:inputOf <get_macro.add_one_0> .
         
         <get_macro.add_three_0.add_one_0.inputs.a> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_one_0.inputs.a.value> ;
             ns1:inheritsPropertiesFrom <get_macro.add_three_0.inputs.c> ;
-            ns1:inputOf <get_macro>,
-                <get_macro.add_three_0>,
-                <get_macro.add_three_0.add_one_0> .
+            ns1:inputOf <get_macro.add_three_0.add_one_0> .
         
         <get_macro.add_three_0.add_two_0.inputs.b> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_one_0.outputs.result.value> ;
             ns1:inheritsPropertiesFrom <get_macro.add_three_0.add_one_0.outputs.result> ;
-            ns1:inputOf <get_macro.add_three_0.add_two_0> ;
-            ns1:outputOf <get_macro.add_three_0.add_one_0> .
+            ns1:inputOf <get_macro.add_three_0.add_two_0> .
         
         <get_macro.outputs.result> a prov:Entity ;
             ns1:hasValue <get_macro.add_one_0.outputs.result.value> ;
             ns1:inheritsPropertiesFrom <get_macro.add_one_0.outputs.result> ;
-            ns1:outputOf <get_macro>,
-                <get_macro.add_one_0> .
+            ns1:outputOf <get_macro> .
         
         <get_macro.add_one_0.outputs.result> a prov:Entity ;
             ns1:hasValue <get_macro.add_one_0.outputs.result.value> ;
@@ -657,14 +651,12 @@ class TestOntology(unittest.TestCase):
         <get_macro.add_three_0.inputs.c> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_one_0.inputs.a.value> ;
             ns1:inheritsPropertiesFrom <get_macro.inputs.c> ;
-            ns1:inputOf <get_macro>,
-                <get_macro.add_three_0> .
+            ns1:inputOf <get_macro.add_three_0> .
         
         <get_macro.add_three_0.outputs.w> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_two_0.outputs.result.value> ;
             ns1:inheritsPropertiesFrom <get_macro.add_three_0.add_two_0.outputs.result> ;
-            ns1:outputOf <get_macro.add_three_0>,
-                <get_macro.add_three_0.add_two_0> .
+            ns1:outputOf <get_macro.add_three_0> .
         
         <get_macro.inputs.c> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_one_0.inputs.a.value> ;

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -288,6 +288,40 @@ def mismatching_peers(x_outer: u(int, uri=EX.Input)) -> u(int, uri=EX.NotOutput)
     return dont_add
 
 
+class Foo: ...
+
+
+def upstream(
+    foo: u(Foo, uri=EX.Foo, triples=(EX.alsoHas, EX.Bar))
+) -> u(Foo, derived_from="inputs.foo"):
+    return foo
+
+
+def downstream(
+    foo: u(
+        Foo,
+        uri=EX.Foo,
+        restrictions=((OWL.onProperty, EX.alsoHas), (OWL.someValuesFrom, EX.Bar)),
+    ),
+) -> u(Foo, derived_from="inputs.foo"):
+    return foo
+
+
+@workflow
+def single(foo: u(Foo, uri=EX.Foo)) -> u(Foo, derived_from="inputs.foo"):
+    up = upstream(foo)
+    dn = downstream(up)
+    return dn
+
+
+@workflow
+def chain(foo: u(Foo, uri=EX.Foo)) -> u(Foo, derived_from="inputs.foo"):
+    up = upstream(foo)
+    dn1 = downstream(up)
+    dn2 = downstream(dn1)
+    return dn2
+
+
 class TestOntology(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -555,6 +589,25 @@ class TestOntology(unittest.TestCase):
                 val["incompatible_connections"],
                 [],
                 msg="Downstream having a narrower type than upstream is fine",
+            )
+
+    def test_uri_restrictions_derived_from_interaction(self):
+        with self.subTest("Single step"):
+            graph = get_knowledge_graph(single._semantikon_workflow)
+            val = validate_values(graph)
+            self.assertFalse(
+                val["missing_triples"] or val["incompatible_connections"],
+                msg=f"URI specification, restrictions, and derived_from should all play"
+                    f"well together. Expected no validation problems, but got {val}"
+            )
+
+        with self.subTest("Chain steps"):
+            graph = get_knowledge_graph(chain._semantikon_workflow)
+            val = validate_values(graph)
+            self.assertFalse(
+                val["missing_triples"] or val["incompatible_connections"],
+                msg=f"URI specification, restrictions, and derived_from should all play"
+                    f"well together. Expected no validation problems, but got {val}"
             )
 
     def test_macro(self):


### PR DESCRIPTION
When checking validity, in `_check_connections`, we see if the downstream input has any `rdflib.RDF.type` fields that are not included in the upstream types. Here, I exclude all downstream types inheriting from `OWL.Restriction`, since we instead handle such restrictions in `_check_missing_triples`.

For the clothing example, this solves my problems and

```python
# Chain together restrictions and inheritance and restrictions
import rdflib

from semantikon import ontology as onto
from semantikon import workflow
from semantikon.metadata import u

EX = rdflib.Namespace("http://www.example.org/")

class Clothes:
    pass

def wash(clothes: Clothes) -> u(
    Clothes,
    uri=EX.Clothes,
    triples=(EX.hasProperty, EX.cleaned),
    derived_from="inputs.clothes"
):
    ...
    return clothes

def dye(clothes: Clothes, color="blue") -> u(
    Clothes,
    uri=EX.Clothes,
    triples=(EX.hasProperty, EX.color),
    derived_from="inputs.clothes",
):
    ...
    return clothes

def sell(
    clothes: u(
        Clothes,
        uri=EX.Clothes,
        restrictions=(
            ((rdflib.OWL.onProperty, EX.hasProperty), (rdflib.OWL.someValuesFrom, EX.cleaned)),
            ((rdflib.OWL.onProperty, EX.hasProperty), (rdflib.OWL.someValuesFrom, EX.color))
        )
    )
) -> u(Clothes, derived_from="inputs.clothes"):  # int
    ...
    return clothes

def my_correct_workflow(clothes: Clothes) -> Clothes:
    dyed_clothes = dye(clothes)
    washed_clothes = wash(dyed_clothes)
    money = sell(washed_clothes)
    more_money = sell(money)
    return more_money

wf_dict = workflow.get_workflow_dict(my_correct_workflow)
graph = onto.get_knowledge_graph(wf_dict)
validity = onto.validate_values(graph)
validity
```

Validates fine, while if we comment out, say `triples=(EX.hasProperty, EX.cleaned),`, then the validity (correctly) fails due to a bunch of missing triples.

Thus, with #241 and this together, output that `derives_from=` the input (correctly!) captures that inputs `uri=` (and other types), _and_ we can combine `uri=` with `restrictions=`.

However, I'm still not super happy with this. First, this attack is still glaringly missing `SH`-based (instead of `OWL`-based) restrictions. But even more fundamentally, I find it quite uncomfortable that `triples=(EX.hasProperty, EX.cleaned)` doesn't impact the `RDF.type` set at all, and yet it satisfies `restrictions=((rdflib.OWL.onProperty, EX.hasProperty), (rdflib.OWL.someValuesFrom, EX.cleaned))`, which has all these extra terms and _does_ modify the set of types! So this gets the behaviour I want, but in a way that makes me uncomfortable. With that said, this is a complicated thing and I am not sure I have a better answer right now.

@samwaseda could you take a critical look at this attack and tell me what you think?