### PR TITLE
[refactor] Separate workflow flattener

### DIFF
--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -1350,19 +1350,18 @@ class _WorkflowGraphSerializer:
     Serializes a workflow dictionary into a SemantikonDiGraph.
     """
 
-    def __init__(self, wf_dict: dict, prefix: str | None = None):
+    def __init__(self, wf_dict: dict):
         self.wf_dict = wf_dict
-        self.prefix = prefix
 
     # -----------------------------
     # Serialization
     # -----------------------------
 
-    def serialize(self) -> SemantikonDiGraph:
+    def serialize(self) -> nx.DiGraph:
         node_dict, channel_dict, edge_list = _WorkflowFlattener.flatten(
             self.wf_dict, self.wf_dict["label"]
         )
-        G = SemantikonDiGraph(prefix=self.prefix)
+        G = nx.DiGraph()
 
         self._add_channels(G, channel_dict)
         self._add_nodes(G, node_dict)
@@ -1370,7 +1369,7 @@ class _WorkflowGraphSerializer:
 
         return self._relabel_graph(G)
 
-    def _add_channels(self, G: SemantikonDiGraph, channel_dict: dict) -> None:
+    def _add_channels(self, G: nx.DiGraph, channel_dict: dict) -> None:
         for key, data in channel_dict.items():
             G.add_node(
                 key,
@@ -1378,7 +1377,7 @@ class _WorkflowGraphSerializer:
                 **{k: v for k, v in data.items() if k != "semantikon_type"},
             )
 
-    def _add_nodes(self, G: SemantikonDiGraph, node_dict: dict) -> None:
+    def _add_nodes(self, G: nx.DiGraph, node_dict: dict) -> None:
         for key, data in node_dict.items():
             if "." not in key:
                 G.name = key
@@ -1395,12 +1394,12 @@ class _WorkflowGraphSerializer:
             for out in data.get("outputs", {}):
                 G.add_edge(key, f"{key}.outputs.{out}")
 
-    def _add_edges(self, G: SemantikonDiGraph, edge_list: list[list[str]]) -> None:
+    def _add_edges(self, G: nx.DiGraph, edge_list: list[list[str]]) -> None:
         for edge in edge_list:
             G.add_edge(*edge)
 
     @staticmethod
-    def _relabel_graph(G: SemantikonDiGraph) -> SemantikonDiGraph:
+    def _relabel_graph(G: nx.DiGraph) -> nx.DiGraph:
         mapping = {n: n.replace(".", "-") for n in G.nodes()}
         return nx.relabel_nodes(G, mapping, copy=True)
 
@@ -1422,7 +1421,8 @@ def serialize_and_convert_to_networkx(
     Returns:
         SemantikonDiGraph: The serialized workflow graph.
     """
-    G = _WorkflowGraphSerializer(wf_dict, prefix=prefix).serialize()
+    G_nx = _WorkflowGraphSerializer(wf_dict).serialize()
+    G = SemantikonDiGraph(G_nx, prefix=prefix)
     if hash_data:
         try:
             hashed_dict = {}

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -1277,11 +1277,12 @@ class _WorkflowFlattener:
     def _dot(*args: str | None) -> str:
         return ".".join(a for a in args if a is not None)
 
-    def flatten(self, wf_dict: dict, prefix: str) -> tuple[dict, dict, list[list[str]]]:
-        node_dict = self._serialize_node_metadata(wf_dict, prefix)
-        channel_dict = self._serialize_channels(wf_dict, prefix)
-        n, c, e = self._serialize_children(wf_dict, prefix)
-        edge_list = self._serialize_edges(wf_dict, prefix)
+    @classmethod
+    def flatten(cls, wf_dict: dict, prefix: str) -> tuple[dict, dict, list[list[str]]]:
+        node_dict = cls._serialize_node_metadata(wf_dict, prefix)
+        channel_dict = cls._serialize_channels(wf_dict, prefix)
+        n, c, e = cls._serialize_children(wf_dict, prefix)
+        edge_list = cls._serialize_edges(wf_dict, prefix)
         node_dict.update(n)
         channel_dict.update(c)
         edge_list.extend(e)
