### PR TITLE
Always prepend to hash dict keys

### DIFF
--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -1391,8 +1391,7 @@ def serialize_and_convert_to_networkx(
         try:
             hashed_dict = {}
             for key, value in get_hashed_node_dict(wf_dict).items():
-                if not key.startswith(G.name):
-                    key = G.name + "-" + key
+                key = G.name + "-" + key
                 hashed_dict[key.replace(".", "-")] = value
         except Exception as e:
             raise RuntimeError(


### PR DESCRIPTION
Otherwise, in the case where the key (child node name) and graph name (parent node name) are the same, the keys of the `hashed_dict` wind up out of sync with the labels available in the digraph.

Closes #421 

The problem is that I don't understand _why_ that if-clause is there to start with. So in the spirit of Chesterton's fence, this change should be scrutinized prior to merging.