### PR TITLE
`fulfills` predicate as a counterpart to `wasDerivedFrom`

### DIFF
--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -328,9 +328,7 @@ def _check_connections(graph: Graph, strict_typing: bool = False) -> list:
     return incompatible_types
 
 
-def _query_meaning(
-    graph: Graph, subject: rdflib.term.Node, ontology=SNS
-):
+def _query_meaning(graph: Graph, subject: rdflib.term.Node, ontology=SNS):
     query = f"""\
         PREFIX ns: <{ontology.BASE}>
         PREFIX prov: <{PROV}>
@@ -392,9 +390,7 @@ def validate_values(
         "incompatible_connections": _check_connections(
             graph, strict_typing=strict_typing
         ),
-        "broken_promises": _check_fulfillment(
-            graph, strict_typing=strict_typing
-        )
+        "broken_promises": _check_fulfillment(graph, strict_typing=strict_typing),
     }
 
 

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -18,6 +18,7 @@ class SNS:
     inputOf: URIRef = BASE["inputOf"]
     outputOf: URIRef = BASE["outputOf"]
     hasValue: URIRef = BASE["hasValue"]
+    fulfills: URIRef = BASE["fulfills"]
 
 
 class NS:
@@ -250,6 +251,7 @@ def _inherit_properties(
         FILTER(?p != ns:hasValue)
         FILTER(?p != ns:inputOf)
         FILTER(?p != ns:outputOf)
+        FILTER(?p != ns:fulfills)
         FILTER(?p != owl:sameAs)
     }}
     """

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -58,7 +58,7 @@ def multiply(a: float, b: float) -> u(
     return a * b
 
 
-def correct_analysis(
+def correct_analysis_owl(
     a: u(
         float,
         restrictions=(
@@ -70,7 +70,7 @@ def correct_analysis(
     return a
 
 
-def wrong_analysis(
+def wrong_analysis_owl(
     a: u(
         float,
         restrictions=(
@@ -157,18 +157,18 @@ def get_vacancy_formation_energy(
 
 
 @workflow
-def get_correct_analysis(a=1.0, b=2.0, c=3.0):
+def get_correct_analysis_owl(a=1.0, b=2.0, c=3.0):
     d = add(a=a, b=b)
     m = multiply(a=d, b=c)
-    analysis = correct_analysis(a=m)
+    analysis = correct_analysis_owl(a=m)
     return analysis
 
 
 @workflow
-def get_wrong_analysis(a=1.0, b=2.0, c=3.0):
+def get_wrong_analysis_owl(a=1.0, b=2.0, c=3.0):
     d = add(a=a, b=b)
     m = multiply(a=d, b=c)
-    analysis = wrong_analysis(a=m)
+    analysis = wrong_analysis_owl(a=m)
     return analysis
 
 
@@ -342,15 +342,15 @@ class TestOntology(unittest.TestCase):
         self.assertTrue((subj, EX.predicate, label) in graph)
         self.assertTrue((label, EX.predicate, obj) in graph)
 
-    def test_correct_analysis(self):
-        graph = get_knowledge_graph(get_correct_analysis._semantikon_workflow)
+    def test_correct_analysis_owl(self):
+        graph = get_knowledge_graph(get_correct_analysis_owl._semantikon_workflow)
         t = validate_values(graph)
         self.assertEqual(
             t["missing_triples"],
             [],
             msg=f"{t} missing in {graph.serialize()}",
         )
-        graph = get_knowledge_graph(get_wrong_analysis._semantikon_workflow)
+        graph = get_knowledge_graph(get_wrong_analysis_owl._semantikon_workflow)
         self.assertEqual(len(validate_values(graph)["missing_triples"]), 1)
 
     def test_correct_analysis_sh(self):
@@ -759,12 +759,12 @@ class TestOntology(unittest.TestCase):
         self.assertIsInstance(visualize(graph), Digraph)
 
     def test_function_referencing(self):
-        graph = get_knowledge_graph(get_correct_analysis._semantikon_workflow)
+        graph = get_knowledge_graph(get_correct_analysis_owl._semantikon_workflow)
         self.assertEqual(
             list(graph.subject_objects(PROV.wasGeneratedBy))[0],
             (
-                URIRef("get_correct_analysis.add_0.inputs.a"),
-                URIRef("get_correct_analysis.add_0"),
+                URIRef("get_correct_analysis_owl.add_0.inputs.a"),
+                URIRef("get_correct_analysis_owl.add_0"),
             ),
         )
 

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -58,6 +58,14 @@ def multiply(a: float, b: float) -> u(
     return a * b
 
 
+def correct_analysis(a: u(float, triples=(EX.HasOperation, EX.Addition))) -> float:
+    return a
+
+
+def wrong_analysis(a: u(float, triples=(EX.HasOperation, EX.Division))) -> float:
+    return a
+
+
 def correct_analysis_owl(
     a: u(
         float,
@@ -154,6 +162,22 @@ def get_vacancy_formation_energy(
     ),
 ):
     return len(structure)
+
+
+@workflow
+def get_correct_analysis(a=1.0, b=2.0, c=3.0):
+    d = add(a=a, b=b)
+    m = multiply(a=d, b=c)
+    analysis = correct_analysis(a=m)
+    return analysis
+
+
+@workflow
+def get_wrong_analysis(a=1.0, b=2.0, c=3.0):
+    d = add(a=a, b=b)
+    m = multiply(a=d, b=c)
+    analysis = wrong_analysis(a=m)
+    return analysis
 
 
 @workflow
@@ -341,6 +365,16 @@ class TestOntology(unittest.TestCase):
         self.assertTrue((EX.subject, EX.predicate, EX.object) in graph)
         self.assertTrue((subj, EX.predicate, label) in graph)
         self.assertTrue((label, EX.predicate, obj) in graph)
+
+    def test_correct_analysis(self):
+        graph = get_knowledge_graph(get_correct_analysis._semantikon_workflow)
+        t = validate_values(graph)
+        self.assertFalse(
+            t["broken_promises"],
+            msg=f"{t["broken_promises"]} expected to be empty in {graph.serialize()}",
+        )
+        graph = get_knowledge_graph(get_wrong_analysis_owl._semantikon_workflow)
+        self.assertEqual(len(validate_values(graph)["broken_promises"]), 1)
 
     def test_correct_analysis_owl(self):
         graph = get_knowledge_graph(get_correct_analysis_owl._semantikon_workflow)

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -399,7 +399,7 @@ class TestOntology(unittest.TestCase):
         t = validate_values(graph)
         self.assertFalse(
             t["broken_promises"],
-            msg=f"{t["broken_promises"]} expected to be empty in {graph.serialize()}",
+            msg=f"{t['broken_promises']} expected to be empty in {graph.serialize()}",
         )
         graph = get_knowledge_graph(get_wrong_analysis_owl._semantikon_workflow)
         self.assertEqual(len(validate_values(graph)["broken_promises"]), 1)

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -638,29 +638,35 @@ class TestOntology(unittest.TestCase):
         
         <get_macro.add_one_0.outputs.result> a prov:Entity ;
             ns1:hasValue <get_macro.add_one_0.outputs.result.value> ;
-            ns1:outputOf <get_macro.add_one_0> .
+            ns1:outputOf <get_macro.add_one_0> ;
+            ns1:fulfills <get_macro.outputs.result> .
         
         <get_macro.add_three_0.add_one_0.outputs.result> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_one_0.outputs.result.value> ;
-            ns1:outputOf <get_macro.add_three_0.add_one_0> .
+            ns1:outputOf <get_macro.add_three_0.add_one_0> ;
+            ns1:fulfills <get_macro.add_three_0.add_two_0.inputs.b> .
         
         <get_macro.add_three_0.add_two_0.outputs.result> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_two_0.outputs.result.value> ;
-            ns1:outputOf <get_macro.add_three_0.add_two_0> .
+            ns1:outputOf <get_macro.add_three_0.add_two_0> ;
+            ns1:fulfills <get_macro.add_three_0.outputs.w> .
         
         <get_macro.add_three_0.inputs.c> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_one_0.inputs.a.value> ;
             prov:wasDerivedFrom <get_macro.inputs.c> ;
-            ns1:inputOf <get_macro.add_three_0> .
+            ns1:inputOf <get_macro.add_three_0> ;
+            ns1:fulfills <get_macro.add_three_0.add_one_0.inputs.a> .
         
         <get_macro.add_three_0.outputs.w> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_two_0.outputs.result.value> ;
             prov:wasDerivedFrom <get_macro.add_three_0.add_two_0.outputs.result> ;
-            ns1:outputOf <get_macro.add_three_0> .
+            ns1:outputOf <get_macro.add_three_0> ;
+            ns1:fulfills <get_macro.add_one_0.inputs.a> .
         
         <get_macro.inputs.c> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_one_0.inputs.a.value> ;
-            ns1:inputOf <get_macro> .
+            ns1:inputOf <get_macro> ;
+            ns1:fulfills <get_macro.add_three_0.inputs.c> .
         
         <get_macro.add_one_0.outputs.result.value> rdf:value 5 .
         


### PR DESCRIPTION
Thinking through a bunch of the challenges in #247, with particular weight on the ideas in [@samwaseda's comment](https://github.com/pyiron/semantikon/pull/247#issuecomment-3222971518) about inter- vs intra-node ontological connections and the idea of an additional predicate, I try here to introduce a new `sns:fulfills` predicate.

This rests on two key concepts. The first is the hypothesis that we can split apart "true"[^1] and "bookkeeping" ontological information. I'm not confident enough in my ontology experience to be confident that this is without failing edge cases, but it's drawn from `ontology._inherit_properties`, which has been pretty successful so far. The idea there is to filter out all the junk we've added in, and leave only ontological information that the user is actually trying to add to their workflows. (Cf. also #244.) 
  I think this is worth highlighting since this is a potential failure point, but it's really super simple: we're just writing an explicit list of terms to exclude when comparing the sets of triples defining two entities.

[^1]: Or "interesting", whatever. The point is they're the ones we care about that the user has indicated matter.

The second is that we can break apart the concept of `prov:wasDerivedFrom` ensuring that ontological information gets carried from upstream to downstream, and the concept that the connections carrying that information may or may not be valid depending on the annotations of the partners in the connection, their context, and the direction the flow of information. [@samwaseda's comment](https://github.com/pyiron/semantikon/pull/247#issuecomment-3222971518) is the canonical example here. 
  What we need is to re-pose the `pyiron_workflow` concept of [type_hint_is_as_or_more_specific_than](https://github.com/pyiron/pyiron_workflow/blob/dc22e3555d5029ee7fc545fb70d43a3aca5c9bd0/pyiron_workflow/type_hinting.py#L62), but for ontologies. For this, I introduced the new predicate `SNS.fulfills`. 
  For inter-node connections, fulfillment and inheritance run opposite[^2] each other: `(upstream, SNS.fulfills, downstream)` and `(downstream, PROV.wasDerivedFrom, upstream)`. I.e., we should guarantee that downstream carries all the information from upstream (derivation) and that downstream doesn't require anything missing from that upstream inheritance (i.e. fulfillment, or upstream is as-or-more-specific-than downstream). 
  For intra-node connections, fulfillment and inheritance run together:  `(downstream, SNS.fulfills, upstream)` and `(downstream, PROV.wasDerivedFrom, upstream)`. I.e., the output of a node that derives from some input field should (unless a cancellation is explicitly noted) carry all the information of the upstream partner _and_ it is free to add additional information.

[^2]: Or this is running in the same direction and intra-nodal connections run opposite. I don't care, the point is just that there is a polarity difference between inter- and intra-nodal connections.

Putting these two together, if `(a, PROV.wasDerivedFrom, b)`, then we want to copy over all the "true" triples from `b` to `a`; if `(c, SNS.fulfills, d)`, then the "true" triples of `d` are a strict subset of the "true" triples of `c`. In this way we propagate information and can validate types without (necessarily) worrying about `restrictions=` or the extra restrictions classes (although we still need `cancel=`).

As of 9d5c1fc060bddd7dd4fea6357c6b9eaf676e0165, I've implemented this fully in parallel to the restrictions approach. That means all the tests are still running (with the changes in #247), and the only difference is that `ontology.validate_values` includes an extra field for parsing if we've broken any `SNS.fulfills` promises.

Critical to check here, but I haven't gotten to:
- Work with `cancel` to allow intra-node connections to _remove_ information vis-a-vis what they `PROV.wasDerivedFrom`
- Check that explicit user restrictions, like `OWL.disjointWith` or a `OWL.Restriction` still result in a validation failure

With that, I wanted to revisit my example from [this comment](https://github.com/pyiron/semantikon/pull/247#issuecomment-3224511243) to demonstrate how the new attack presently[^3] looks.

[^3]: 9d5c1fc060bddd7dd4fea6357c6b9eaf676e0165

## The original way with restrictions

With restrictions, we would write

```python
import rdflib

from semantikon import ontology as onto
from semantikon import workflow
from semantikon.metadata import u

EX = rdflib.Namespace("http://www.example.org/")

class Person: ...

def mutate(hero: u(Person, uri=EX.Hero)) -> u(
    Person,
    derived_from="inputs.hero",
    triples=(EX.hasPower, EX.SuperStrength),
):
    return hero

def train(trainee: u(
        Person,
        uri=EX.Hero,
        restrictions=(
            (
                (rdflib.OWL.onProperty, EX.hasPower),
                (rdflib.OWL.someValuesFrom, EX.SuperStrength)
            ),
        ),
    )
) -> u(
    Person,
    derived_from="inputs.trainee",
    triples=(EX.hasPower, EX.SuperSpeed),
):
    return trainee

def battle(challenger: u(
        Person,
        uri=EX.Hero,
        restrictions=(
            (
                (rdflib.OWL.onProperty, EX.hasPower),
                (rdflib.OWL.someValuesFrom, EX.SuperStrength)
            ),
            (
                (rdflib.OWL.onProperty, EX.hasPower),
                (rdflib.OWL.someValuesFrom, EX.SuperSpeed)
            )
        )
    )
):
    return "Victory!"

def video_game(character):
    protagonist = mutate(character)
    hero = train(protagonist)
    outcome = battle(hero)
    return outcome

wf_dict = workflow.get_workflow_dict(video_game)
graph = onto.get_knowledge_graph(wf_dict)
validity = onto.validate_values(graph)
validity
>>> {'missing_triples': [],
...  'incompatible_connections': [],
...  'broken_promises': {rdflib.term.URIRef('video_game.mutate_0.outputs.hero'): 
... (rdflib.term.URIRef('video_game.train_0.inputs.trainee'),
...    {(rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
...      rdflib.term.URIRef('N2adc791ac25c4950ae927729262e0200')),
...     (rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
...      rdflib.term.URIRef('N886e6081649e419cb843187e3a6cd8d3'))}),
...   rdflib.term.URIRef('video_game.train_0.outputs.trainee'): ...
...  ....
```

We've been correctly using restrictions, so there are no "incompatible connections", but the current restricitons setup runs around introducing new `RDF.type` to our entities, so the fulfillment validation complains left, right, and center. That's not so important, although I do want to take a moment to highlight the dictionary `fulfiller: (fulfilled, (unfulfilled predictate-object))` format for the problems, which I think has improved readability compared to "incompatible_connections" list approach.

## The new way for fulfillment promises

```python
import rdflib

from semantikon import ontology as onto
from semantikon import workflow
from semantikon.metadata import u

EX = rdflib.Namespace("http://www.example.org/")

class Person: ...

def mutate(hero: u(Person, uri=EX.Hero)) -> u(
    Person,
    derived_from="inputs.hero",
    triples=(EX.hasPower, EX.SuperStrength),
):
    return hero

def train(trainee: u(
        Person,
        uri=EX.Hero,
        triples=(EX.hasPower, EX.SuperStrength),
    )
) -> u(
    Person,
    derived_from="inputs.trainee",
    triples=(EX.hasPower, EX.SuperSpeed),
):
    return trainee

def battle(challenger: u(
        Person,
        uri=EX.Hero,
        triples=(
            (EX.hasPower, EX.SuperStrength),
            (EX.hasPower, EX.SuperSpeed),
        )
    )
):
    return "Victory!"

def video_game(character):
    protagonist = mutate(character)
    hero = train(protagonist)
    outcome = battle(hero)
    return outcome

wf_dict = workflow.get_workflow_dict(video_game)
graph = onto.get_knowledge_graph(wf_dict)
validity = onto.validate_values(graph)
validity
>>> {'missing_triples': [], 'incompatible_connections': [], 'broken_promises': {}}
```

IMO this is easier to work with than the restrictions. I always found it very confusing that if my upstream `(EX.hasPower, EX.SuperStrength)`, then my downstream needed to guarantee that it had a property `EX.hasPower` with "some values from" `EX.SuperStrength`. Now, if my input wants the triple `(EX.hasPower, EX.SuperStrength)`, then my upstream had better have that!

Note how `train` demands `(EX.hasPower, EX.SuperStrength)` for its input, inherits from that input, adds the triple `(EX.hasPower, EX.SuperSpeed)`, and consequently has both at output.

Suppose now that we go in and modify `train` so it doesn't add this extra triple:

```python
def train(trainee: u(
        Person,
        uri=EX.Hero,
        triples=(EX.hasPower, EX.SuperStrength),
    )
) -> u(
    Person,
    derived_from="inputs.trainee",
    # triples=(EX.hasPower, EX.SuperSpeed),
):
    return trainee
```

In this case our validation comes out as 

```python
{
    "missing_triples": [],
    "incompatible_connections": [],
    "broken_promises": {
        rdflib.term.URIRef("video_game.train_0.outputs.trainee"): (
            rdflib.term.URIRef("video_game.battle_0.inputs.challenger"),
            {
                (
                    rdflib.term.URIRef("http://www.example.org/hasPower"),
                    rdflib.term.URIRef("http://www.example.org/SuperSpeed"),
                )
            },
        )
    },
}
```

I'm not worried that "incompatible_connections" is empty -- that needs restrictions and we haven't provided those --  but we see exactly what we want for the fulfillment: the output of `train` is missing `SuperSpeed` for the input of `battle`!

I'll push more examples and edge cases to see if this has any nasty failure points, but so far I'm pretty happy and optimistic. I'm looking forward to your feedback, @samwaseda 