### PR TITLE
Use pmdco:0000128 (local identifier) instead of rdfs:label for python names

### DIFF
--- a/semantikon/analysis.py
+++ b/semantikon/analysis.py
@@ -24,9 +24,10 @@ def label_to_uri(graph: Graph, label: str) -> list[URIRef]:
     Returns:
         list[URIRef]: The corresponding URIs from the graph.
     """
-    query = """SELECT DISTINCT ?s
+    query = """PREFIX pmdco: <https://w3id.org/pmd/co/PMD_>
+    SELECT DISTINCT ?s
     WHERE {
-      ?s rdfs:label ?label .
+      ?s pmdco:0000128 ?label .
       ?s a owl:Class .
     }"""
     result = list(graph.query(query, initBindings={"label": Literal(label)}))
@@ -282,7 +283,7 @@ def _get_label_from_port(port, graph) -> list[str]:
     query_io_node = f"""PREFIX pmdco: <https://w3id.org/pmd/co/PMD_>
     SELECT DISTINCT ?parent ?label WHERE {{
         ?parent rdfs:subClassOf ?bnode .
-        ?parent rdfs:label ?label .
+        ?parent pmdco:0000128 ?label .
         ?bnode a owl:Restriction .
         ?bnode owl:onProperty bfo:0000051 .
         ?bnode owl:someValuesFrom <{port}> .

--- a/semantikon/analysis.py
+++ b/semantikon/analysis.py
@@ -279,7 +279,8 @@ class Completer(_Node):
 
 
 def _get_label_from_port(port, graph) -> list[str]:
-    query_io_node = f"""SELECT DISTINCT ?parent ?label WHERE {{
+    query_io_node = f"""PREFIX pmdco: <https://w3id.org/pmd/co/PMD_>
+    SELECT DISTINCT ?parent ?label WHERE {{
         ?parent rdfs:subClassOf ?bnode .
         ?parent rdfs:label ?label .
         ?bnode a owl:Restriction .
@@ -293,9 +294,10 @@ def _get_label_from_port(port, graph) -> list[str]:
 
 
 def _get_labels(graph):
-    query_data_node = """SELECT DISTINCT ?parent ?data_node ?label ?io_class WHERE {
+    query_data_node = """PREFIX pmdco: <https://w3id.org/pmd/co/PMD_>
+    SELECT DISTINCT ?parent ?data_node ?label ?io_class WHERE {
         ?parent rdfs:subClassOf ?bnode .
-        ?parent rdfs:label ?label .
+        ?parent pmdco:0000128 ?label .
         ?bnode a owl:Restriction .
         ?bnode owl:onProperty ro:0000057 .
         ?bnode owl:someValuesFrom ?data_node .
@@ -319,14 +321,15 @@ def _get_labels(graph):
 
 
 def _add_child_data_class(graph, label_dict):
-    query_data_class = """SELECT DISTINCT ?parent ?child ?label WHERE {{
+    query_data_class = """PREFIX pmdco: <https://w3id.org/pmd/co/PMD_>
+    SELECT DISTINCT ?parent ?child ?label WHERE {{
         ?parent rdfs:subClassOf ?bnode .
         ?bnode a owl:Restriction .
         ?bnode owl:onProperty bfo:0000051 .
         ?bnode owl:someValuesFrom ?child .
         ?parent rdfs:subClassOf obi:0001933 .
         ?child rdfs:subClassOf obi:0001933 .
-        ?child rdfs:label ?label .
+        ?child pmdco:0000128 ?label .
     }}"""
     child_label_dict = {}
     for parent_uri, child_uri, key in graph.query(query_data_class):

--- a/semantikon/analysis.py
+++ b/semantikon/analysis.py
@@ -13,13 +13,13 @@ from semantikon.converter import to_identifier
 from semantikon.ontology import SNS, serialize_and_convert_to_networkx
 
 
-def label_to_uri(graph: Graph, label: str) -> list[URIRef]:
+def identifier_to_uri(graph: Graph, identifier: str) -> list[URIRef]:
     """
-    Convert a human-readable label to its corresponding URIRef in the graph.
+    Convert a local identifier (pmdco:0000128) to its corresponding URIRef in the graph.
 
     Args:
         graph (Graph): The RDF graph to query.
-        label (str): The human-readable label or URIRef.
+        identifier (str): The local identifier (Python name) to look up.
 
     Returns:
         list[URIRef]: The corresponding URIs from the graph.
@@ -27,11 +27,11 @@ def label_to_uri(graph: Graph, label: str) -> list[URIRef]:
     query = """PREFIX pmdco: <https://w3id.org/pmd/co/PMD_>
     SELECT DISTINCT ?s
     WHERE {
-      ?s pmdco:0000128 ?label .
+      ?s pmdco:0000128 ?identifier .
       ?s a owl:Class .
     }"""
-    result = list(graph.query(query, initBindings={"label": Literal(label)}))
-    assert len(result) > 0, f"No result found for {label}"
+    result = list(graph.query(query, initBindings={"identifier": Literal(identifier)}))
+    assert len(result) > 0, f"No result found for {identifier}"
     return [r[0] for r in result]
 
 

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -204,6 +204,7 @@ def _inherit_properties(graph: Graph, n_max: int = 1000):
         ?target ?p ?o .
         FILTER(?p != ro:0001000)
         FILTER(?p != rdfs:label)
+        FILTER(?p != pmdco:0000128)
         FILTER(?p != pmdco:0000006)
         FILTER(?p != rdf:type)
         FILTER(?p != owl:sameAs)
@@ -563,7 +564,8 @@ def _wf_node_to_graph(
                 f_node,
                 restriction_type=OWL.hasValue,
             )
-        g.add((node, RDFS.label, Literal(node_name.split("-")[-1])))
+        g.add((node, RDFS.label, Literal(node_name)))
+        g.add((node, SNS.local_identifier, Literal(node_name.split("-")[-1])))
     else:
         node = G.get_a_node(node_name)
         g.add((node, RDF.type, G.t_ns[node_name]))
@@ -957,6 +959,7 @@ def _nx_to_kg(G: SemantikonDiGraph, t_box: bool) -> Graph:
     if t_box:
         g.add((workflow_node, RDF.type, OWL.Class))
         g.add((workflow_node, RDFS.subClassOf, SNS.workflow_node))
+        g.add((workflow_node, SNS.local_identifier, Literal(G.name)))
         g.add((workflow_node, RDFS.label, Literal(G.name)))
     else:
         g.add((workflow_node, RDF.type, G.t_ns[G.name]))

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -72,7 +72,7 @@ class SNS:
     import_path: URIRef = PMD["0000101"]
     function_name: URIRef = PMD["0000100"]
     file_data_item: URIRef = NFDI["0000027"]
-    workflow_argument_name: URIRef = PMD["0000128"]
+    local_identifier: URIRef = PMD["0000128"]
 
 
 ud = UnitsDict()
@@ -504,7 +504,7 @@ def _function_to_graph(
                 g.add((arg_node, RDF.type, SNS.input_specification))
             else:
                 g.add((arg_node, RDF.type, SNS.output_specification))
-            g.add((arg_node, SNS.workflow_argument_name, Literal(arg_name)))
+            g.add((arg_node, SNS.local_identifier, Literal(arg_name)))
             g.add((f_node, SNS.has_part, arg_node))
             g.add(
                 (arg_node, SNS.has_parameter_position, Literal(arg.get("position", ii)))
@@ -819,7 +819,7 @@ def _wf_io_to_graph(
     node = G.t_ns[node_name] if t_box else G.get_a_node(node_name)
     g = _get_bound_graph()
     g.add((node, RDFS.label, Literal(node_name)))
-    g.add((node, SNS.workflow_argument_name, Literal(node_name.split("-")[-1])))
+    g.add((node, SNS.local_identifier, Literal(node_name.split("-")[-1])))
     if t_box:
         g += _to_owl_restriction(node, has_specified_io, data_node)
         g.add((node, RDFS.subClassOf, io_assignment))
@@ -1119,7 +1119,7 @@ class _DataclassTranslator:
         graph.add((field_node, RDFS.subClassOf, SNS.value_specification))
         graph.add((field_node, RDFS.label, Literal(field_node)))
         graph.add(
-            (field_node, SNS.workflow_argument_name, Literal(field_node.split("-")[-1]))
+            (field_node, SNS.local_identifier, Literal(field_node.split("-")[-1]))
         )
 
         units = metadata.get("units", metadata.get("unit"))
@@ -1163,7 +1163,7 @@ class _DataclassTranslator:
         graph.add((field_node, RDF.type, field_class))
         graph.add((field_node, RDFS.label, Literal(field_node)))
         graph.add(
-            (field_node, SNS.workflow_argument_name, Literal(field_node.split("-")[-1]))
+            (field_node, SNS.local_identifier, Literal(field_node.split("-")[-1]))
         )
 
         units = metadata.get("units", metadata.get("unit"))

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -564,8 +564,7 @@ def _wf_node_to_graph(
                 f_node,
                 restriction_type=OWL.hasValue,
             )
-        g.add((node, RDFS.label, Literal(node_name)))
-        g.add((node, SNS.workflow_argument_name, Literal(node_name.split("-")[-1])))
+        g.add((node, RDFS.label, Literal(node_name.split("-")[-1])))
     else:
         node = G.get_a_node(node_name)
         g.add((node, RDF.type, G.t_ns[node_name]))

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -1120,7 +1120,8 @@ class _DataclassTranslator:
         )
 
         graph.add((field_node, RDFS.subClassOf, SNS.value_specification))
-        graph.add((field_node, RDFS.label, Literal(field_node)))
+        field_label = str(field_node).rsplit("#", 1)[-1].rsplit("/", 1)[-1]
+        graph.add((field_node, RDFS.label, Literal(field_label)))
         graph.add(
             (field_node, SNS.local_identifier, Literal(field_node.split("-")[-1]))
         )

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -72,6 +72,7 @@ class SNS:
     import_path: URIRef = PMD["0000101"]
     function_name: URIRef = PMD["0000100"]
     file_data_item: URIRef = NFDI["0000027"]
+    workflow_argument_name: URIRef = PMD["0000128"]
 
 
 ud = UnitsDict()
@@ -503,7 +504,8 @@ def _function_to_graph(
                 g.add((arg_node, RDF.type, SNS.input_specification))
             else:
                 g.add((arg_node, RDF.type, SNS.output_specification))
-            g.add((arg_node, RDFS.label, Literal(arg_name)))
+            g.add((arg_node, SNS.workflow_argument_name, Literal(arg_name)))
+            g.add((arg_node, RDFS.label, Literal(str(f_node))))
             g.add((f_node, SNS.has_part, arg_node))
             g.add(
                 (arg_node, SNS.has_parameter_position, Literal(arg.get("position", ii)))
@@ -562,7 +564,8 @@ def _wf_node_to_graph(
                 f_node,
                 restriction_type=OWL.hasValue,
             )
-        g.add((node, RDFS.label, Literal(node_name.split("-")[-1])))
+        g.add((node, RDFS.label, Literal(node_name)))
+        g.add((node, SNS.workflow_argument_name, Literal(node_name.split("-")[-1])))
     else:
         node = G.get_a_node(node_name)
         g.add((node, RDF.type, G.t_ns[node_name]))
@@ -817,7 +820,8 @@ def _wf_io_to_graph(
 ) -> Graph:
     node = G.t_ns[node_name] if t_box else G.get_a_node(node_name)
     g = _get_bound_graph()
-    g.add((node, RDFS.label, Literal(node_name.split("-")[-1])))
+    g.add((node, RDFS.label, Literal(node_name)))
+    g.add((node, SNS.workflow_argument_name, Literal(node_name.split("-")[-1])))
     if t_box:
         g += _to_owl_restriction(node, has_specified_io, data_node)
         g.add((node, RDFS.subClassOf, io_assignment))
@@ -1115,7 +1119,10 @@ class _DataclassTranslator:
         )
 
         graph.add((field_node, RDFS.subClassOf, SNS.value_specification))
-        graph.add((field_node, RDFS.label, Literal(field_node.split("-")[-1])))
+        graph.add((field_node, RDFS.label, Literal(field_node)))
+        graph.add(
+            (field_node, SNS.workflow_argument_name, Literal(field_node.split("-")[-1]))
+        )
 
         units = metadata.get("units", metadata.get("unit"))
         if units is not None:
@@ -1156,7 +1163,10 @@ class _DataclassTranslator:
         """
         graph.add((parent, SNS.has_part, field_node))
         graph.add((field_node, RDF.type, field_class))
-        graph.add((field_node, RDFS.label, Literal(field_node.split("-")[-1])))
+        graph.add((field_node, RDFS.label, Literal(field_node)))
+        graph.add(
+            (field_node, SNS.workflow_argument_name, Literal(field_node.split("-")[-1]))
+        )
 
         units = metadata.get("units", metadata.get("unit"))
         if units is not None:

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -505,7 +505,6 @@ def _function_to_graph(
             else:
                 g.add((arg_node, RDF.type, SNS.output_specification))
             g.add((arg_node, SNS.workflow_argument_name, Literal(arg_name)))
-            g.add((arg_node, RDFS.label, Literal(str(f_node))))
             g.add((f_node, SNS.has_part, arg_node))
             g.add(
                 (arg_node, SNS.has_parameter_position, Literal(arg.get("position", ii)))

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -1096,6 +1096,19 @@ class _DataclassTranslator:
                     dtype=field_type,
                 )
 
+    @staticmethod
+    def _to_field_label(field_node: URIRef) -> Literal:
+        """
+        Generate a human-readable label for a dataclass field.
+
+        Args:
+            field_node: URIRef representing the field.
+
+        Returns:
+            A Literal containing the field label.
+        """
+        return Literal(str(field_node).rsplit("#", 1)[-1].rsplit("/", 1)[-1])
+
     def _emit_tbox(
         self,
         *,
@@ -1120,8 +1133,7 @@ class _DataclassTranslator:
         )
 
         graph.add((field_node, RDFS.subClassOf, SNS.value_specification))
-        field_label = str(field_node).rsplit("#", 1)[-1].rsplit("/", 1)[-1]
-        graph.add((field_node, RDFS.label, Literal(field_label)))
+        graph.add((field_node, RDFS.label, self._to_field_label(field_node)))
         graph.add(
             (field_node, SNS.local_identifier, Literal(field_node.split("-")[-1]))
         )
@@ -1165,7 +1177,7 @@ class _DataclassTranslator:
         """
         graph.add((parent, SNS.has_part, field_node))
         graph.add((field_node, RDF.type, field_class))
-        graph.add((field_node, RDFS.label, Literal(field_node)))
+        graph.add((field_node, RDFS.label, self._to_field_label(field_node)))
         graph.add(
             (field_node, SNS.local_identifier, Literal(field_node.split("-")[-1]))
         )

--- a/tests/unit/test_analysis.py
+++ b/tests/unit/test_analysis.py
@@ -78,7 +78,7 @@ class TestAnalysis(unittest.TestCase):
         g = onto.get_knowledge_graph(wf_dict, prefix="T")
 
         with self.subTest("workflow instance exists"):
-            uri = asis.label_to_uri(g, "my_kinetic_energy_workflow")[0]
+            uri = asis.identifier_to_uri(g, "my_kinetic_energy_workflow")[0]
             workflows = list(g.subjects(RDF.type, uri))
             self.assertEqual(len(workflows), 1)
 
@@ -86,9 +86,9 @@ class TestAnalysis(unittest.TestCase):
 
         with self.subTest("workflow has both function executions as parts"):
             parts = list(g.objects(wf, onto.BFO["0000051"]))
-            uri = asis.label_to_uri(g, "get_kinetic_energy_0")[0]
+            uri = asis.identifier_to_uri(g, "get_kinetic_energy_0")[0]
             ke_calls = [p for p in parts if (p, RDF.type, uri) in g]
-            uri = asis.label_to_uri(g, "get_speed_0")[0]
+            uri = asis.identifier_to_uri(g, "get_speed_0")[0]
             speed_calls = [p for p in parts if (p, RDF.type, uri) in g]
             self.assertEqual(len(ke_calls), 1)
             self.assertEqual(len(speed_calls), 1)
@@ -237,12 +237,12 @@ class TestAnalysis(unittest.TestCase):
             [(1.0,)],
         )
 
-    def test_label_to_uri(self):
+    def test_identifier_to_uri(self):
         wf_dict = my_kinetic_energy_workflow.get_semantikon_dict()
         g = onto.get_knowledge_graph(wf_dict)
-        uri = asis.label_to_uri(g, "my_kinetic_energy_workflow")[0]
-        label = str(g.value(uri, RDFS.label))
-        self.assertEqual(label, "my_kinetic_energy_workflow")
+        uri = asis.identifier_to_uri(g, "my_kinetic_energy_workflow")[0]
+        identifier = str(g.value(uri, onto.SNS.local_identifier))
+        self.assertEqual(identifier, "my_kinetic_energy_workflow")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_analysis.py
+++ b/tests/unit/test_analysis.py
@@ -2,7 +2,7 @@ import unittest
 from dataclasses import dataclass
 from typing import Annotated
 
-from rdflib import RDF, RDFS, Namespace
+from rdflib import RDF, Namespace
 
 from semantikon import analysis as asis
 from semantikon import ontology as onto

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -655,7 +655,7 @@ class TestOntology(unittest.TestCase):
         mass_spec = list(graph.query(query))
         self.assertEqual(len(mass_spec), 1)
         self.assertIn((mass_spec[0][0], RDF.type, onto.SNS.input_specification), graph)
-        self.assertIn((mass_spec[0][0], onto.SNS.workflow_argument_name, Literal("mass")), graph)
+        self.assertIn((mass_spec[0][0], onto.SNS.local_identifier, Literal("mass")), graph)
         self.assertIn(
             (mass_spec[0][0], onto.SNS.has_parameter_position, Literal(0)), graph
         )
@@ -673,7 +673,7 @@ class TestOntology(unittest.TestCase):
         self.assertIn(
             (output_spec[0][0], RDF.type, onto.SNS.output_specification), graph
         )
-        self.assertIn((output_spec[0][0], onto.SNS.workflow_argument_name, Literal("kinetic_energy")), graph)
+        self.assertIn((output_spec[0][0], onto.SNS.local_identifier, Literal("kinetic_energy")), graph)
         self.assertIn(
             (output_spec[0][0], onto.SNS.has_parameter_position, Literal(0)), graph
         )

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -655,7 +655,9 @@ class TestOntology(unittest.TestCase):
         mass_spec = list(graph.query(query))
         self.assertEqual(len(mass_spec), 1)
         self.assertIn((mass_spec[0][0], RDF.type, onto.SNS.input_specification), graph)
-        self.assertIn((mass_spec[0][0], onto.SNS.local_identifier, Literal("mass")), graph)
+        self.assertIn(
+            (mass_spec[0][0], onto.SNS.local_identifier, Literal("mass")), graph
+        )
         self.assertIn(
             (mass_spec[0][0], onto.SNS.has_parameter_position, Literal(0)), graph
         )
@@ -673,7 +675,10 @@ class TestOntology(unittest.TestCase):
         self.assertIn(
             (output_spec[0][0], RDF.type, onto.SNS.output_specification), graph
         )
-        self.assertIn((output_spec[0][0], onto.SNS.local_identifier, Literal("kinetic_energy")), graph)
+        self.assertIn(
+            (output_spec[0][0], onto.SNS.local_identifier, Literal("kinetic_energy")),
+            graph,
+        )
         self.assertIn(
             (output_spec[0][0], onto.SNS.has_parameter_position, Literal(0)), graph
         )

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -655,7 +655,7 @@ class TestOntology(unittest.TestCase):
         mass_spec = list(graph.query(query))
         self.assertEqual(len(mass_spec), 1)
         self.assertIn((mass_spec[0][0], RDF.type, onto.SNS.input_specification), graph)
-        self.assertIn((mass_spec[0][0], RDFS.label, Literal("mass")), graph)
+        self.assertIn((mass_spec[0][0], onto.SNS.workflow_argument_name, Literal("mass")), graph)
         self.assertIn(
             (mass_spec[0][0], onto.SNS.has_parameter_position, Literal(0)), graph
         )
@@ -673,7 +673,7 @@ class TestOntology(unittest.TestCase):
         self.assertIn(
             (output_spec[0][0], RDF.type, onto.SNS.output_specification), graph
         )
-        self.assertIn((output_spec[0][0], RDFS.label, Literal("kinetic_energy")), graph)
+        self.assertIn((output_spec[0][0], onto.SNS.workflow_argument_name, Literal("kinetic_energy")), graph)
         self.assertIn(
             (output_spec[0][0], onto.SNS.has_parameter_position, Literal(0)), graph
         )
@@ -819,7 +819,7 @@ class TestOntology(unittest.TestCase):
         query = sparql_prefixes + """
             SELECT ?label WHERE {
               ?function bfo:0000051 ?bnode .
-              ?bnode rdfs:label ?label .
+              ?bnode pmdco:0000128 ?label .
             }"""
         g = onto.function_to_knowledge_graph(prepare_pizza)
         self.assertEqual(list(g.query(query))[0][0].toPython(), "output_0")


### PR DESCRIPTION
According to @joergwa `rdfs:label` is meant for human readability, which I was using to store the python names (e.g. `f`, `x` etc.). Now I use `pmdco:0000128` (local identifiers) for the python names, and more detailed names for `rdfs:label`