### PR TITLE
Use python native `__metadata__` instead of creating a new object for the function metadata

### DIFF
--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -47,44 +47,6 @@ __date__ = "Aug 21, 2021"
 class NotAstNameError(TypeError): ...
 
 
-F = TypeVar("F", bound=Callable[..., object])
-
-
-class FunctionWithMetadata(Generic[F]):
-    """
-    A wrapper class for functions that allows attaching metadata to the function.
-
-    Example:
-    >>> from semantikon.typing import u
-    >>>
-    >>> @u(uri="http://example.com/my_function")
-    >>> def my_function(x):
-    >>>     return x * 2
-    >>>
-    >>> print(my_function._semantikon_metadata)
-
-    Output: {'uri': 'http://example.com/my_function'}
-
-    This information is automatically parsed when knowledge graph is generated.
-    For more info, take a look at semantikon.ontology.get_knowledge_graph.
-    """
-
-    def __init__(self, function: F, metadata: dict[str, object]) -> None:
-        self.function = function
-        self._semantikon_metadata: dict[str, object] = metadata
-        update_wrapper(self, function)  # Copies __name__, __doc__, etc.
-
-    def __call__(self, *args, **kwargs):
-        return self.function(*args, **kwargs)
-
-    def __getattr__(self, item):
-        return getattr(self.function, item)
-
-    def __deepcopy__(self, memo=None):
-        new_func = deepcopy(self.function, memo)
-        return FunctionWithMetadata(new_func, self._semantikon_metadata)
-
-
 def _get_ureg(args: Any, kwargs: dict[str, Any]) -> UnitRegistry | None:
     for arg in args + tuple(kwargs.values()):
         if isinstance(arg, Quantity):
@@ -414,10 +376,9 @@ def units(func: Callable) -> Callable:
     return wrapper
 
 
-def get_function_dict(function: Callable | FunctionWithMetadata) -> dict[str, Any]:
+def get_function_dict(function: Callable) -> dict[str, Any]:
     result = get_function_metadata(function, full_metadata=True)
-    if hasattr(function, "_semantikon_metadata"):
-        result.update(function._semantikon_metadata)
+    result.update(getattr(function, "__metadata__", {}))
     return result
 
 

--- a/semantikon/metadata.py
+++ b/semantikon/metadata.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from rdflib import BNode, URIRef
 
-from semantikon.converter import FunctionWithMetadata, parse_metadata
+from semantikon.converter import parse_metadata
 from semantikon.datastructure import (
     MISSING,
     FunctionMetadata,
@@ -74,13 +74,10 @@ def meta(
     used: str | URIRef | Missing = MISSING,
 ):
     def decorator(func: Callable):
-        if not callable(func):
-            raise TypeError(f"Expected a callable, got {type(func)}")
-        return FunctionWithMetadata(
-            func,
-            FunctionMetadata(triples=triples, uri=uri, used=used).to_dictionary(),
-        )
-
+        func.__metadata__ = FunctionMetadata(
+            triples=triples, uri=uri, used=used
+        ).to_dictionary()
+        return func
     return decorator
 
 

--- a/semantikon/workflow.py
+++ b/semantikon/workflow.py
@@ -171,8 +171,7 @@ def _get_node_dict(
         "function": function,
         "type": type_,
     }
-    if hasattr(function, "_semantikon_metadata"):
-        data.update(function._semantikon_metadata)
+    data.update(getattr(function, "__metadata__", {}))
     return data
 
 
@@ -279,7 +278,7 @@ def get_ports(
 
 def get_node(func: Callable, label: str | None = None) -> Function | Workflow:
     metadata_dict = (
-        func._semantikon_metadata if hasattr(func, "_semantikon_metadata") else MISSING
+        func.__metadata__ if hasattr(func, "__metadata__") else MISSING
     )
     metadata = (
         metadata_dict

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -43,7 +43,7 @@ class TestParser(unittest.TestCase):
             self.assertIn(key, output_args)
         self.assertEqual(output_args["units"], "meter/second")
         self.assertEqual(output_args["label"], "speed")
-        self.assertEqual(get_speed._semantikon_metadata["uri"], "abc")
+        self.assertEqual(get_speed.__metadata__["uri"], "abc")
         self.assertRaises(TypeError, u, "abc")
         f_dict = get_function_dict(get_speed)
         self.assertEqual(f_dict["uri"], "abc")

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -448,9 +448,9 @@ class TestWorkflow(unittest.TestCase):
             with self.subTest(fnc=fnc, msg=fnc.__name__):
                 entry = swf._get_node_dict(fnc)
                 # Cheat and modify the entry to resemble the node structure
-                if hasattr(fnc, "_semantikon_metadata"):
+                if hasattr(fnc, "__metadata__"):
                     # Nest the metadata in the entry
-                    metadata = fnc._semantikon_metadata
+                    metadata = fnc.__metadata__
                     for k in metadata.keys():
                         entry.pop(k)
                     entry["metadata"] = metadata


### PR DESCRIPTION
Today at the pyiron meeting I talked about this idea, but ChatGPT does not find it very good and recommended this solution instead.