@@ -1303,11 +1304,12 @@ class _WorkflowFlattener:
             node_dict[prefix]["function"] = meta
         return node_dict
 
-    def _serialize_channels(self, wf_dict: dict, prefix: str) -> dict:
+    @classmethod
+    def _serialize_channels(cls, wf_dict: dict, prefix: str) -> dict:
         channel_dict = {}
         for io_type in ("inputs", "outputs"):
             for pos, (arg, channel) in enumerate(wf_dict.get(io_type, {}).items()):
-                label = self._remove_us(prefix, io_type, arg)
+                label = cls._remove_us(prefix, io_type, arg)
                 assert "semantikon_type" not in channel
                 if "dtype" in channel:
                     channel.update(meta_to_dict(channel["dtype"]))
@@ -1319,25 +1321,27 @@ class _WorkflowFlattener:
                 }
         return channel_dict
 
+    @classmethod
     def _serialize_children(
-        self, wf_dict: dict, prefix: str
+        cls, wf_dict: dict, prefix: str
     ) -> tuple[dict, dict, list[list[str]]]:
         node_dict = {}
         channel_dict = {}
         edge_list = []
         for key, node in wf_dict.get("nodes", {}).items():
-            child_key = self._dot(prefix, key)
-            n, c, e = self.flatten(node, child_key)
+            child_key = cls._dot(prefix, key)
+            n, c, e = cls.flatten(node, child_key)
             node_dict.update(n)
             channel_dict.update(c)
             edge_list.extend(e)
             node_dict[child_key]["parent"] = prefix.replace(".", "-")
         return node_dict, channel_dict, edge_list
 
-    def _serialize_edges(self, wf_dict: dict, prefix: str) -> list[list[str]]:
+    @classmethod
+    def _serialize_edges(cls, wf_dict: dict, prefix: str) -> list[list[str]]:
         edge_list = []
         for edge in wf_dict.get("edges", []):
-            edge_list.append([self._remove_us(prefix, a) for a in edge])
+            edge_list.append([cls._remove_us(prefix, a) for a in edge])
         return edge_list
 
 
@@ -1355,7 +1359,7 @@ class _WorkflowGraphSerializer:
     # -----------------------------
 
     def serialize(self) -> SemantikonDiGraph:
