### PR TITLE
Translate `owl:disjointWith` into shacl shape

### DIFF
--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -1549,10 +1549,13 @@ class _OWLToSHACLConverter:
         """
         self.owl_graph = owl_graph
         self.excluded_nodes = excluded_nodes
-        self.shacl_graph = _get_bound_graph()
-        self.node_shapes: dict[URIRef, BNode] = {}
-        self.shacl_graph.bind("sh", str(SH))
-        self.shacl_graph.bind("sns", str(BASE))
+
+    @staticmethod
+    def _get_bound_graph():
+        shacl_graph = _get_bound_graph()
+        shacl_graph.bind("sh", str(SH))
+        shacl_graph.bind("sns", str(BASE))
+        return shacl_graph
 
     def _iter_supported_restrictions(self):
         """
@@ -1577,73 +1580,82 @@ class _OWLToSHACLConverter:
                 for base_cls in self.owl_graph.subjects(RDFS.subClassOf, r):
                     yield base_cls, prop, restriction_type, value
 
-    def _translate_disjoint_with(self):
+    def _translate_restrictions(self) -> Graph:
+        node_shapes: dict[URIRef, BNode] = {}
+        shacl_graph = self._get_bound_graph()
+        for base_cls, prop, rtype, value in self._iter_supported_restrictions():
+
+            # One NodeShape per base class
+            if base_cls not in node_shapes:
+                ns = BNode()
+                node_shapes[base_cls] = ns
+                shacl_graph.add((ns, RDF.type, SH.NodeShape))
+                shacl_graph.add((ns, SH.targetClass, base_cls))
+            else:
+                ns = node_shapes[base_cls]
+
+            ps = BNode()
+            shacl_graph.add((ps, RDF.type, SH.PropertyShape))
+            shacl_graph.add((ps, SH.path, prop))
+
+            if rtype == OWL.someValuesFrom:
+                # Existential restriction:
+                # ∃ prop . C  →  qualifiedValueShape + qualifiedMinCount
+                qvs = BNode()
+                shacl_graph.add((qvs, SH["class"], value))
+
+                shacl_graph.add((ps, SH.qualifiedValueShape, qvs))
+                shacl_graph.add((ps, SH.qualifiedMinCount, Literal(1)))
+
+            elif rtype == OWL.hasValue:
+                shacl_graph.add((ps, SH.hasValue, value))
+
+            elif rtype == OWL.allValuesFrom:
+                # Universal restriction:
+                # ∀ prop . C  →  class
+                shacl_graph.add((ps, SH["class"], value))
+
+            shacl_graph.add((ns, SH.property, ps))
+        return shacl_graph
+
+    def _translate_disjoint_with(self) -> Graph:
         """
         Translate OWL disjointWith axioms into SHACL shapes with sh:not.
         """
+        node_shapes: dict[URIRef, BNode] = {}
+        shacl_graph = self._get_bound_graph()
         for cls in self.owl_graph.subjects(RDF.type, OWL.Class):
             disjoints = list(self.owl_graph.objects(cls, OWL.disjointWith))
             if not disjoints:
                 continue
 
             # Create a NodeShape for the class if it doesn't exist
-            if cls not in self.node_shapes:
+            if cls not in node_shapes:
                 ns = BNode()
-                self.node_shapes[cls] = ns
-                self.shacl_graph.add((ns, RDF.type, SH.NodeShape))
-                self.shacl_graph.add((ns, SH.targetClass, cls))
+                node_shapes[cls] = ns
+                shacl_graph.add((ns, RDF.type, SH.NodeShape))
+                shacl_graph.add((ns, SH.targetClass, cls))
             else:
-                ns = self.node_shapes[cls]
+                ns = node_shapes[cls]
 
             # Create a shape that represents the disjoint classes
             disjoint_shape = BNode()
-            self.shacl_graph.add((disjoint_shape, RDF.type, SH.NodeShape))
+            shacl_graph.add((disjoint_shape, RDF.type, SH.NodeShape))
             for disjoint_cls in disjoints:
