### PR TITLE
Improve algorithm for parsing triples of nested workflows

### DIFF
--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -119,7 +119,7 @@ class SemantikonDiGraph(nx.DiGraph):
                 c for c in self.predecessors(io) if self.nodes[c]["step"] != "node"
             ]
             assert len(candidate) <= 1
-            if len(candidate) == 0 or self.nodes[candidate[0]]["step"] == "node":
+            if len(candidate) == 0:
                 return f"{io}_data"
             io = candidate[0]
 

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -115,7 +115,9 @@ class SemantikonDiGraph(nx.DiGraph):
     @cache
     def _get_data_node(self, io: str) -> str:
         while True:
-            candidate = [c for c in self.predecessors(io) if self.nodes[c]["step"] != "node"]
+            candidate = [
+                c for c in self.predecessors(io) if self.nodes[c]["step"] != "node"
+            ]
             assert len(candidate) <= 1
             if len(candidate) == 0 or self.nodes[candidate[0]]["step"] == "node":
                 return f"{io}_data"

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -878,11 +878,6 @@ def _parse_precedes(
                             SNS.precedes,
                             G.t_ns[succ],
                         )
-                    g += _to_owl_restriction(
-                        workflow_node,
-                        SNS.has_part,
-                        G.t_ns[node[0]],
-                    )
                 else:
                     for succ in successors:
                         g.add(
@@ -892,7 +887,6 @@ def _parse_precedes(
                                 G.get_a_node(succ),
                             )
                         )
-                    g.add((workflow_node, SNS.has_part, G.get_a_node(node[0])))
     return g
 
 
@@ -956,15 +950,7 @@ def _nx_to_kg(G: SemantikonDiGraph, t_box: bool) -> Graph:
                 t_box=t_box,
             )
 
-    if t_box:
-        g.add((workflow_node, RDF.type, OWL.Class))
-        g.add((workflow_node, RDFS.subClassOf, SNS.workflow_node))
-        g.add((workflow_node, SNS.local_identifier, Literal(G.name)))
-        g.add((workflow_node, RDFS.label, Literal(G.name)))
-    else:
-        g.add((workflow_node, RDF.type, G.t_ns[G.name]))
     g += _parse_precedes(G=G, workflow_node=workflow_node, t_box=t_box)
-    g += _parse_global_io(G=G, workflow_node=workflow_node, t_box=t_box)
     return g
 
 

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -613,7 +613,7 @@ def _input_is_connected(io: str, G: SemantikonDiGraph) -> bool:
             return True
         return _input_is_connected(candidate[0], G)
     if len(candidate) != 0:
-        raise ValueError(f"No predecessors for {io} in {G.nodes}")
+        raise ValueError(f"Too many predecessors for {io}: {candidate}")
     return False
 
 

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -1249,8 +1249,7 @@ class _WorkflowGraphSerializer:
 
     @staticmethod
     def _remove_us(*args: str) -> str:
-        s = ".".join(args)
-        return ".".join(part.split("__")[-1] for part in s.split("."))
+        return ".".join(args)
 
     @staticmethod
     def _dot(*args: str | None) -> str:

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -598,12 +598,12 @@ def _output_is_connected(io: str, G: SemantikonDiGraph) -> bool:
             return True
         return _output_is_connected(candidate[0], G)
     elif n_candidates == 2 and _is_macro_input(io, G, tuple(candidate)):
