### PR TITLE
Don't just `else` into `"outputs"`

### DIFF
--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -948,13 +948,15 @@ def _nx_to_kg(G: SemantikonDiGraph, t_box: bool) -> Graph:
                 G=G,
                 t_box=t_box,
             )
-        else:
+        elif step == "outputs":
             g += _wf_output_to_graph(
                 node_name=node_name,
                 data=data,
                 G=G,
                 t_box=t_box,
             )
+        else:
+            raise ValueError(f"Encountered unknown step: {step}")
 
     if t_box:
         g.add((workflow_node, RDF.type, OWL.Class))


### PR DESCRIPTION
As we update formats, we might get an annoying bug where a name has changed but we don't notice because we `else` right into assuming we're dealing with `"outputs"`. Guard against this magic-string danger by making all clauses explicit.