### PR TITLE
Correct inheritance of URI

### DIFF
--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -198,6 +198,7 @@ def _inherit_properties(graph: Graph, n_max: int = 1000):
     PREFIX owl: <{OWL}>
     PREFIX ro: <{RO}>
     PREFIX pmdco: <{PMD}>
+    PREFIX obi: <{OBI}>
     INSERT {{
         ?subject ?p ?o .
     }}
@@ -210,6 +211,7 @@ def _inherit_properties(graph: Graph, n_max: int = 1000):
         FILTER(?p != pmdco:0000006)
         FILTER(?p != rdf:type)
         FILTER(?p != owl:sameAs)
+        FILTER(?p != obi:0001927)
     }}
     """
     n = 0

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -1021,13 +1021,13 @@ class TestOntology(unittest.TestCase):
         onto._inherit_properties(g)
         uri_node = list(g.subjects(RDF.type, EX.Something))[0]
         data_node = list(g.subjects(onto.SNS.specifies_value_of, uri_node))
-        self.assertEqual(
-            len(data_node),
-            1,
+        self.assertIn(
+            "wf_triples-inputs-a_data",
+            str(data_node[0]),
             msg=dedent(f"""
                 Expected only the input data node specifying value of {uri_node}
                 (which should end with 'wf_triples-inputs-a_data'), found
-                {len(data_node)}
+                {data_node}
                 """),
         )
 

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -114,9 +114,15 @@ def get_speed_with_dataclass(speed_data: NewSpeedData):
 
 
 def f_triples(
-    a: float, b: Annotated[float, {"triples": ("self", EX.relatedTo, "inputs.a")}]
+    a: Annotated[float, {"uri": EX.Something}],
+    b: Annotated[float, {"triples": ("self", EX.relatedTo, "inputs.a")}],
 ) -> Annotated[
-    float, {"triples": ((EX.hasSomeRelation, "inputs.b")), "derived_from": "inputs.a"}
+    float,
+    {
+        "triples": ((EX.hasSomeRelation, "inputs.b")),
+        "derived_from": "inputs.a",
+        "uri": EX.SomethingElse,
+    },
 ]:
     return a
 
@@ -1008,6 +1014,21 @@ class TestOntology(unittest.TestCase):
                 should be inconsistent because it requires an individual to be
                 both a Meal and a Water.
             """),
+        )
+
+    def test_inheritance_of_derives_from(self):
+        g = onto.get_knowledge_graph(wf_triples.get_semantikon_dict())
+        onto._inherit_properties(g)
+        uri_node = list(g.subjects(RDF.type, EX.Something))[0]
+        data_node = list(g.subjects(onto.SNS.specifies_value_of, uri_node))
+        self.assertEqual(
+            len(data_node),
+            1,
+            msg=dedent(f"""
+                Expected only the input data node specifying value of {uri_node}
+                (which should end with 'wf_triples-inputs-a_data'), found
+                {len(data_node)}
+                """),
         )
 
 


### PR DESCRIPTION
(I had forgot to take care of this when we moved from `rdf:type` to `obi:specifies_value_of`)

This pull request makes improvements to ontology property inheritance logic and updates related unit tests to ensure correct behavior. The main changes include refining property filtering in the `_inherit_properties` function, adding new prefixes, and enhancing test coverage for property inheritance and annotation handling.

**Ontology property inheritance improvements:**

* Added the `obi` prefix to SPARQL queries in the `_inherit_properties` function in `ontology.py` to support additional ontology terms.
* Updated property filtering in `_inherit_properties` to exclude the `obi:0001927` property, preventing unintended inheritance of this property.

**Unit test enhancements:**

* Modified the `f_triples` function annotation in `test_ontology.py` to include explicit `uri` metadata for both input and output parameters, improving clarity and test accuracy.
* Added a new test, `test_inheritance_of_derives_from`, to verify that derived property inheritance correctly associates input data nodes with their corresponding URIs.