### PR TITLE
[nit] add error message

### DIFF
--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -359,7 +359,12 @@ class TestOntology(unittest.TestCase):
             ?output ro:0000057 ?data .
             ?data qudt:hasUnit unit:J .
         }}"""
-        self.assertTrue(g.query(query).askAnswer, msg=g.serialize())
+        self.assertTrue(
+            g.query(query).askAnswer, msg=g.serialize() + """
+            The reason why this test failed is probably because the representation
+            of the workflow graph changed and therefore also its hash value
+            """
+        )
         self.assertTrue(onto.validate_values(g)[0])
 
     def test_to_restrictions(self):

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -360,11 +360,12 @@ class TestOntology(unittest.TestCase):
             ?data qudt:hasUnit unit:J .
         }}"""
         self.assertTrue(
-            g.query(query).askAnswer, msg=g.serialize() + """
+            g.query(query).askAnswer,
+            msg=g.serialize() + """
             The reason why this test failed is probably because the representation
             of the workflow graph changed and therefore also its hash value
             (starting with W in the URI)
-            """
+            """,
         )
         self.assertTrue(onto.validate_values(g)[0])
 

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -363,6 +363,7 @@ class TestOntology(unittest.TestCase):
             g.query(query).askAnswer, msg=g.serialize() + """
             The reason why this test failed is probably because the representation
             of the workflow graph changed and therefore also its hash value
+            (starting with W in the URI)
             """
         )
         self.assertTrue(onto.validate_values(g)[0])


### PR DESCRIPTION
This unit test is meant to check the consistency among different OS and python versions, but since semantikon is still evolving, the hash value might not stay the same. Nevertheless, I think it helps us to understand the error better