### PR TITLE
Nested io

### DIFF
--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -598,12 +598,12 @@ def _output_is_connected(io: str, G: SemantikonDiGraph) -> bool:
             return True
         return _output_is_connected(candidate[0], G)
     elif n_candidates == 2 and _is_macro_input(io, G, tuple(candidate)):
-        return (
-            _output_is_connected(candidate[0], G)
-            and _output_is_connected(candidate[1], G)
+        return _output_is_connected(candidate[0], G) and _output_is_connected(
+            candidate[1], G
         )
     else:
         return any(_output_is_connected(c, G) for c in candidate)
+
 
 def _is_macro_input(io: str, G: SemantikonDiGraph, candidates: tuple[str, str]):
     successor_types = {G.nodes[c]["step"] for c in candidates}
@@ -622,9 +622,8 @@ def _input_is_connected(io: str, G: SemantikonDiGraph) -> bool:
             return True
         return _input_is_connected(candidate[0], G)
     elif n_predecessors == 2 and _is_macro_output(io, G, tuple(candidate)):
-        return (
-            _input_is_connected(candidate[0], G)
-            and _input_is_connected(candidate[1], G)
+        return _input_is_connected(candidate[0], G) and _input_is_connected(
+            candidate[1], G
         )
     else:
         predecessor_steps = {c: G.nodes[c]["step"] for c in candidate}

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -590,20 +590,26 @@ def _wf_node_to_graph(
 
 def _output_is_connected(io: str, G: SemantikonDiGraph) -> bool:
     candidate = list(G.successors(io))
-    if len(candidate) == 1:
+    n_candidates = len(candidate)
+    if n_candidates == 0:
+        return False
+    elif n_candidates == 1:
         if G.nodes[candidate[0]]["step"] == "node":
             return True
         return _output_is_connected(candidate[0], G)
-    elif len(candidate) > 1:
-        if trouble := {
-            c: G.nodes[c] for c in candidate if G.nodes[c]["step"] == "node"
-        }:
-            raise ValueError(
-                f"Problematic candidates for {io} `_output_is_connected` check from "
-                f"among {candidate}: {trouble!r}"
-            )
+    elif n_candidates == 2 and _is_macro_input(io, G, tuple(candidate)):
+        return (
+            _output_is_connected(candidate[0], G)
+            and _output_is_connected(candidate[1], G)
+        )
+    else:
         return any(_output_is_connected(c, G) for c in candidate)
-    return False
+
+def _is_macro_input(io: str, G: SemantikonDiGraph, candidates: tuple[str, str]):
+    successor_types = {G.nodes[c]["step"] for c in candidates}
+    step_type = G.nodes[io]["step"]
+    input_edge_predecessors = {"node", "inputs"}
+    return step_type == "inputs" and successor_types == input_edge_predecessors
 
 
 def _input_is_connected(io: str, G: SemantikonDiGraph) -> bool:

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -614,13 +614,31 @@ def _is_macro_input(io: str, G: SemantikonDiGraph, candidates: tuple[str, str]):
 
 def _input_is_connected(io: str, G: SemantikonDiGraph) -> bool:
     candidate = list(G.predecessors(io))
-    if len(candidate) == 1:
+    n_predecessors = len(candidate)
+    if n_predecessors == 0:
+        return False
+    elif n_predecessors == 1:
         if G.nodes[candidate[0]]["step"] == "node":
             return True
         return _input_is_connected(candidate[0], G)
-    if len(candidate) != 0:
-        raise ValueError(f"Too many predecessors for {io}: {candidate}")
-    return False
+    elif n_predecessors == 2 and _is_macro_output(io, G, tuple(candidate)):
+        return (
+            _input_is_connected(candidate[0], G)
+            and _input_is_connected(candidate[1], G)
+        )
+    else:
+        predecessor_steps = {c: G.nodes[c]["step"] for c in candidate}
+        step_type = G.nodes[io]["step"]
+        raise ValueError(
+            f"Too many predecessors for {io} ({step_type}): {predecessor_steps}"
+        )
+
+
+def _is_macro_output(io: str, G: SemantikonDiGraph, candidates: tuple[str, str]):
+    predecessor_types = {G.nodes[c]["step"] for c in candidates}
+    step_type = G.nodes[io]["step"]
+    output_edge_predecessors = {"node", "outputs"}
+    return step_type == "outputs" and predecessor_types == output_edge_predecessors
 
 
 def _detect_io_from_str(G: SemantikonDiGraph, seeked_io: str, ref_io: str) -> str:

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import unittest
 from dataclasses import dataclass, field
@@ -9,7 +10,7 @@ from pyshacl import validate
 from rdflib import OWL, RDF, RDFS, SH, BNode, Graph, Literal, Namespace
 from rdflib.compare import graph_diff
 
-from semantikon import ontology as onto
+from semantikon import ontology as onto, get_knowledge_graph
 from semantikon.metadata import SemantikonURI, meta
 from semantikon.visualize import visualize_recipe
 from semantikon.workflow import workflow
@@ -32,6 +33,23 @@ prefixes = """
 """
 
 sparql_prefixes = prefixes.replace("@prefix ", "PREFIX ").replace(" .\n", "\n")
+
+
+def add_one(x):
+    y = x + 1
+    return y
+
+@workflow
+def add_two(a):
+    b = add_one(a)
+    c = add_one(b)
+    return c
+
+@workflow
+def add_three(alpha):
+    beta = add_two(alpha)
+    gamma = add_two(beta)
+    return gamma
 
 
 def get_speed(
@@ -349,6 +367,41 @@ class TestOntology(unittest.TestCase):
     def setUpClass(cls):
         cls.maxDiff = None
         cls.static_dir = Path(__file__).parent.parent / "static"
+
+    def test_nested_topology(self):
+        wf_dict = add_three.get_semantikon_dict()
+
+        def _label(fnc) -> str:
+            return fnc.__name__ + "_0"
+
+        with self.subTest("Basic construction"):
+            g = onto.get_knowledge_graph(wf_dict=wf_dict)
+            validation = onto.validate_values(g)
+            self.assertTrue(
+                validation[0],
+                msg="Trivial deeply nested topology should parse and validates"
+            )
+
+        subgraph_label = add_two.__name__ + "_0"
+        subgraph_edges = wf_dict["nodes"][subgraph_label]["edges"]
+
+
+        with self.subTest("Too many inputs"):
+            extra_input = ('inputs.a', 'add_one_1.inputs.x')
+            overloaded_input_edges = list(subgraph_edges)
+            overloaded_input_edges.append(extra_input)
+            overloaded_dict = copy.deepcopy(wf_dict)
+            overloaded_dict["nodes"][subgraph_label]["edges"] = overloaded_input_edges
+
+            with self.assertRaises(
+                AssertionError,
+                msg="Providing an input with two legitimate sources (a peer source and "
+                "a parent source, in this case) should force an error. It would be "
+                "nice to hit the ValueError in __, but we hit an assertion in "
+                "`_get_data_node` first."
+            ):
+                onto.get_knowledge_graph(wf_dict=overloaded_dict)
+
 
     def test_my_kinetic_energy_workflow_graph(self):
         wf_dict = my_kinetic_energy_workflow.get_semantikon_dict()

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -10,7 +10,7 @@ from pyshacl import validate
 from rdflib import OWL, RDF, RDFS, SH, BNode, Graph, Literal, Namespace
 from rdflib.compare import graph_diff
 
-from semantikon import ontology as onto, get_knowledge_graph
+from semantikon import ontology as onto
 from semantikon.metadata import SemantikonURI, meta
 from semantikon.visualize import visualize_recipe
 from semantikon.workflow import workflow

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -39,11 +39,13 @@ def add_one(x):
     y = x + 1
     return y
 
+
 @workflow
 def add_two(a):
     b = add_one(a)
     c = add_one(b)
     return c
+
 
 @workflow
 def add_three(alpha):
@@ -379,15 +381,14 @@ class TestOntology(unittest.TestCase):
             validation = onto.validate_values(g)
             self.assertTrue(
                 validation[0],
-                msg="Trivial deeply nested topology should parse and validates"
+                msg="Trivial deeply nested topology should parse and validates",
             )
 
         subgraph_label = add_two.__name__ + "_0"
         subgraph_edges = wf_dict["nodes"][subgraph_label]["edges"]
 
-
         with self.subTest("Too many inputs"):
-            extra_input = ('inputs.a', 'add_one_1.inputs.x')
+            extra_input = ("inputs.a", "add_one_1.inputs.x")
             overloaded_input_edges = list(subgraph_edges)
             overloaded_input_edges.append(extra_input)
             overloaded_dict = copy.deepcopy(wf_dict)
@@ -398,10 +399,9 @@ class TestOntology(unittest.TestCase):
                 msg="Providing an input with two legitimate sources (a peer source and "
                 "a parent source, in this case) should force an error. It would be "
                 "nice to hit the ValueError in __, but we hit an assertion in "
-                "`_get_data_node` first."
+                "`_get_data_node` first.",
             ):
                 onto.get_knowledge_graph(wf_dict=overloaded_dict)
-
 
     def test_my_kinetic_energy_workflow_graph(self):
         wf_dict = my_kinetic_energy_workflow.get_semantikon_dict()


### PR DESCRIPTION
There is a root paradigm is that the graph connectivity proceeds `input -> node -> output`. By including nested workflows such that parents pass their input to children, and populate their output from children, we get `input -> node + input -> child_input` and `node -> output + child_output -> output`, which breaks some of the validation. The place I'm running into this is in nested macros. Consider this simple case:

```python
import semantikon
from semantikon.workflow import workflow

def add_one(x):
    y = x + 1
    return y

@workflow
def add_two(a):
    b = add_one(a)
    c = add_one(b)
    return c

@workflow
def add_three(alpha):
    beta = add_two(alpha)
    gamma = add_two(beta)
    return gamma

wf_dict = add_three.get_semantikon_dict()
wf_dict

```

<details>
<summary>Which has a (IMO) reasonable and well formed dictionary representation</summary>

```
{'type': 'workflow',
 'label': 'add_three',
 'nodes': {'add_two_0': {'type': 'workflow',
   'label': 'add_two_0',
   'nodes': {'add_one_0': {'type': 'atomic',
     'function': <function __main__.add_one(x)>,
     'inputs': {'x': {}},
     'outputs': {'y': {}}},
    'add_one_1': {'type': 'atomic',
     'function': <function __main__.add_one(x)>,
     'inputs': {'x': {}},
     'outputs': {'y': {}}}},
   'edges': [('inputs.a', 'add_one_0.inputs.x'),
    ('add_one_0.outputs.y', 'add_one_1.inputs.x'),
    ('add_one_1.outputs.y', 'outputs.c')],
   'inputs': {'a': {}},
   'outputs': {'c': {}},
   'function': <function __main__.add_two(a)>},
  'add_two_1': {'type': 'workflow',
   'label': 'add_two_1',
   'nodes': {'add_one_0': {'type': 'atomic',
     'function': <function __main__.add_one(x)>,
     'inputs': {'x': {}},
     'outputs': {'y': {}}},
    'add_one_1': {'type': 'atomic',
     'function': <function __main__.add_one(x)>,
     'inputs': {'x': {}},
     'outputs': {'y': {}}}},
   'edges': [('inputs.a', 'add_one_0.inputs.x'),
    ('add_one_0.outputs.y', 'add_one_1.inputs.x'),
    ('add_one_1.outputs.y', 'outputs.c')],
   'inputs': {'a': {}},
   'outputs': {'c': {}},
   'function': <function __main__.add_two(a)>}},
 'edges': [('inputs.alpha', 'add_two_0.inputs.a'),
  ('add_two_0.outputs.c', 'add_two_1.inputs.a'),
  ('add_two_1.outputs.c', 'outputs.gamma')],
 'inputs': {'alpha': {}},
 'outputs': {'gamma': {}},
 'function': <function __main__.add_three(alpha)>}
```

</details>

Therefor, we'd like to be able to validate it:

```python
g = semantikon.get_knowledge_graph(wf_dict=wf_dict)
semantikon.validate_values(g)
```

Here this works fine, because I've modified the `_output_is_connected` and `_input_is_connected` checks to look (in a quacks-like-a-duck way) to see if we're looking at a port negotiating this sort of subgraph information flow.

On #425 it raises an error like:

```
----> 1 g = semantikon.get_knowledge_graph(wf_dict=wf_dict)

...

ValueError: Problematic candidates for add_three-add_two_1-inputs-a `_output_is_connected` check from among ['add_three-add_two_1', 'add_three-add_two_1-add_one_0-inputs-x']: {'add_three-add_two_1': {'step': 'node', 'type': 'workflow', 'label': 'add_two_1', 'function': {'module': '__main__', 'qualname': 'add_two', 'version': 'not_defined', 'hash': 'add_two:11dbfeca63783b3ec675a13c5d816b149b117fa49bf1f5104cb718fe7a497693', 'docstring': '', 'name': 'add_two', 'identifier': '__main__.add_two.not_defined'}, 'parent': 'add_three'}}
```

I.e. `add_three-add_two_1-inputs-a` is being swept up in an _output_ connection check, and fails because it has as its successor both its owning node (because `input -> node`) and the child input (because this is how information gets down into the subgraph).

At a minimum, I'll add tests based off this example to validate that the `SemantikonDigraph` generation handles nested topology. I also see that in #425 the "parent" info is explicitly tracked, so I might be able to use that to get the "is this negotiating subgraph data flow?" check to be more robust.