### PR TITLE
Introduce `sns:linksTo` to split `prov:wasDerivedBy`

### DIFF
--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -369,7 +369,7 @@ def validate_values(
     return {
         "missing_triples": _check_missing_triples(graph),
         "incompatible_connections": _check_connections(
-            graph, strict_typing=strict_typing
+            graph, strict_typing=strict_typing, ontology=ontology
         ),
         "distinct_units": _check_units(graph, ontology=ontology),
     }
@@ -500,7 +500,7 @@ def _parse_workflow(
         for label, content in channel_dict.items()
         for triple in _parse_channel(content, label, full_edge_dict, ontology)
     ]
-    triples.extend(_edges_to_triples(_get_edge_dict(edge_list)))
+    triples.extend(_edges_to_triples(_get_edge_dict(edge_list), ontology=ontology))
 
     for key, node in node_dict.items():
         triples.append((key, RDF.type, PROV.Activity))

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -270,11 +270,11 @@ def _inherit_properties(
         triples_to_cancel = []
     n = 0
     for _ in range(n_max):
-        graph.update(prov_query)
-        graph.update(link_query)
-        for t in triples_to_cancel:
-            if t in graph:
-                graph.remove(t)
+        for query in [prov_query, link_query]:
+            graph.update(query)
+            for t in triples_to_cancel:
+                if t in graph:
+                    graph.remove(t)
         if len(graph) == n:
             break
         n = len(graph)
@@ -308,7 +308,7 @@ def _check_connections(graph: Graph, strict_typing: bool = False) -> list:
         (list): list of incompatible connections
     """
     incompatible_types = []
-    for inp, out in graph.subject_objects(PROV.wasDerivedFrom):
+    for out, inp in graph.subject_objects(SNS.linksTo):
         i_type, o_type = [
             [g for g in graph.objects(tag, RDF.type) if g != PROV.Entity]
             for tag in (inp, out)

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -1,13 +1,13 @@
 import warnings
 from collections import defaultdict
 from dataclasses import is_dataclass
+from string import Template
 from typing import Any, Callable, TypeAlias, cast
 
 import rdflib.term
 from owlrl import DeductiveClosure, OWLRL_Semantics
 from rdflib import OWL, PROV, RDF, RDFS, SH, BNode, Graph, Literal, Namespace, URIRef
 from rdflib.term import IdentifiedNode
-from string import Template
 
 from semantikon.converter import get_function_dict, meta_to_dict
 from semantikon.qudt import UnitsDict
@@ -235,7 +235,8 @@ def _parse_triple(
 def _inherit_properties(
     graph: Graph, triples_to_cancel: list | None = None, n_max: int = 1000, ontology=SNS
 ):
-    update_query = Template(f"""\
+    update_query = Template(
+        f"""\
     PREFIX ns: <{ontology.BASE}>
     PREFIX prov: <{PROV}>
     PREFIX rdfs: <{RDFS}>
@@ -258,10 +259,9 @@ def _inherit_properties(
         FILTER(?p != ns:linksTo)
         FILTER(?p != owl:sameAs)
     }}
-    """)
-    prov_query = update_query.substitute(
-        line="?subject prov:wasDerivedFrom ?target ."
+    """
     )
+    prov_query = update_query.substitute(line="?subject prov:wasDerivedFrom ?target .")
     link_query = update_query.substitute(line="?target ns:linksTo ?subject .")
     if triples_to_cancel is None:
         triples_to_cancel = []
@@ -481,7 +481,10 @@ def _dot(*args) -> str:
 
 
 def _edges_to_triples(edges: dict, ontology=SNS) -> list:
-    return [(upstream, ontology.linksTo, downstream) for downstream, upstream in edges.items()]
+    return [
+        (upstream, ontology.linksTo, downstream)
+        for downstream, upstream in edges.items()
+    ]
 
 
 def _parse_workflow(

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -314,7 +314,6 @@ def _check_connections(graph: Graph, strict_typing: bool = False, ontology=SNS) 
             for tag in (inp, out)
         ]
         # Exclude any i_type that is an OWL restriction or a subclass of OWL.Restriction
-        # (What about SH restrictions?)
         # This is because we handle restrictions in _check_missing_triples
         i_type_filtered = [
             t

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -251,21 +251,18 @@ def _inherit_properties(
         FILTER(?p != prov:wasDerivedFrom)
         FILTER(?p != rdfs:label)
         FILTER(?p != rdf:value)
+        FILTER(?p != rdf:type)
         FILTER(?p != ns:hasValue)
         FILTER(?p != ns:inputOf)
         FILTER(?p != ns:outputOf)
         FILTER(?p != ns:linksTo)
         FILTER(?p != owl:sameAs)
-        $additiona_filter
     }}
     """)
     prov_query = update_query.substitute(
-        line="?subject prov:wasDerivedFrom ?target .", additiona_filter=""
+        line="?subject prov:wasDerivedFrom ?target ."
     )
-    link_query = update_query.substitute(
-        line="?target ns:linksTo ?subject .",
-        additiona_filter="FILTER(?o != rdf:type)",
-    )
+    link_query = update_query.substitute(line="?target ns:linksTo ?subject .")
     if triples_to_cancel is None:
         triples_to_cancel = []
     n = 0

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -4,7 +4,6 @@ from dataclasses import is_dataclass
 from string import Template
 from typing import Any, Callable, TypeAlias, cast
 
-import rdflib.term
 from owlrl import DeductiveClosure, OWLRL_Semantics
 from rdflib import OWL, PROV, RDF, RDFS, SH, BNode, Graph, Literal, Namespace, URIRef
 from rdflib.term import IdentifiedNode

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -328,9 +328,7 @@ def _check_connections(graph: Graph, strict_typing: bool = False) -> list:
     return incompatible_types
 
 
-def _query_meaning(
-    graph: Graph, subject: rdflib.term.Node, ontology=SNS
-):
+def _query_meaning(graph: Graph, subject: rdflib.term.Node, ontology=SNS):
     query = f"""\
         PREFIX ns: <{ontology.BASE}>
         PREFIX prov: <{PROV}>
@@ -392,9 +390,7 @@ def validate_values(
         "incompatible_connections": _check_connections(
             graph, strict_typing=strict_typing
         ),
-        "broken_promises": _check_fulfillment(
-            graph, strict_typing=strict_typing
-        )
+        "broken_promises": _check_fulfillment(graph, strict_typing=strict_typing),
     }
 
 

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -296,7 +296,7 @@ def _check_missing_triples(graph: Graph) -> list:
     return list(set(graph.query(query)))
 
 
-def _check_connections(graph: Graph, strict_typing: bool = False) -> list:
+def _check_connections(graph: Graph, strict_typing: bool = False, ontology=SNS) -> list:
     """
     Check if the connections between inputs and outputs are compatible
 
@@ -308,7 +308,7 @@ def _check_connections(graph: Graph, strict_typing: bool = False) -> list:
         (list): list of incompatible connections
     """
     incompatible_types = []
-    for out, inp in graph.subject_objects(SNS.linksTo):
+    for out, inp in graph.subject_objects(ontology.linksTo):
         i_type, o_type = [
             [g for g in graph.objects(tag, RDF.type) if g != PROV.Entity]
             for tag in (inp, out)
@@ -484,11 +484,8 @@ def _dot(*args) -> str:
     return ".".join([a for a in args if a is not None])
 
 
-def _edges_to_triples(edges: dict) -> list:
-    triples = []
-    for downstream, upstream in edges.items():
-        triples.append((upstream, SNS.linksTo, downstream))
-    return triples
+def _edges_to_triples(edges: dict, ontology=SNS) -> list:
+    return [(upstream, ontology.linksTo, downstream) for downstream, upstream in edges.items()]
 
 
 def _parse_workflow(

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -18,6 +18,7 @@ class SNS:
     inputOf: URIRef = BASE["inputOf"]
     outputOf: URIRef = BASE["outputOf"]
     hasValue: URIRef = BASE["hasValue"]
+    fulfills: URIRef = BASE["fulfills"]
 
 
 class NS:
@@ -250,6 +251,7 @@ def _inherit_properties(
         FILTER(?p != ns:hasValue)
         FILTER(?p != ns:inputOf)
         FILTER(?p != ns:outputOf)
+        FILTER(?p != ns:fulfills)
         FILTER(?p != owl:sameAs)
     }}
     """

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -294,7 +294,7 @@ def _check_connections(graph: Graph, strict_typing: bool = False) -> list:
         (list): list of incompatible connections
     """
     incompatible_types = []
-    for (inp, out) in graph.subject_objects(SNS.inheritsPropertiesFrom):
+    for inp, out in graph.subject_objects(SNS.inheritsPropertiesFrom):
         i_type, o_type = [
             [g for g in graph.objects(tag, RDF.type) if g != PROV.Entity]
             for tag in (inp, out)

--- a/semantikon/visualize.py
+++ b/semantikon/visualize.py
@@ -11,6 +11,8 @@ _edge_colors = {
     "sns:outputOf": "darkred",
     "sns:inputOf": "darkorange",
     "sns:hasValue": "brown",
+    "sns:linksTo": "gray",
+    "sns:hasNode": "deeppink",
     "prov:wasDerivedFrom": "purple",
 }
 

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -586,12 +586,7 @@ class TestOntology(unittest.TestCase):
         out_tag = URIRef(
             f"{clothes_wf.__name__}.{machine_wash.__name__}_0.outputs.clothes"
         )
-        out_global_tag = URIRef(
-            f"{clothes_wf.__name__}.outputs.washed"
-        )
-        inp_tag = URIRef(
-            f"{clothes_wf.__name__}.{machine_wash.__name__}_0.inputs.clothes"
-        )
+        out_global_tag = URIRef(f"{clothes_wf.__name__}.outputs.washed")
 
         with self.subTest("Inherit type"):
             graph = get_knowledge_graph(clothes_wf._semantikon_workflow)
@@ -636,7 +631,14 @@ class TestOntology(unittest.TestCase):
             self.assertListEqual(val["missing_triples"], [])
             self.assertListEqual(
                 val["incompatible_connections"],
-                [(out_global_tag, out_tag, [EX.Garment, EX.SomethingElse], [EX.SomethingElse])],
+                [
+                    (
+                        out_global_tag,
+                        out_tag,
+                        [EX.Garment, EX.SomethingElse],
+                        [EX.SomethingElse],
+                    )
+                ],
                 msg="Downstream having a broader type than upstream is disallowed",
             )
 

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -759,55 +759,49 @@ class TestOntology(unittest.TestCase):
         
         <get_macro.add_one_0.inputs.a> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_two_0.outputs.result.value> ;
-            prov:wasDerivedFrom <get_macro.add_three_0.outputs.w> ;
             ns1:inputOf <get_macro.add_one_0> .
         
         <get_macro.add_three_0.add_one_0.inputs.a> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_one_0.inputs.a.value> ;
-            prov:wasDerivedFrom <get_macro.add_three_0.inputs.c> ;
             ns1:inputOf <get_macro.add_three_0.add_one_0> .
         
         <get_macro.add_three_0.add_two_0.inputs.b> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_one_0.outputs.result.value> ;
-            prov:wasDerivedFrom <get_macro.add_three_0.add_one_0.outputs.result> ;
             ns1:inputOf <get_macro.add_three_0.add_two_0> .
         
         <get_macro.outputs.result> a prov:Entity ;
             ns1:hasValue <get_macro.add_one_0.outputs.result.value> ;
-            prov:wasDerivedFrom <get_macro.add_one_0.outputs.result> ;
             ns1:outputOf <get_macro> .
         
         <get_macro.add_one_0.outputs.result> a prov:Entity ;
             ns1:hasValue <get_macro.add_one_0.outputs.result.value> ;
             ns1:outputOf <get_macro.add_one_0> ;
-            ns1:fulfills <get_macro.outputs.result> .
+            ns1:linksTo <get_macro.outputs.result> .
         
         <get_macro.add_three_0.add_one_0.outputs.result> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_one_0.outputs.result.value> ;
             ns1:outputOf <get_macro.add_three_0.add_one_0> ;
-            ns1:fulfills <get_macro.add_three_0.add_two_0.inputs.b> .
+            ns1:linksTo <get_macro.add_three_0.add_two_0.inputs.b> .
         
         <get_macro.add_three_0.add_two_0.outputs.result> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_two_0.outputs.result.value> ;
             ns1:outputOf <get_macro.add_three_0.add_two_0> ;
-            ns1:fulfills <get_macro.add_three_0.outputs.w> .
+            ns1:linksTo <get_macro.add_three_0.outputs.w> .
         
         <get_macro.add_three_0.inputs.c> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_one_0.inputs.a.value> ;
-            prov:wasDerivedFrom <get_macro.inputs.c> ;
             ns1:inputOf <get_macro.add_three_0> ;
-            ns1:fulfills <get_macro.add_three_0.add_one_0.inputs.a> .
+            ns1:linksTo <get_macro.add_three_0.add_one_0.inputs.a> .
         
         <get_macro.add_three_0.outputs.w> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_two_0.outputs.result.value> ;
-            prov:wasDerivedFrom <get_macro.add_three_0.add_two_0.outputs.result> ;
             ns1:outputOf <get_macro.add_three_0> ;
-            ns1:fulfills <get_macro.add_one_0.inputs.a> .
+            ns1:linksTo <get_macro.add_one_0.inputs.a> .
         
         <get_macro.inputs.c> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_one_0.inputs.a.value> ;
             ns1:inputOf <get_macro> ;
-            ns1:fulfills <get_macro.add_three_0.inputs.c> .
+            ns1:linksTo <get_macro.add_three_0.inputs.c> .
         
         <get_macro.add_one_0.outputs.result.value> rdf:value 5 .
         

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -58,7 +58,7 @@ def multiply(a: float, b: float) -> u(
     return a * b
 
 
-def correct_analysis(
+def correct_analysis_owl(
     a: u(
         float,
         restrictions=(
@@ -70,7 +70,7 @@ def correct_analysis(
     return a
 
 
-def wrong_analysis(
+def wrong_analysis_owl(
     a: u(
         float,
         restrictions=(
@@ -157,18 +157,18 @@ def get_vacancy_formation_energy(
 
 
 @workflow
-def get_correct_analysis(a=1.0, b=2.0, c=3.0):
+def get_correct_analysis_owl(a=1.0, b=2.0, c=3.0):
     d = add(a=a, b=b)
     m = multiply(a=d, b=c)
-    analysis = correct_analysis(a=m)
+    analysis = correct_analysis_owl(a=m)
     return analysis
 
 
 @workflow
-def get_wrong_analysis(a=1.0, b=2.0, c=3.0):
+def get_wrong_analysis_owl(a=1.0, b=2.0, c=3.0):
     d = add(a=a, b=b)
     m = multiply(a=d, b=c)
-    analysis = wrong_analysis(a=m)
+    analysis = wrong_analysis_owl(a=m)
     return analysis
 
 
@@ -342,15 +342,15 @@ class TestOntology(unittest.TestCase):
         self.assertTrue((subj, EX.predicate, label) in graph)
         self.assertTrue((label, EX.predicate, obj) in graph)
 
-    def test_correct_analysis(self):
-        graph = get_knowledge_graph(get_correct_analysis._semantikon_workflow)
+    def test_correct_analysis_owl(self):
+        graph = get_knowledge_graph(get_correct_analysis_owl._semantikon_workflow)
         t = validate_values(graph)
         self.assertEqual(
             t["missing_triples"],
             [],
             msg=f"{t} missing in {graph.serialize()}",
         )
-        graph = get_knowledge_graph(get_wrong_analysis._semantikon_workflow)
+        graph = get_knowledge_graph(get_wrong_analysis_owl._semantikon_workflow)
         self.assertEqual(len(validate_values(graph)["missing_triples"]), 1)
 
     def test_correct_analysis_sh(self):
@@ -759,12 +759,12 @@ class TestOntology(unittest.TestCase):
         self.assertIsInstance(visualize(graph), Digraph)
 
     def test_function_referencing(self):
-        graph = get_knowledge_graph(get_correct_analysis._semantikon_workflow)
+        graph = get_knowledge_graph(get_correct_analysis_owl._semantikon_workflow)
         self.assertEqual(
             list(graph.subject_objects(PROV.wasGeneratedBy))[0],
             (
-                URIRef("get_correct_analysis.add_0.inputs.a"),
-                URIRef("get_correct_analysis.add_0"),
+                URIRef("get_correct_analysis_owl.add_0.inputs.a"),
+                URIRef("get_correct_analysis_owl.add_0"),
             ),
         )
 

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -58,6 +58,14 @@ def multiply(a: float, b: float) -> u(
     return a * b
 
 
+def correct_analysis(a: u(float, triples=(EX.HasOperation, EX.Addition))) -> float:
+    return a
+
+
+def wrong_analysis(a: u(float, triples=(EX.HasOperation, EX.Division))) -> float:
+    return a
+
+
 def correct_analysis_owl(
     a: u(
         float,
@@ -154,6 +162,22 @@ def get_vacancy_formation_energy(
     ),
 ):
     return len(structure)
+
+
+@workflow
+def get_correct_analysis(a=1.0, b=2.0, c=3.0):
+    d = add(a=a, b=b)
+    m = multiply(a=d, b=c)
+    analysis = correct_analysis(a=m)
+    return analysis
+
+
+@workflow
+def get_wrong_analysis(a=1.0, b=2.0, c=3.0):
+    d = add(a=a, b=b)
+    m = multiply(a=d, b=c)
+    analysis = wrong_analysis(a=m)
+    return analysis
 
 
 @workflow
@@ -341,6 +365,16 @@ class TestOntology(unittest.TestCase):
         self.assertTrue((EX.subject, EX.predicate, EX.object) in graph)
         self.assertTrue((subj, EX.predicate, label) in graph)
         self.assertTrue((label, EX.predicate, obj) in graph)
+
+    def test_correct_analysis(self):
+        graph = get_knowledge_graph(get_correct_analysis._semantikon_workflow)
+        t = validate_values(graph)
+        self.assertFalse(
+            t["broken_promises"],
+            msg=f"{t["broken_promises"]} expected to be empty in {graph.serialize()}",
+        )
+        graph = get_knowledge_graph(get_wrong_analysis_owl._semantikon_workflow)
+        self.assertEqual(len(validate_values(graph)["broken_promises"]), 1)
 
     def test_correct_analysis_owl(self):
         graph = get_knowledge_graph(get_correct_analysis_owl._semantikon_workflow)

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -399,7 +399,7 @@ class TestOntology(unittest.TestCase):
         t = validate_values(graph)
         self.assertFalse(
             t["broken_promises"],
-            msg=f"{t["broken_promises"]} expected to be empty in {graph.serialize()}",
+            msg=f"{t['broken_promises']} expected to be empty in {graph.serialize()}",
         )
         graph = get_knowledge_graph(get_wrong_analysis_owl._semantikon_workflow)
         self.assertEqual(len(validate_values(graph)["broken_promises"]), 1)

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -457,16 +457,6 @@ class TestOntology(unittest.TestCase):
     def test_correct_analysis(self):
         graph = get_knowledge_graph(get_correct_analysis._semantikon_workflow)
         t = validate_values(graph)
-        self.assertFalse(
-            t["broken_promises"],
-            msg=f"{t['broken_promises']} expected to be empty in {graph.serialize()}",
-        )
-        graph = get_knowledge_graph(get_wrong_analysis_owl._semantikon_workflow)
-        self.assertEqual(len(validate_values(graph)["broken_promises"]), 1)
-
-    def test_correct_analysis_owl(self):
-        graph = get_knowledge_graph(get_correct_analysis_owl._semantikon_workflow)
-        t = validate_values(graph)
         self.assertEqual(
             t["missing_triples"],
             [],
@@ -725,7 +715,7 @@ class TestOntology(unittest.TestCase):
                     URIRef("get_macro." + tag), subj, msg=f"{tag} not in {subj}"
                 )
         inherits_from = [
-            (str(g[0]), str(g[1])) for g in graph.subject_objects(PROV.wasDerivedFrom)
+            (str(g[1]), str(g[0])) for g in graph.subject_objects(SNS.linksTo)
         ]
         get_macro_io_passing = 2
         get_three_io_passing = 2
@@ -875,36 +865,6 @@ class TestOntology(unittest.TestCase):
                 ]
             ],
         )
-
-    def test_cancel_and_fulfills(self):
-        with self.subTest("Early cancellation"):
-            graph = get_knowledge_graph(
-                get_right_order_for_fulfillment._semantikon_workflow
-            )
-            self.assertFalse(
-                validate_values(graph)["broken_promises"],
-                msg="If the cancel comes before there is anything to cancel, it should "
-                "be harmless",
-            )
-
-        with self.subTest("Late cancellation"):
-            graph = get_knowledge_graph(
-                get_wrong_order_for_fulfillment._semantikon_workflow
-            )
-            o_port = URIRef(
-                "get_wrong_order_for_fulfillment.create_vacancy_0.outputs.structure"
-            )
-            i_port = URIRef(
-                "get_wrong_order_for_fulfillment."
-                "get_vacancy_formation_energy_fulfills_0.inputs.structure"
-            )
-            cancelled = (EX.hasState, EX.relaxed)
-            self.assertDictEqual(
-                {o_port: (i_port, {cancelled})},
-                validate_values(graph)["broken_promises"],
-                msg="If the cancel comes after a triple has been added, it should be "
-                "removed -- here it was necessary.",
-            )
 
     def test_serialize_data(self):
         data = get_macro.run()

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -265,22 +265,6 @@ def get_wrong_order(structure="abc"):
     return energy
 
 
-@workflow
-def get_right_order_for_fulfillment(structure="abc"):
-    vac = create_vacancy(structure=structure)
-    relaxed = relax_structure(structure=vac)
-    energy = get_vacancy_formation_energy_fulfills(structure=relaxed)
-    return energy
-
-
-@workflow
-def get_wrong_order_for_fulfillment(structure="abc"):
-    relaxed = relax_structure(structure=structure)
-    vac = create_vacancy(structure=relaxed)
-    energy = get_vacancy_formation_energy_fulfills(structure=vac)
-    return energy
-
-
 class Meal:
     pass
 

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -638,29 +638,35 @@ class TestOntology(unittest.TestCase):
         
         <get_macro.add_one_0.outputs.result> a prov:Entity ;
             ns1:hasValue <get_macro.add_one_0.outputs.result.value> ;
-            ns1:outputOf <get_macro.add_one_0> .
+            ns1:outputOf <get_macro.add_one_0> ;
+            ns1:fulfills <get_macro.outputs.result> .
         
         <get_macro.add_three_0.add_one_0.outputs.result> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_one_0.outputs.result.value> ;
-            ns1:outputOf <get_macro.add_three_0.add_one_0> .
+            ns1:outputOf <get_macro.add_three_0.add_one_0> ;
+            ns1:fulfills <get_macro.add_three_0.add_two_0.inputs.b> .
         
         <get_macro.add_three_0.add_two_0.outputs.result> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_two_0.outputs.result.value> ;
-            ns1:outputOf <get_macro.add_three_0.add_two_0> .
+            ns1:outputOf <get_macro.add_three_0.add_two_0> ;
+            ns1:fulfills <get_macro.add_three_0.outputs.w> .
         
         <get_macro.add_three_0.inputs.c> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_one_0.inputs.a.value> ;
             prov:wasDerivedFrom <get_macro.inputs.c> ;
-            ns1:inputOf <get_macro.add_three_0> .
+            ns1:inputOf <get_macro.add_three_0> ;
+            ns1:fulfills <get_macro.add_three_0.add_one_0.inputs.a> .
         
         <get_macro.add_three_0.outputs.w> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_two_0.outputs.result.value> ;
             prov:wasDerivedFrom <get_macro.add_three_0.add_two_0.outputs.result> ;
-            ns1:outputOf <get_macro.add_three_0> .
+            ns1:outputOf <get_macro.add_three_0> ;
+            ns1:fulfills <get_macro.add_one_0.inputs.a> .
         
         <get_macro.inputs.c> a prov:Entity ;
             ns1:hasValue <get_macro.add_three_0.add_one_0.inputs.a.value> ;
-            ns1:inputOf <get_macro> .
+            ns1:inputOf <get_macro> ;
+            ns1:fulfills <get_macro.add_three_0.inputs.c> .
         
         <get_macro.add_one_0.outputs.result.value> rdf:value 5 .
         


### PR DESCRIPTION
Originally I wanted to amend #252 but I ended up only introducing `sns:linksTo`, because I decided not to inherit types for the reasons that I stated [here](https://github.com/pyiron/semantikon/issues/262#issuecomment-3271031001).

`sns:linksTo` does practically the same thing as `prov:wasDerivedBy` (although opposite direction). The intra-node link is now `prov:wasDerivedBy` and trans-node link is `sns:linksTo`.