### PR TITLE
Append URI and units if the inputs are not connected

### DIFF
--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -563,7 +563,7 @@ def _wf_input_to_graph(
             if "units" in data:
                 g.add((data_node, QUDT.hasUnit, _units_to_uri(data["units"])))
             if "uri" in data:
-                bnode = BNode()
+                bnode = BNode(str(data_node) + "_uri")
                 g.add((bnode, RDF.type, data["uri"]))
                 g.add((data_node, SNS.specifies_value_of, bnode))
     g += _wf_io_to_graph(


### PR DESCRIPTION
While updating the documentation in #343, I realized there is no way to refer to the URI of global inputs, i.e.:

```python
def f(x: Annotated[float, {"uri": some_uri}]):
    ...
    return x

def my_workflow(x):
    y = f(x)
    ...
```

In this workflow `some_uri` does not get stored because it has no meaning for the validation, but since it's important for the data acquisition, I added it to the data node.