### PR TITLE
Use blank nodes instead of URI for the a-box

### DIFF
--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -340,7 +340,13 @@ def _parse_precedes(
                     )
                 else:
                     for succ in successors:
-                        g.add((BNode(namespace[node[0]]), SNS.precedes, BNode(namespace[succ])))
+                        g.add(
+                            (
+                                BNode(namespace[node[0]]),
+                                SNS.precedes,
+                                BNode(namespace[succ]),
+                            )
+                        )
                     g.add((workflow_node, SNS.has_part, BNode(namespace[node[0]])))
     return g
 

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -28,6 +28,7 @@ prefixes = """
 
 sparql_prefixes = prefixes.replace("@prefix ", "PREFIX ").replace(" .\n", "\n")
 
+
 def get_speed(
     distance: u(float, uri=PMD["0040001"], units="meter", label="Distance"),
     time: u(float, units="second"),


### PR DESCRIPTION
Without making the distinction between blank nodes and uri, the type definition `(abox_node, RDF.type, tbox_node)` makes little sense. I also removed the user-defined namespace, because it only makes the thing more complicated.