-        return (
-            _output_is_connected(candidate[0], G)
-            and _output_is_connected(candidate[1], G)
+        return _output_is_connected(candidate[0], G) and _output_is_connected(
+            candidate[1], G
         )
     else:
         return any(_output_is_connected(c, G) for c in candidate)
+
 
 def _is_macro_input(io: str, G: SemantikonDiGraph, candidates: tuple[str, str]):
     successor_types = {G.nodes[c]["step"] for c in candidates}
@@ -622,9 +622,8 @@ def _input_is_connected(io: str, G: SemantikonDiGraph) -> bool:
             return True
         return _input_is_connected(candidate[0], G)
     elif n_predecessors == 2 and _is_macro_output(io, G, tuple(candidate)):
-        return (
-            _input_is_connected(candidate[0], G)
-            and _input_is_connected(candidate[1], G)
+        return _input_is_connected(candidate[0], G) and _input_is_connected(
+            candidate[1], G
         )
     else:
         predecessor_steps = {c: G.nodes[c]["step"] for c in candidate}

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -566,6 +566,12 @@ def _wf_node_to_graph(
             )
         g.add((node, RDFS.label, Literal(node_name)))
         g.add((node, SNS.local_identifier, Literal(node_name.split("-")[-1])))
+        if "parent" in data:
+            g += _to_owl_restriction(
+                G.t_ns[data["parent"]],
+                SNS.has_part,
+                node,
+            )
     else:
         node = G.get_a_node(node_name)
         g.add((node, RDF.type, G.t_ns[node_name]))
@@ -575,6 +581,8 @@ def _wf_node_to_graph(
             g.add((node, SNS.has_part, G.get_a_node(out)))
         if "function" in data:
             g.add((node, SNS.concretizes, f_node))
+        if "parent" in data:
+            g.add((G.get_a_node(data["parent"]), SNS.has_part, node))
     return g
 
 
@@ -863,30 +871,22 @@ def _parse_precedes(
     for node in G.nodes.data():
         if node[1]["step"] == "node":
             successors = list(_get_successor_nodes(G, node[0]))
-            if len(successors) == 0:
-                if t_box:
+            if t_box:
+                for succ in successors:
                     g += _to_owl_restriction(
-                        workflow_node, SNS.has_part, G.t_ns[node[0]]
+                        G.t_ns[node[0]],
+                        SNS.precedes,
+                        G.t_ns[succ],
                     )
-                else:
-                    g.add((workflow_node, SNS.has_part, G.get_a_node(node[0])))
             else:
-                if t_box:
-                    for succ in successors:
-                        g += _to_owl_restriction(
-                            G.t_ns[node[0]],
+                for succ in successors:
+                    g.add(
+                        (
+                            G.get_a_node(node[0]),
                             SNS.precedes,
-                            G.t_ns[succ],
+                            G.get_a_node(succ),
                         )
-                else:
-                    for succ in successors:
-                        g.add(
-                            (
-                                G.get_a_node(node[0]),
-                                SNS.precedes,
-                                G.get_a_node(succ),
-                            )
-                        )
+                    )
     return g
 
 
@@ -1300,7 +1300,9 @@ class _WorkflowGraphSerializer:
 
     def _serialize_children(self, wf_dict: dict, prefix: str) -> None:
         for key, node in wf_dict.get("nodes", {}).items():
-            self._serialize_workflow(node, self._dot(prefix, key))
+            child_key = self._dot(prefix, key)
+            self._serialize_workflow(node, child_key)
+            self.node_dict[child_key]["parent"] = prefix
 
     def _serialize_edges(self, wf_dict: dict, prefix: str) -> None:
         for edge in wf_dict.get("edges", []):

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -610,7 +610,8 @@ def _input_is_connected(io: str, G: SemantikonDiGraph) -> bool:
         if G.nodes[candidate[0]]["step"] == "node":
             return True
         return _input_is_connected(candidate[0], G)
-    assert len(candidate) == 0
+    if len(candidate) == 0:
+        raise ValueError(f"No predecessors for {io} in {G.nodes}")
     return False
 
 

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -1304,7 +1304,7 @@ class _WorkflowGraphSerializer:
         for key, node in wf_dict.get("nodes", {}).items():
             child_key = self._dot(prefix, key)
             self._serialize_workflow(node, child_key)
-            self.node_dict[child_key]["parent"] = prefix
+            self.node_dict[child_key]["parent"] = prefix.replace(".", "-")
 
     def _serialize_edges(self, wf_dict: dict, prefix: str) -> None:
         for edge in wf_dict.get("edges", []):

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -866,7 +866,6 @@ def _wf_io_to_graph(
 
 def _parse_precedes(
     G: SemantikonDiGraph,
-    workflow_node: URIRef,
     t_box: bool,
 ) -> Graph:
     g = _get_bound_graph()
@@ -952,7 +951,7 @@ def _nx_to_kg(G: SemantikonDiGraph, t_box: bool) -> Graph:
                 t_box=t_box,
             )
 
-    g += _parse_precedes(G=G, workflow_node=workflow_node, t_box=t_box)
+    g += _parse_precedes(G=G, t_box=t_box)
     return g
 
 

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -1345,7 +1345,6 @@ class _WorkflowGraphSerializer:
         for key, data in self.node_dict.items():
             if "." not in key:
                 G.name = key
-                continue
 
             G.add_node(
                 key,

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -595,7 +595,11 @@ def _output_is_connected(io: str, G: SemantikonDiGraph) -> bool:
             return True
         return _output_is_connected(candidate[0], G)
     elif len(candidate) > 1:
-        assert all(G.nodes[c]["step"] != "node" for c in candidate)
+        if trouble:= {c: G.nodes[c] for c in candidate if G.nodes[c]["step"] != "node"}:
+            raise ValueError(
+                f"Problematic candidates for {io} `_output_is_connected` check from "
+                f"among {candidate}: {trouble!r}"
+            )
         return any(_output_is_connected(c, G) for c in candidate)
     return False
 

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -920,7 +920,6 @@ def _parse_global_io(
 
 def _nx_to_kg(G: SemantikonDiGraph, t_box: bool) -> Graph:
     g = _get_bound_graph()
-    workflow_node = G.t_ns[G.name] if t_box else G.get_a_node(G.name)
     for node_name, data in G.nodes.data():
         data = data.copy()
         step = data.pop("step")

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -595,7 +595,9 @@ def _output_is_connected(io: str, G: SemantikonDiGraph) -> bool:
             return True
         return _output_is_connected(candidate[0], G)
     elif len(candidate) > 1:
-        if trouble:= {c: G.nodes[c] for c in candidate if G.nodes[c]["step"] == "node"}:
+        if trouble := {
+            c: G.nodes[c] for c in candidate if G.nodes[c]["step"] == "node"
+        }:
             raise ValueError(
                 f"Problematic candidates for {io} `_output_is_connected` check from "
                 f"among {candidate}: {trouble!r}"

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -590,20 +590,26 @@ def _wf_node_to_graph(
 
 def _output_is_connected(io: str, G: SemantikonDiGraph) -> bool:
     candidate = list(G.successors(io))
-    if len(candidate) == 1:
+    n_candidates = len(candidate)
+    if n_candidates == 0:
+        return False
+    elif n_candidates == 1:
         if G.nodes[candidate[0]]["step"] == "node":
             return True
         return _output_is_connected(candidate[0], G)
-    elif len(candidate) > 1:
-        if trouble := {
-            c: G.nodes[c] for c in candidate if G.nodes[c]["step"] == "node"
-        }:
-            raise ValueError(
-                f"Problematic candidates for {io} `_output_is_connected` check from "
-                f"among {candidate}: {trouble!r}"
-            )
+    elif n_candidates == 2 and _is_macro_input(io, G, tuple(candidate)):
+        return (
+            _output_is_connected(candidate[0], G)
+            and _output_is_connected(candidate[1], G)
+        )
+    else:
         return any(_output_is_connected(c, G) for c in candidate)
-    return False
+
+def _is_macro_input(io: str, G: SemantikonDiGraph, candidates: tuple[str, str]):
+    successor_types = {G.nodes[c]["step"] for c in candidates}
+    step_type = G.nodes[io]["step"]
+    input_edge_predecessors = {"node", "inputs"}
+    return step_type == "inputs" and successor_types == input_edge_predecessors
 
 
 def _input_is_connected(io: str, G: SemantikonDiGraph) -> bool:

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -115,7 +115,7 @@ class SemantikonDiGraph(nx.DiGraph):
     @cache
     def _get_data_node(self, io: str) -> str:
         while True:
-            candidate = list(self.predecessors(io))
+            candidate = [c for c in self.predecessors(io) if self.nodes[c]["step"] != "node"]
             assert len(candidate) <= 1
             if len(candidate) == 0 or self.nodes[candidate[0]]["step"] == "node":
                 return f"{io}_data"

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -595,7 +595,7 @@ def _output_is_connected(io: str, G: SemantikonDiGraph) -> bool:
             return True
         return _output_is_connected(candidate[0], G)
     elif len(candidate) > 1:
-        if trouble:= {c: G.nodes[c] for c in candidate if G.nodes[c]["step"] != "node"}:
+        if trouble:= {c: G.nodes[c] for c in candidate if G.nodes[c]["step"] == "node"}:
             raise ValueError(
                 f"Problematic candidates for {io} `_output_is_connected` check from "
                 f"among {candidate}: {trouble!r}"
@@ -610,7 +610,7 @@ def _input_is_connected(io: str, G: SemantikonDiGraph) -> bool:
         if G.nodes[candidate[0]]["step"] == "node":
             return True
         return _input_is_connected(candidate[0], G)
-    if len(candidate) == 0:
+    if len(candidate) != 0:
         raise ValueError(f"No predecessors for {io} in {G.nodes}")
     return False
 

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -614,13 +614,31 @@ def _is_macro_input(io: str, G: SemantikonDiGraph, candidates: tuple[str, str]):
 
 def _input_is_connected(io: str, G: SemantikonDiGraph) -> bool:
     candidate = list(G.predecessors(io))
-    if len(candidate) == 1:
+    n_predecessors = len(candidate)
+    if n_predecessors == 0:
+        return False
+    elif n_predecessors == 1:
         if G.nodes[candidate[0]]["step"] == "node":
             return True
         return _input_is_connected(candidate[0], G)
-    if len(candidate) != 0:
-        raise ValueError(f"Too many predecessors for {io}: {candidate}")
-    return False
+    elif n_predecessors == 2 and _is_macro_output(io, G, tuple(candidate)):
+        return (
+            _input_is_connected(candidate[0], G)
+            and _input_is_connected(candidate[1], G)
+        )
+    else:
+        predecessor_steps = {c: G.nodes[c]["step"] for c in candidate}
+        step_type = G.nodes[io]["step"]
+        raise ValueError(
+            f"Too many predecessors for {io} ({step_type}): {predecessor_steps}"
+        )
+
+
+def _is_macro_output(io: str, G: SemantikonDiGraph, candidates: tuple[str, str]):
+    predecessor_types = {G.nodes[c]["step"] for c in candidates}
+    step_type = G.nodes[io]["step"]
+    output_edge_predecessors = {"node", "outputs"}
+    return step_type == "outputs" and predecessor_types == output_edge_predecessors
 
 
 def _detect_io_from_str(G: SemantikonDiGraph, seeked_io: str, ref_io: str) -> str:

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -913,9 +913,10 @@ class TestOntology(unittest.TestCase):
             ?bnode owl:onProperty bfo:0000051 .
             ?bnode owl:someValuesFrom sns:T_wf_nested_triples-wf_triples_0 .
         }"""
-        g = onto.get_knowledge_graph(wf_nested_triples.get_semantikon_dict(), prefix="T")
+        g = onto.get_knowledge_graph(
+            wf_nested_triples.get_semantikon_dict(), prefix="T"
+        )
         self.assertTrue(g.query(query).askAnswer, msg=g.serialize())
-
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import unittest
 from dataclasses import dataclass, field
@@ -9,7 +10,7 @@ from pyshacl import validate
 from rdflib import OWL, RDF, RDFS, SH, BNode, Graph, Literal, Namespace
 from rdflib.compare import graph_diff
 
-from semantikon import ontology as onto
+from semantikon import ontology as onto, get_knowledge_graph
 from semantikon.metadata import SemantikonURI, meta
 from semantikon.visualize import visualize_recipe
 from semantikon.workflow import workflow
@@ -32,6 +33,23 @@ prefixes = """
 """
 
 sparql_prefixes = prefixes.replace("@prefix ", "PREFIX ").replace(" .\n", "\n")
+
+
+def add_one(x):
+    y = x + 1
+    return y
+
+@workflow
+def add_two(a):
+    b = add_one(a)
+    c = add_one(b)
+    return c
+
+@workflow
+def add_three(alpha):
+    beta = add_two(alpha)
+    gamma = add_two(beta)
+    return gamma
 
 
 def get_speed(
@@ -349,6 +367,41 @@ class TestOntology(unittest.TestCase):
     def setUpClass(cls):
         cls.maxDiff = None
         cls.static_dir = Path(__file__).parent.parent / "static"
+
+    def test_nested_topology(self):
+        wf_dict = add_three.get_semantikon_dict()
+
+        def _label(fnc) -> str:
+            return fnc.__name__ + "_0"
+
+        with self.subTest("Basic construction"):
+            g = onto.get_knowledge_graph(wf_dict=wf_dict)
+            validation = onto.validate_values(g)
+            self.assertTrue(
+                validation[0],
+                msg="Trivial deeply nested topology should parse and validates"
+            )
+
+        subgraph_label = add_two.__name__ + "_0"
+        subgraph_edges = wf_dict["nodes"][subgraph_label]["edges"]
+
+
+        with self.subTest("Too many inputs"):
+            extra_input = ('inputs.a', 'add_one_1.inputs.x')
+            overloaded_input_edges = list(subgraph_edges)
+            overloaded_input_edges.append(extra_input)
+            overloaded_dict = copy.deepcopy(wf_dict)
+            overloaded_dict["nodes"][subgraph_label]["edges"] = overloaded_input_edges
+
+            with self.assertRaises(
+                AssertionError,
+                msg="Providing an input with two legitimate sources (a peer source and "
+                "a parent source, in this case) should force an error. It would be "
+                "nice to hit the ValueError in __, but we hit an assertion in "
+                "`_get_data_node` first."
+            ):
+                onto.get_knowledge_graph(wf_dict=overloaded_dict)
+
 
     def test_my_kinetic_energy_workflow_graph(self):
         wf_dict = my_kinetic_energy_workflow.get_semantikon_dict()

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -355,7 +355,7 @@ class TestOntology(unittest.TestCase):
         PREFIX obi: <http://purl.obolibrary.org/obo/OBI_>
 
         ASK {{
-            ?output a sns:W20ec0adc_my_kinetic_energy_workflow-outputs-kinetic_energy .
+            ?output a sns:W2733726e_my_kinetic_energy_workflow-outputs-kinetic_energy .
             ?output ro:0000057 ?data .
             ?data qudt:hasUnit unit:J .
         }}"""

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -355,7 +355,7 @@ class TestOntology(unittest.TestCase):
         PREFIX obi: <http://purl.obolibrary.org/obo/OBI_>
 
         ASK {{
-            ?output a sns:W2733726e_my_kinetic_energy_workflow-outputs-kinetic_energy .
+            ?output a sns:Wc59275b7_my_kinetic_energy_workflow-outputs-kinetic_energy .
             ?output ro:0000057 ?data .
             ?data qudt:hasUnit unit:J .
         }}"""

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -10,7 +10,7 @@ from pyshacl import validate
 from rdflib import OWL, RDF, RDFS, SH, BNode, Graph, Literal, Namespace
 from rdflib.compare import graph_diff
 
-from semantikon import ontology as onto, get_knowledge_graph
+from semantikon import ontology as onto
 from semantikon.metadata import SemantikonURI, meta
 from semantikon.visualize import visualize_recipe
 from semantikon.workflow import workflow

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -107,6 +107,12 @@ def wf_triples(a, b):
     return a
 
 
+@workflow
+def wf_nested_triples(a, b):
+    result = wf_triples(a, b)
+    return result
+
+
 class Meal:
     pass
 
@@ -898,6 +904,18 @@ class TestOntology(unittest.TestCase):
             )
 
         os.remove("test.h5")
+
+    def test_nested_workflow(self):
+        query = sparql_prefixes + """
+        ASK {
+            sns:T_wf_nested_triples rdfs:subClassOf ?bnode .
+            ?bnode a owl:Restriction .
+            ?bnode owl:onProperty bfo:0000051 .
+            ?bnode owl:someValuesFrom sns:T_wf_nested_triples-wf_triples_0 .
+        }"""
+        g = onto.get_knowledge_graph(wf_nested_triples.get_semantikon_dict(), prefix="T")
+        self.assertTrue(g.query(query).askAnswer, msg=g.serialize())
+
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -39,11 +39,13 @@ def add_one(x):
     y = x + 1
     return y
 
+
 @workflow
 def add_two(a):
     b = add_one(a)
     c = add_one(b)
     return c
+
 
 @workflow
 def add_three(alpha):
@@ -379,15 +381,14 @@ class TestOntology(unittest.TestCase):
             validation = onto.validate_values(g)
             self.assertTrue(
                 validation[0],
-                msg="Trivial deeply nested topology should parse and validates"
+                msg="Trivial deeply nested topology should parse and validates",
             )
 
         subgraph_label = add_two.__name__ + "_0"
         subgraph_edges = wf_dict["nodes"][subgraph_label]["edges"]
 
-
         with self.subTest("Too many inputs"):
-            extra_input = ('inputs.a', 'add_one_1.inputs.x')
+            extra_input = ("inputs.a", "add_one_1.inputs.x")
             overloaded_input_edges = list(subgraph_edges)
             overloaded_input_edges.append(extra_input)
             overloaded_dict = copy.deepcopy(wf_dict)
@@ -398,10 +399,9 @@ class TestOntology(unittest.TestCase):
                 msg="Providing an input with two legitimate sources (a peer source and "
                 "a parent source, in this case) should force an error. It would be "
                 "nice to hit the ValueError in __, but we hit an assertion in "
-                "`_get_data_node` first."
+                "`_get_data_node` first.",
             ):
                 onto.get_knowledge_graph(wf_dict=overloaded_dict)
-
 
     def test_my_kinetic_energy_workflow_graph(self):
         wf_dict = my_kinetic_energy_workflow.get_semantikon_dict()


### PR DESCRIPTION
The relationship between parent node and child node is now explicitly stored in `SemantikonDiGraph` and the corresponding triple is now added in `_wf_node_to_graph` instead of `_parse_precedes`.

This being said, this is more like a quick fix to make it backward compatible for the users; we probably need an overhaul.