-                self.shacl_graph.add((disjoint_shape, SH.targetClass, disjoint_cls))
+                shacl_graph.add((disjoint_shape, SH.targetClass, disjoint_cls))
 
             # Add a sh:not constraint to the original shape
-            self.shacl_graph.add((ns, SH["not"], disjoint_shape))
+            shacl_graph.add((ns, SH["not"], disjoint_shape))
+        return shacl_graph
 
     def convert(self) -> Graph:
         """
         Convert the OWL restrictions in the graph to SHACL shapes.
         """
-        for base_cls, prop, rtype, value in self._iter_supported_restrictions():
 
-            # One NodeShape per base class
-            if base_cls not in self.node_shapes:
-                ns = BNode()
-                self.node_shapes[base_cls] = ns
-                self.shacl_graph.add((ns, RDF.type, SH.NodeShape))
-                self.shacl_graph.add((ns, SH.targetClass, base_cls))
-            else:
-                ns = self.node_shapes[base_cls]
-
-            ps = BNode()
-            self.shacl_graph.add((ps, RDF.type, SH.PropertyShape))
-            self.shacl_graph.add((ps, SH.path, prop))
-
-            if rtype == OWL.someValuesFrom:
-                # Existential restriction:
-                # ∃ prop . C  →  qualifiedValueShape + qualifiedMinCount
-                qvs = BNode()
-                self.shacl_graph.add((qvs, SH["class"], value))
-
-                self.shacl_graph.add((ps, SH.qualifiedValueShape, qvs))
-                self.shacl_graph.add((ps, SH.qualifiedMinCount, Literal(1)))
-
-            elif rtype == OWL.hasValue:
-                self.shacl_graph.add((ps, SH.hasValue, value))
-
-            elif rtype == OWL.allValuesFrom:
-                # Universal restriction:
-                # ∀ prop . C  →  class
-                self.shacl_graph.add((ps, SH["class"], value))
-
-            self.shacl_graph.add((ns, SH.property, ps))
-
-        self._translate_disjoint_with()
-        return self.shacl_graph
+        shacl_graph = self._translate_restrictions()
+        shacl_graph += self._translate_disjoint_with()
+        return shacl_graph
 
 
 def owl_restrictions_to_shacl(

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -1623,10 +1623,7 @@ class _OWLToSHACLConverter:
         node_shapes: dict[URIRef, BNode] = {}
         shacl_graph = self._get_bound_graph()
         for cls in self.owl_graph.subjects(RDF.type, OWL.Class):
-            disjoints = {
-                *self.owl_graph.objects(cls, OWL.disjointWith),
-                *self.owl_graph.subjects(OWL.disjointWith, cls),
-            }
+            disjoints = list(self.owl_graph.objects(cls, OWL.disjointWith))
             if not disjoints:
                 continue
 

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -1602,7 +1602,7 @@ class _OWLToSHACLConverter:
                 self.shacl_graph.add((disjoint_shape, SH.targetClass, disjoint_cls))
 
             # Add a sh:not constraint to the original shape
-            self.shacl_graph.add((ns, SH.not_, disjoint_shape))
+            self.shacl_graph.add((ns, SH["not"], disjoint_shape))
 
 
     def convert(self) -> Graph:

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -1623,7 +1623,10 @@ class _OWLToSHACLConverter:
         node_shapes: dict[URIRef, BNode] = {}
         shacl_graph = self._get_bound_graph()
         for cls in self.owl_graph.subjects(RDF.type, OWL.Class):
-            disjoints = list(self.owl_graph.objects(cls, OWL.disjointWith))
+            disjoints = {
+                *self.owl_graph.objects(cls, OWL.disjointWith),
+                *self.owl_graph.subjects(OWL.disjointWith, cls),
+            }
             if not disjoints:
                 continue
 

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -1554,7 +1554,7 @@ class _OWLToSHACLConverter:
         self.shacl_graph.bind("sh", str(SH))
         self.shacl_graph.bind("sns", str(BASE))
 
-    def iter_supported_restrictions(self):
+    def _iter_supported_restrictions(self):
         """
         Yield (base_class, restriction_node, property, restriction_type, value)
         for supported OWL restrictions.
@@ -1577,11 +1577,39 @@ class _OWLToSHACLConverter:
                 for base_cls in self.owl_graph.subjects(RDFS.subClassOf, r):
                     yield base_cls, prop, restriction_type, value
 
+    def _translate_disjoint_with(self):
+        """
+        Translate OWL disjointWith axioms into SHACL shapes with sh:not.
+        """
+        for cls in self.owl_graph.subjects(RDF.type, OWL.Class):
+            disjoints = list(self.owl_graph.objects(cls, OWL.disjointWith))
+            if not disjoints:
+                continue
+
+            # Create a NodeShape for the class if it doesn't exist
+            if cls not in self.node_shapes:
+                ns = BNode()
+                self.node_shapes[cls] = ns
+                self.shacl_graph.add((ns, RDF.type, SH.NodeShape))
+                self.shacl_graph.add((ns, SH.targetClass, cls))
+            else:
+                ns = self.node_shapes[cls]
+
+            # Create a shape that represents the disjoint classes
+            disjoint_shape = BNode()
+            self.shacl_graph.add((disjoint_shape, RDF.type, SH.NodeShape))
+            for disjoint_cls in disjoints:
+                self.shacl_graph.add((disjoint_shape, SH.targetClass, disjoint_cls))
+
+            # Add a sh:not constraint to the original shape
+            self.shacl_graph.add((ns, SH.not_, disjoint_shape))
+
+
     def convert(self) -> Graph:
         """
         Convert the OWL restrictions in the graph to SHACL shapes.
         """
-        for base_cls, prop, rtype, value in self.iter_supported_restrictions():
+        for base_cls, prop, rtype, value in self._iter_supported_restrictions():
 
             # One NodeShape per base class
             if base_cls not in self.node_shapes:
@@ -1615,6 +1643,7 @@ class _OWLToSHACLConverter:
 
             self.shacl_graph.add((ns, SH.property, ps))
 
+        self._translate_disjoint_with()
         return self.shacl_graph
 
 

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -1628,13 +1628,11 @@ class _OWLToSHACLConverter:
                 continue
 
             # Create a NodeShape for the class if it doesn't exist
-            if cls not in node_shapes:
+            if not (ns := node_shapes.get(cls)):
                 ns = BNode()
                 node_shapes[cls] = ns
                 shacl_graph.add((ns, RDF.type, SH.NodeShape))
                 shacl_graph.add((ns, SH.targetClass, cls))
-            else:
-                ns = node_shapes[cls]
 
             # Create a shape that represents the disjoint classes
             disjoint_shape = BNode()
@@ -1648,9 +1646,9 @@ class _OWLToSHACLConverter:
 
     def convert(self) -> Graph:
         """
-        Convert the OWL restrictions in the graph to SHACL shapes.
+        Convert the OWL logics into SHACL shapes, including both restrictions
+        and disjointness axioms.
         """
-
         shacl_graph = self._translate_restrictions()
         shacl_graph += self._translate_disjoint_with()
         return shacl_graph

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -1604,7 +1604,6 @@ class _OWLToSHACLConverter:
             # Add a sh:not constraint to the original shape
             self.shacl_graph.add((ns, SH["not"], disjoint_shape))
 
-
     def convert(self) -> Graph:
         """
         Convert the OWL restrictions in the graph to SHACL shapes.

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -1551,7 +1551,7 @@ class _OWLToSHACLConverter:
         self.excluded_nodes = excluded_nodes
 
     @staticmethod
-    def _get_bound_graph():
+    def _new_shacl_graph():
         shacl_graph = _get_bound_graph()
         shacl_graph.bind("sh", str(SH))
         shacl_graph.bind("sns", str(BASE))
@@ -1582,7 +1582,7 @@ class _OWLToSHACLConverter:
 
     def _translate_restrictions(self) -> Graph:
         node_shapes: dict[URIRef, BNode] = {}
-        shacl_graph = self._get_bound_graph()
+        shacl_graph = self._new_shacl_graph()
         for base_cls, prop, rtype, value in self._iter_supported_restrictions():
 
             # One NodeShape per base class
@@ -1621,7 +1621,7 @@ class _OWLToSHACLConverter:
         Translate OWL disjointWith axioms into SHACL shapes with sh:not.
         """
         node_shapes: dict[URIRef, BNode] = {}
-        shacl_graph = self._get_bound_graph()
+        shacl_graph = self._new_shacl_graph()
         for cls in self.owl_graph.subjects(RDF.type, OWL.Class):
             disjoints = list(self.owl_graph.objects(cls, OWL.disjointWith))
             if not disjoints:

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -1559,7 +1559,7 @@ class _OWLToSHACLConverter:
 
     def _iter_supported_restrictions(self):
         """
-        Yield (base_class, restriction_node, property, restriction_type, value)
+        Yield (base_class, property, restriction_type, value) tuples
         for supported OWL restrictions.
         """
         for r in self.owl_graph.subjects(RDF.type, OWL.Restriction):

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -1586,13 +1586,11 @@ class _OWLToSHACLConverter:
         for base_cls, prop, rtype, value in self._iter_supported_restrictions():
 
             # One NodeShape per base class
-            if base_cls not in node_shapes:
+            if not (ns := node_shapes.get(base_cls)):
                 ns = BNode()
                 node_shapes[base_cls] = ns
                 shacl_graph.add((ns, RDF.type, SH.NodeShape))
                 shacl_graph.add((ns, SH.targetClass, base_cls))
-            else:
-                ns = node_shapes[base_cls]
 
             ps = BNode()
             shacl_graph.add((ps, RDF.type, SH.PropertyShape))

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -152,6 +152,16 @@ def eat_pizza():
     return comment
 
 
+class Drink:
+    pass
+
+
+@workflow
+def swallow_pizza_painfully(drink: Annotated[Drink, {"uri": EX.Water}]):
+    x = eat(drink)
+    return x
+
+
 uri_color = SemantikonURI(EX.Color)
 uri_cleaned = SemantikonURI(EX.Cleaned)
 
@@ -977,6 +987,28 @@ class TestOntology(unittest.TestCase):
             wf_nested_triples.get_semantikon_dict(), prefix="T"
         )
         self.assertTrue(g.query(query).askAnswer, msg=g.serialize())
+
+    def test_inconsistent_workflow_and_child_node_inputs(self):
+        wf_dict = swallow_pizza_painfully.get_semantikon_dict()
+        g = onto.get_knowledge_graph(wf_dict)
+        self.assertTrue(
+            onto.validate_values(g)[0],
+            msg=dedent("""
+                As long as the knowledge graph does not know that EX.Meal and
+                EX.Water are disjoint, it should not raise an error
+            """),
+        )
+        g.add((EX.Meal, OWL.disjointWith, EX.Water))
+        g.add((EX.Meal, RDF.type, OWL.Class))
+        g.add((EX.Water, RDF.type, OWL.Class))
+        self.assertFalse(
+            onto.validate_values(g)[0],
+            msg=dedent("""
+                Once we add that EX.Meal and EX.Water are disjoint, the workflow
+                should be inconsistent because it requires an individual to be
+                both a Meal and a Water.
+            """),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

```python
import rdflib

import semantikon
from semantikon.workflow import workflow

EX: rdflib.Namespace = rdflib.Namespace("http://example.org/")


def io_transformer(
    x: semantikon.u(int, uri=EX.Input),
) -> semantikon.u(int, uri=EX.Output):
    y = x
    return y

@workflow
def bad_parent_edge(
    x_outer: semantikon.u(int, uri=EX.NotInput)
) -> semantikon.u(int, uri=EX.Output):
    transformed = io_transformer(x_outer)
    return transformed

kg = semantikon.get_knowledge_graph(bad_parent_edge.get_semantikon_dict())
kg.add((EX.Input, rdflib.OWL.disjointWith, EX.NotInput))
kg.add((EX.Input, rdflib.RDF.type, rdflib.OWL.Class))
kg.add((EX.NotInput, rdflib.RDF.type, rdflib.OWL.Class))

semantikon.validate_values(kg)
```

This now gives `False` because `ex:NotInput` and `ex:Input` are disjoint and no object can provide them both at the same time.