### PR TITLE
Include inputs, outputs and label in the node dict for parsing

### DIFF
--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -705,7 +705,7 @@ def serialize_data(
         prefix: {
             key: value
             for key, value in wf_dict.items()
-            if key not in ["inputs", "outputs", "nodes", "edges", "label"]
+            if key not in ["nodes", "edges"]
         }
     }
     for io_ in ["inputs", "outputs"]:


### PR DESCRIPTION
Following #295, I'm checking whether the full node information can be returned in `node_dict`.