### PR TITLE
Do not extract data classes by default

### DIFF
--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -1,5 +1,4 @@
 import uuid
-import warnings
 from collections import defaultdict
 from dataclasses import is_dataclass
 from string import Template
@@ -554,7 +553,9 @@ def _translate_dataclass(
             )
     for k, v in dtype.__annotations__.items():
         metadata = meta_to_dict(v)
-        triples.append((_dot(unique_io_port, k) + ".value", RDFS.subClassOf, value_node))
+        triples.append(
+            (_dot(unique_io_port, k) + ".value", RDFS.subClassOf, value_node)
+        )
         triples.extend(
             _translate_has_value(
                 io_port=io_port,
@@ -569,7 +570,7 @@ def _translate_dataclass(
 
 
 def _triples_to_knowledge_graph(
-    triples: list, graph: Graph | None = None,  namespace: Namespace | None = None
+    triples: list, graph: Graph | None = None, namespace: Namespace | None = None
 ) -> Graph:
     if graph is None:
         graph = Graph()

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -15,9 +15,9 @@ from semantikon.ontology import (
     _get_precedes,
     _parse_cancel,
     dataclass_to_knowledge_graph,
+    extract_dataclass,
     get_knowledge_graph,
     serialize_data,
-    extract_dataclass,
     validate_values,
 )
 from semantikon.visualize import visualize


### PR DESCRIPTION
Data classes such as:

```python
@dataclass
class Input:
    T: u(float, units="kelvin")
    n: int
```

was automatically translated into subclasses in the knowledge graph instead of storing the full `Input` as an object. This is not done anymore in this implementation. Instead, the user has to explicitly call `extract_dataclass`. Otherwise there's no change in the functionality.