-        node_dict, channel_dict, edge_list = _WorkflowFlattener().flatten(
+        node_dict, channel_dict, edge_list = _WorkflowFlattener.flatten(
             self.wf_dict, self.wf_dict["label"]
         )
         G = SemantikonDiGraph(prefix=self.prefix)

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -1351,26 +1351,21 @@ class _WorkflowGraphSerializer:
     nodes represent workflow steps and channels,
     """
 
-    def __init__(self, wf_dict: dict):
-        self.wf_dict = wf_dict
-
-    # -----------------------------
-    # Serialization
-    # -----------------------------
-
-    def serialize(self) -> nx.DiGraph:
+    @classmethod
+    def serialize(cls, wf_dict: dict) -> nx.DiGraph:
         node_dict, channel_dict, edge_list = _WorkflowFlattener.flatten(
-            self.wf_dict, self.wf_dict["label"]
+            wf_dict, wf_dict["label"]
         )
         G = nx.DiGraph()
 
-        self._add_channels(G, channel_dict)
-        self._add_nodes(G, node_dict)
-        self._add_edges(G, edge_list)
+        cls._add_channels(G, channel_dict)
+        cls._add_nodes(G, node_dict)
+        cls._add_edges(G, edge_list)
 
-        return self._relabel_graph(G)
+        return cls._relabel_graph(G)
 
-    def _add_channels(self, G: nx.DiGraph, channel_dict: dict) -> None:
+    @classmethod
+    def _add_channels(cls, G: nx.DiGraph, channel_dict: dict) -> None:
         for key, data in channel_dict.items():
             G.add_node(
                 key,
@@ -1378,7 +1373,8 @@ class _WorkflowGraphSerializer:
                 **{k: v for k, v in data.items() if k != "semantikon_type"},
             )
 
-    def _add_nodes(self, G: nx.DiGraph, node_dict: dict) -> None:
+    @classmethod
+    def _add_nodes(cls, G: nx.DiGraph, node_dict: dict) -> None:
         for key, data in node_dict.items():
             if "." not in key:
                 G.name = key
@@ -1395,7 +1391,8 @@ class _WorkflowGraphSerializer:
             for out in data.get("outputs", {}):
                 G.add_edge(key, f"{key}.outputs.{out}")
 
-    def _add_edges(self, G: nx.DiGraph, edge_list: list[list[str]]) -> None:
+    @classmethod
+    def _add_edges(cls, G: nx.DiGraph, edge_list: list[list[str]]) -> None:
         for edge in edge_list:
             G.add_edge(*edge)
 
@@ -1422,7 +1419,7 @@ def serialize_and_convert_to_networkx(
     Returns:
         SemantikonDiGraph: The serialized workflow graph.
     """
-    G_nx = _WorkflowGraphSerializer(wf_dict).serialize()
+    G_nx = _WorkflowGraphSerializer.serialize(wf_dict)
     G = SemantikonDiGraph(G_nx, prefix=prefix)
     if hash_data:
         try:

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -1261,6 +1261,76 @@ def _get_successor_nodes(G, node_name):
                 yield node
 
 
+class _WorkflowFlattener:
+    @staticmethod
+    def _remove_us(*args: str) -> str:
+        return ".".join(args)
+
+    @staticmethod
+    def _dot(*args: str | None) -> str:
+        return ".".join(a for a in args if a is not None)
+
+    def flatten(self, wf_dict: dict, prefix: str) -> tuple[dict, dict, list[list[str]]]:
+        node_dict = self._serialize_node_metadata(wf_dict, prefix)
+        channel_dict = self._serialize_channels(wf_dict, prefix)
+        n, c, e = self._serialize_children(wf_dict, prefix)
+        edge_list = self._serialize_edges(wf_dict, prefix)
+        return node_dict, channel_dict, edge_list
+
+    @staticmethod
+    def _serialize_node_metadata(wf_dict: dict, prefix: str) -> dict:
+        node_dict = {
+            prefix: {k: v for k, v in wf_dict.items() if k not in {"nodes", "edges"}}
+        }
+
+        assert "function" in wf_dict or wf_dict["type"] != "atomic"
+
+        if "function" in wf_dict:
+            meta = get_function_dict(wf_dict["function"])
+            meta["identifier"] = ".".join(
+                (meta["module"], meta["qualname"], meta["version"])
+            )
+            node_dict[prefix]["function"] = meta
+        return node_dict
+
+    def _serialize_channels(self, wf_dict: dict, prefix: str) -> dict:
+        channel_dict = {}
+        for io_type in ("inputs", "outputs"):
+            for pos, (arg, channel) in enumerate(wf_dict.get(io_type, {}).items()):
+                label = self._remove_us(prefix, io_type, arg)
+                assert "semantikon_type" not in channel
+                if "dtype" in channel:
+                    channel.update(meta_to_dict(channel["dtype"]))
+
+                channel_dict[label] = channel | {
+                    "semantikon_type": io_type,
+                    "position": channel.get("position", pos),
+                    "arg": arg,
+                }
+        return channel_dict
+
+    def _serialize_children(
+        self, wf_dict: dict, prefix: str
+    ) -> tuple[dict, dict, list[list[str]]]:
+        node_dict = {}
+        channel_dict = {}
+        edge_list = []
+        for key, node in wf_dict.get("nodes", {}).items():
+            child_key = self._dot(prefix, key)
+            n, c, e = self.flatten(node, child_key)
+            node_dict.update(n)
+            channel_dict.update(c)
+            edge_list.extend(e)
+            node_dict[child_key]["parent"] = prefix.replace(".", "-")
+        return node_dict, channel_dict, edge_list
+
+    def _serialize_edges(self, wf_dict: dict, prefix: str) -> list[list[str]]:
+        edge_list = []
+        for edge in wf_dict.get("edges", []):
+            edge_list.append([self._remove_us(prefix, a) for a in edge])
+        return edge_list
+
+
 class _WorkflowGraphSerializer:
     """
     Serializes a workflow dictionary into a SemantikonDiGraph.
@@ -1274,74 +1344,11 @@ class _WorkflowGraphSerializer:
         self.prefix = prefix
 
     # -----------------------------
-    # String utilities
-    # -----------------------------
-
-    @staticmethod
-    def _remove_us(*args: str) -> str:
-        return ".".join(args)
-
-    @staticmethod
-    def _dot(*args: str | None) -> str:
-        return ".".join(a for a in args if a is not None)
-
-    # -----------------------------
     # Serialization
     # -----------------------------
 
     def serialize(self) -> SemantikonDiGraph:
-        self._serialize_workflow(self.wf_dict, self.wf_dict["label"])
-        return self._build_graph()
-
-    def _serialize_workflow(self, wf_dict: dict, prefix: str) -> None:
-        self._serialize_node_metadata(wf_dict, prefix)
-        self._serialize_channels(wf_dict, prefix)
-        self._serialize_children(wf_dict, prefix)
-        self._serialize_edges(wf_dict, prefix)
-
-    def _serialize_node_metadata(self, wf_dict: dict, prefix: str) -> None:
-        self.node_dict[prefix] = {
-            k: v for k, v in wf_dict.items() if k not in {"nodes", "edges"}
-        }
-
-        assert "function" in wf_dict or wf_dict["type"] != "atomic"
-
-        if "function" in wf_dict:
-            meta = get_function_dict(wf_dict["function"])
-            meta["identifier"] = ".".join(
-                (meta["module"], meta["qualname"], meta["version"])
-            )
-            self.node_dict[prefix]["function"] = meta
-
-    def _serialize_channels(self, wf_dict: dict, prefix: str) -> None:
-        for io_type in ("inputs", "outputs"):
-            for pos, (arg, channel) in enumerate(wf_dict.get(io_type, {}).items()):
-                label = self._remove_us(prefix, io_type, arg)
-                assert "semantikon_type" not in channel
-                if "dtype" in channel:
-                    channel.update(meta_to_dict(channel["dtype"]))
-
-                self.channel_dict[label] = channel | {
-                    "semantikon_type": io_type,
-                    "position": channel.get("position", pos),
-                    "arg": arg,
-                }
-
-    def _serialize_children(self, wf_dict: dict, prefix: str) -> None:
-        for key, node in wf_dict.get("nodes", {}).items():
-            child_key = self._dot(prefix, key)
-            self._serialize_workflow(node, child_key)
-            self.node_dict[child_key]["parent"] = prefix.replace(".", "-")
-
-    def _serialize_edges(self, wf_dict: dict, prefix: str) -> None:
-        for edge in wf_dict.get("edges", []):
-            self.edge_list.append([self._remove_us(prefix, a) for a in edge])
-
-    # -----------------------------
-    # Graph construction
-    # -----------------------------
-
-    def _build_graph(self) -> SemantikonDiGraph:
+        _WorkflowFlattener().flatten(self.wf_dict, self.wf_dict["label"])
         G = SemantikonDiGraph(prefix=self.prefix)
 
         self._add_channels(G)

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -1282,6 +1282,9 @@ class _WorkflowFlattener:
         channel_dict = self._serialize_channels(wf_dict, prefix)
         n, c, e = self._serialize_children(wf_dict, prefix)
         edge_list = self._serialize_edges(wf_dict, prefix)
+        node_dict.update(n)
+        channel_dict.update(c)
+        edge_list.extend(e)
         return node_dict, channel_dict, edge_list
 
     @staticmethod
@@ -1345,9 +1348,6 @@ class _WorkflowGraphSerializer:
 
     def __init__(self, wf_dict: dict, prefix: str | None = None):
         self.wf_dict = wf_dict
-        self.node_dict: dict = {}
-        self.channel_dict: dict = {}
-        self.edge_list: list[list[str]] = []
         self.prefix = prefix
 
     # -----------------------------
@@ -1355,25 +1355,27 @@ class _WorkflowGraphSerializer:
     # -----------------------------
 
     def serialize(self) -> SemantikonDiGraph:
-        _WorkflowFlattener().flatten(self.wf_dict, self.wf_dict["label"])
+        node_dict, channel_dict, edge_list = _WorkflowFlattener().flatten(
+            self.wf_dict, self.wf_dict["label"]
+        )
         G = SemantikonDiGraph(prefix=self.prefix)
 
-        self._add_channels(G)
-        self._add_nodes(G)
-        self._add_edges(G)
+        self._add_channels(G, channel_dict)
+        self._add_nodes(G, node_dict)
+        self._add_edges(G, edge_list)
 
         return self._relabel_graph(G)
 
-    def _add_channels(self, G: SemantikonDiGraph) -> None:
-        for key, data in self.channel_dict.items():
+    def _add_channels(self, G: SemantikonDiGraph, channel_dict: dict) -> None:
+        for key, data in channel_dict.items():
             G.add_node(
                 key,
                 step=data["semantikon_type"],
                 **{k: v for k, v in data.items() if k != "semantikon_type"},
             )
 
-    def _add_nodes(self, G: SemantikonDiGraph) -> None:
-        for key, data in self.node_dict.items():
+    def _add_nodes(self, G: SemantikonDiGraph, node_dict: dict | None) -> None:
+        for key, data in node_dict.items():
             if "." not in key:
                 G.name = key
 
@@ -1389,8 +1391,8 @@ class _WorkflowGraphSerializer:
             for out in data.get("outputs", {}):
                 G.add_edge(key, f"{key}.outputs.{out}")
 
-    def _add_edges(self, G: SemantikonDiGraph) -> None:
-        for edge in self.edge_list:
+    def _add_edges(self, G: SemantikonDiGraph, edge_list: list[list[str]]) -> None:
+        for edge in edge_list:
             G.add_edge(*edge)
 
     @staticmethod

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -1347,7 +1347,8 @@ class _WorkflowFlattener:
 
 class _WorkflowGraphSerializer:
     """
-    Serializes a workflow dictionary into a SemantikonDiGraph.
+    Serializes a workflow dictionary into a NetworkX directed graph, where
+    nodes represent workflow steps and channels,
     """
 
     def __init__(self, wf_dict: dict):

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -1374,7 +1374,7 @@ class _WorkflowGraphSerializer:
                 **{k: v for k, v in data.items() if k != "semantikon_type"},
             )
 
-    def _add_nodes(self, G: SemantikonDiGraph, node_dict: dict | None) -> None:
+    def _add_nodes(self, G: SemantikonDiGraph, node_dict: dict) -> None:
         for key, data in node_dict.items():
             if "." not in key:
                 G.name = key


### PR DESCRIPTION
This pull request refactors the workflow serialization logic in `semantikon/ontology.py` to improve modularity and clarity. The main change is the extraction of the flattening and serialization logic from `_WorkflowGraphSerializer` into a new helper class, `_WorkflowFlattener`. This makes the code more maintainable and separates concerns between flattening workflow data and constructing the graph.

**Refactor: Workflow flattening and serialization**

* Introduced a new `_WorkflowFlattener` class that encapsulates the logic for flattening workflow dictionaries into node, channel, and edge collections, moving this responsibility out of `_WorkflowGraphSerializer`.
* Refactored methods such as `_serialize_node_metadata`, `_serialize_channels`, `_serialize_children`, and `_serialize_edges` to be static methods of `_WorkflowFlattener`, returning data instead of mutating instance state. [[1]](diffhunk://#diff-05c9c64509257364104a98638356d5f3dda8d593c626be11754319ce3a9e2d4eL1295-R1293) [[2]](diffhunk://#diff-05c9c64509257364104a98638356d5f3dda8d593c626be11754319ce3a9e2d4eL1321-R1378)

**_WorkflowGraphSerializer simplification**

* Simplified `_WorkflowGraphSerializer` to use the new `_WorkflowFlattener` for serialization, and updated its methods to accept the new data structures produced by the flattener.
* Updated `_add_channels`, `_add_nodes`, and `_add_edges` to accept the corresponding dictionaries and lists, instead of relying on instance variables.

These changes improve code readability, testability, and separation of concerns.