### PR TITLE
Forbid `derived_from` in inputs

### DIFF
--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -755,6 +755,11 @@ def _wf_input_to_graph(
 ) -> Graph:
     g = _get_bound_graph()
     units = data.get("units", data.get("unit"))
+    if "derived_from" in data:
+        raise ValueError(
+            f"'derived_from' (defined for the argument '{data['arg']}') is not"
+            " supported for inputs."
+        )
     if t_box:
         data_node = G.t_ns[G._get_data_node(io=node_name)]
         if _input_is_connected(node_name, G):

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -397,6 +397,17 @@ def my_unhashable_inputs(uh):
     return result
 
 
+def use_derived_from_wrongly_in_input(
+    x: Annotated[float, {"derived_from": "inputs.x"}],
+):
+    return x
+
+
+@workflow
+def workflow_with_wrong_derived_from(x):
+    result = use_derived_from_wrongly_in_input(x)
+    return result
+
 
 class TestOntology(unittest.TestCase):
     @classmethod
@@ -1068,6 +1079,13 @@ class TestOntology(unittest.TestCase):
                 (which should end with 'wf_triples-inputs-a_data'), found
                 {data_node}
                 """),
+        )
+
+    def test_derived_from_in_inputs(self):
+        self.assertRaises(
+            ValueError,
+            onto.get_knowledge_graph,
+            workflow_with_wrong_derived_from.get_semantikon_dict()
         )
 
 

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -374,6 +374,7 @@ def my_unhashable_inputs(uh):
     return result
 
 
+
 class TestOntology(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -1085,7 +1085,7 @@ class TestOntology(unittest.TestCase):
         self.assertRaises(
             ValueError,
             onto.get_knowledge_graph,
-            workflow_with_wrong_derived_from.get_semantikon_dict()
+            workflow_with_wrong_derived_from.get_semantikon_dict(),
         )
 
 


### PR DESCRIPTION
This pull request introduces validation to prevent the use of the `derived_from` attribute in workflow input definitions, as this is not supported. It also adds comprehensive test coverage to ensure this restriction is enforced.

**Input validation improvements:**

* Added a check in `_wf_input_to_graph` (in `semantikon/ontology.py`) to raise a `ValueError` if `derived_from` is specified in input argument metadata, preventing unsupported usage.

**Test coverage:**

* Added a new workflow and function in `tests/unit/test_ontology.py` that intentionally misuses `derived_from` in an input, to test the new validation.
* Implemented a unit test to assert that using `derived_from` in workflow inputs raises a `ValueError`, ensuring the validation works as intended.