### PR TITLE
[refactor] Move wf_dict serializer to flowrep_dict

### DIFF
--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -3,6 +3,8 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 import ast
+import hashlib
+import importlib
 import inspect
 import re
 import string
@@ -29,7 +31,6 @@ from pint.registry_helpers import (
 )
 
 from semantikon.datastructure import TypeMetadata
-from semantikon.flowrep_dict import get_function_metadata
 
 __author__ = "Sam Waseda"
 __copyright__ = (
@@ -374,6 +375,78 @@ def units(func: Callable) -> Callable:
             return output_units * func(*args, **new_kwargs)
 
     return wrapper
+
+
+def hash_function(fn: Callable) -> str:
+    """
+    Hash a function based on its source code or signature.
+
+    For regular functions, the hash is based on the dedented source code.
+    For other callables (built-ins, methods, etc.), the hash is based on
+    the module, qualified name, and signature. If source code is unavailable
+    for a function, falls back to signature-based hashing.
+
+    Args:
+        fn (Callable): The function to hash.
+
+    Returns:
+        str: A stable hash string in the format "function_name:hash_hex".
+    """
+
+    if inspect.isfunction(fn):
+        try:
+            source_code = inspect.getsource(fn)
+            source_code = textwrap.dedent(
+                source_code.replace("\r\n", "\n").replace("\r", "\n")
+            )
+        except (OSError, TypeError):
+            # Fall back to signature for functions where source is unavailable
+            source_code = f"{fn.__module__}:{fn.__qualname__}:{inspect.signature(fn)}"
+    else:
+        source_code = f"{fn.__module__}:{fn.__qualname__}:{inspect.signature(fn)}"
+    source_code_hash = hashlib.sha256(source_code.encode("utf-8")).hexdigest()
+    name = getattr(fn, "__name__", "unknown")
+    return name + ":" + source_code_hash
+
+
+def _get_version_from_module(module_name: str) -> str:
+    base_module_name = module_name.split(".")[0]
+    base_module = importlib.import_module(base_module_name)
+    return getattr(base_module, "__version__", "not_defined")
+
+
+def get_function_metadata(
+    cls: Callable | dict[str, str], full_metadata: bool = False
+) -> dict[str, str]:
+    """
+    Get metadata for a given function or class.
+
+    Args:
+        cls (Callable | dict[str, str]): The function or class to get metadata for.
+        full_metadata (bool): Whether to include full metadata including hash,
+            docstring, and name.
+
+    Returns:
+        dict[str, str]: A dictionary containing the metadata of the function or class.
+    """
+    if isinstance(cls, dict):
+        if "module" in cls and "qualname" in cls:
+            return cls
+        else:
+            raise ValueError(f"Got a dict, but it doesn't look like metadata: {cls}")
+
+    data = {
+        "module": cls.__module__,
+        "qualname": cls.__qualname__,
+    }
+
+    data["version"] = _get_version_from_module(data["module"])
+    if not full_metadata:
+        return data
+    data["hash"] = hash_function(cls)
+    data["docstring"] = cls.__doc__ or ""
+    data["name"] = cls.__name__
+    return data
 
 
 def get_function_dict(function: Callable) -> dict[str, Any]:

--- a/semantikon/flowrep_dict.py
+++ b/semantikon/flowrep_dict.py
@@ -32,11 +32,9 @@ import collections
 import copy
 import dataclasses
 import hashlib
-import inspect
 import json
 import re
-import textwrap
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from typing import Annotated, Any, cast, get_args, get_origin
 
 import networkx as nx

--- a/semantikon/flowrep_dict.py
+++ b/semantikon/flowrep_dict.py
@@ -40,7 +40,12 @@ from typing import Annotated, Any, cast, get_args, get_origin
 import networkx as nx
 from flowrep.api import schemas as frs
 from pyiron_snippets import retrieve
-from semantikon.converter import get_function_dict, get_function_metadata, meta_to_dict
+from semantikon.converter import (
+    get_function_dict,
+    get_function_metadata,
+    hash_function,
+    meta_to_dict,
+)
 
 
 def live_to_dict(

--- a/semantikon/flowrep_dict.py
+++ b/semantikon/flowrep_dict.py
@@ -32,7 +32,6 @@ import collections
 import copy
 import dataclasses
 import hashlib
-import importlib
 import inspect
 import json
 import re
@@ -43,6 +42,7 @@ from typing import Annotated, Any, cast, get_args, get_origin
 import networkx as nx
 from flowrep.api import schemas as frs
 from pyiron_snippets import retrieve
+from semantikon.converter import get_function_dict, get_function_metadata, meta_to_dict
 
 
 def live_to_dict(
@@ -603,78 +603,6 @@ def serialize_functions(data: dict[str, Any]) -> dict[str, Any]:
     return data
 
 
-def _get_version_from_module(module_name: str) -> str:
-    base_module_name = module_name.split(".")[0]
-    base_module = importlib.import_module(base_module_name)
-    return getattr(base_module, "__version__", "not_defined")
-
-
-def get_function_metadata(
-    cls: Callable | dict[str, str], full_metadata: bool = False
-) -> dict[str, str]:
-    """
-    Get metadata for a given function or class.
-
-    Args:
-        cls (Callable | dict[str, str]): The function or class to get metadata for.
-        full_metadata (bool): Whether to include full metadata including hash,
-            docstring, and name.
-
-    Returns:
-        dict[str, str]: A dictionary containing the metadata of the function or class.
-    """
-    if isinstance(cls, dict):
-        if "module" in cls and "qualname" in cls:
-            return cls
-        else:
-            raise ValueError(f"Got a dict, but it doesn't look like metadata: {cls}")
-
-    data = {
-        "module": cls.__module__,
-        "qualname": cls.__qualname__,
-    }
-
-    data["version"] = _get_version_from_module(data["module"])
-    if not full_metadata:
-        return data
-    data["hash"] = hash_function(cls)
-    data["docstring"] = cls.__doc__ or ""
-    data["name"] = cls.__name__
-    return data
-
-
-def hash_function(fn: Callable) -> str:
-    """
-    Hash a function based on its source code or signature.
-
-    For regular functions, the hash is based on the dedented source code.
-    For other callables (built-ins, methods, etc.), the hash is based on
-    the module, qualified name, and signature. If source code is unavailable
-    for a function, falls back to signature-based hashing.
-
-    Args:
-        fn (Callable): The function to hash.
-
-    Returns:
-        str: A stable hash string in the format "function_name:hash_hex".
-    """
-
-    if inspect.isfunction(fn):
-        try:
-            source_code = inspect.getsource(fn)
-            source_code = textwrap.dedent(
-                source_code.replace("\r\n", "\n").replace("\r", "\n")
-            )
-        except (OSError, TypeError):
-            # Fall back to signature for functions where source is unavailable
-            source_code = f"{fn.__module__}:{fn.__qualname__}:{inspect.signature(fn)}"
-    else:
-        source_code = f"{fn.__module__}:{fn.__qualname__}:{inspect.signature(fn)}"
-    source_code_hash = hashlib.sha256(source_code.encode("utf-8")).hexdigest()
-    name = getattr(fn, "__name__", "unknown")
-    return name + ":" + source_code_hash
-
-
 def recursive_defaultdict() -> collections.defaultdict:
     """
     Create a recursively nested collections.defaultdict.
@@ -703,3 +631,142 @@ def recursive_dd_to_dict(d: dict | collections.defaultdict) -> dict:
     if isinstance(d, collections.defaultdict):
         return {k: recursive_dd_to_dict(v) for k, v in d.items()}
     return d
+
+
+# ---------------------------------------------------------------------------
+# Workflow dict → graph conversion
+# ---------------------------------------------------------------------------
+
+
+class _WorkflowFlattener:
+    @staticmethod
+    def _remove_us(*args: str) -> str:
+        return ".".join(args)
+
+    @staticmethod
+    def _dot(*args: str | None) -> str:
+        return ".".join(a for a in args if a is not None)
+
+    @classmethod
+    def flatten(cls, wf_dict: dict, prefix: str) -> tuple[dict, dict, list[list[str]]]:
+        node_dict = cls._serialize_node_metadata(wf_dict, prefix)
+        channel_dict = cls._serialize_channels(wf_dict, prefix)
+        n, c, e = cls._serialize_children(wf_dict, prefix)
+        edge_list = cls._serialize_edges(wf_dict, prefix)
+        node_dict.update(n)
+        channel_dict.update(c)
+        edge_list.extend(e)
+        return node_dict, channel_dict, edge_list
+
+    @staticmethod
+    def _serialize_node_metadata(wf_dict: dict, prefix: str) -> dict:
+        node_dict = {
+            prefix: {k: v for k, v in wf_dict.items() if k not in {"nodes", "edges"}}
+        }
+
+        assert "function" in wf_dict or wf_dict["type"] != "atomic"
+
+        if "function" in wf_dict:
+            meta = get_function_dict(wf_dict["function"])
+            meta["identifier"] = ".".join(
+                (meta["module"], meta["qualname"], meta["version"])
+            )
+            node_dict[prefix]["function"] = meta
+        return node_dict
+
+    @classmethod
+    def _serialize_channels(cls, wf_dict: dict, prefix: str) -> dict:
+        channel_dict = {}
+        for io_type in ("inputs", "outputs"):
+            for pos, (arg, channel) in enumerate(wf_dict.get(io_type, {}).items()):
+                label = cls._remove_us(prefix, io_type, arg)
+                assert "semantikon_type" not in channel
+                if "dtype" in channel:
+                    channel.update(meta_to_dict(channel["dtype"]))
+
+                channel_dict[label] = channel | {
+                    "semantikon_type": io_type,
+                    "position": channel.get("position", pos),
+                    "arg": arg,
+                }
+        return channel_dict
+
+    @classmethod
+    def _serialize_children(
+        cls, wf_dict: dict, prefix: str
+    ) -> tuple[dict, dict, list[list[str]]]:
+        node_dict = {}
+        channel_dict = {}
+        edge_list = []
+        for key, node in wf_dict.get("nodes", {}).items():
+            child_key = cls._dot(prefix, key)
+            n, c, e = cls.flatten(node, child_key)
+            node_dict.update(n)
+            channel_dict.update(c)
+            edge_list.extend(e)
+            node_dict[child_key]["parent"] = prefix.replace(".", "-")
+        return node_dict, channel_dict, edge_list
+
+    @classmethod
+    def _serialize_edges(cls, wf_dict: dict, prefix: str) -> list[list[str]]:
+        edge_list = []
+        for edge in wf_dict.get("edges", []):
+            edge_list.append([cls._remove_us(prefix, a) for a in edge])
+        return edge_list
+
+
+class _WorkflowGraphSerializer:
+    """
+    Serializes a workflow dictionary into a NetworkX directed graph, where
+    nodes represent workflow steps and channels,
+    """
+
+    @classmethod
+    def serialize(cls, wf_dict: dict) -> nx.DiGraph:
+        node_dict, channel_dict, edge_list = _WorkflowFlattener.flatten(
+            wf_dict, wf_dict["label"]
+        )
+        G = nx.DiGraph()
+
+        cls._add_channels(G, channel_dict)
+        cls._add_nodes(G, node_dict)
+        cls._add_edges(G, edge_list)
+
+        return cls._relabel_graph(G)
+
+    @classmethod
+    def _add_channels(cls, G: nx.DiGraph, channel_dict: dict) -> None:
+        for key, data in channel_dict.items():
+            G.add_node(
+                key,
+                step=data["semantikon_type"],
+                **{k: v for k, v in data.items() if k != "semantikon_type"},
+            )
+
+    @classmethod
+    def _add_nodes(cls, G: nx.DiGraph, node_dict: dict) -> None:
+        for key, data in node_dict.items():
+            if "." not in key:
+                G.name = key
+
+            G.add_node(
+                key,
+                step="node",
+                **{k: v for k, v in data.items() if k not in {"inputs", "outputs"}},
+            )
+
+            for inp in data.get("inputs", {}):
+                G.add_edge(f"{key}.inputs.{inp}", key)
+
+            for out in data.get("outputs", {}):
+                G.add_edge(key, f"{key}.outputs.{out}")
+
+    @classmethod
+    def _add_edges(cls, G: nx.DiGraph, edge_list: list[list[str]]) -> None:
+        for edge in edge_list:
+            G.add_edge(*edge)
+
+    @staticmethod
+    def _relabel_graph(G: nx.DiGraph) -> nx.DiGraph:
+        mapping = {n: n.replace(".", "-") for n in G.nodes()}
+        return nx.relabel_nodes(G, mapping, copy=True)

--- a/semantikon/flowrep_dict.py
+++ b/semantikon/flowrep_dict.py
@@ -40,6 +40,7 @@ from typing import Annotated, Any, cast, get_args, get_origin
 import networkx as nx
 from flowrep.api import schemas as frs
 from pyiron_snippets import retrieve
+
 from semantikon.converter import get_function_dict, get_function_metadata, meta_to_dict
 
 

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -23,7 +23,7 @@ from semantikon.converter import (
     parse_input_args,
     parse_output_args,
 )
-from semantikon.flowrep_dict import get_hashed_node_dict, _WorkflowGraphSerializer
+from semantikon.flowrep_dict import _WorkflowGraphSerializer, get_hashed_node_dict
 from semantikon.metadata import SemantikonURI
 from semantikon.qudt import UnitsDict
 

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -23,7 +23,7 @@ from semantikon.converter import (
     parse_input_args,
     parse_output_args,
 )
-from semantikon.flowrep_dict import get_hashed_node_dict
+from semantikon.flowrep_dict import get_hashed_node_dict, _WorkflowGraphSerializer
 from semantikon.metadata import SemantikonURI
 from semantikon.qudt import UnitsDict
 
@@ -1266,140 +1266,6 @@ def _get_successor_nodes(G, node_name):
         for inp in G.successors(out):
             for node in G.successors(inp):
                 yield node
-
-
-class _WorkflowFlattener:
-    @staticmethod
-    def _remove_us(*args: str) -> str:
-        return ".".join(args)
-
-    @staticmethod
-    def _dot(*args: str | None) -> str:
-        return ".".join(a for a in args if a is not None)
-
-    @classmethod
-    def flatten(cls, wf_dict: dict, prefix: str) -> tuple[dict, dict, list[list[str]]]:
-        node_dict = cls._serialize_node_metadata(wf_dict, prefix)
-        channel_dict = cls._serialize_channels(wf_dict, prefix)
-        n, c, e = cls._serialize_children(wf_dict, prefix)
-        edge_list = cls._serialize_edges(wf_dict, prefix)
-        node_dict.update(n)
-        channel_dict.update(c)
-        edge_list.extend(e)
-        return node_dict, channel_dict, edge_list
-
-    @staticmethod
-    def _serialize_node_metadata(wf_dict: dict, prefix: str) -> dict:
-        node_dict = {
-            prefix: {k: v for k, v in wf_dict.items() if k not in {"nodes", "edges"}}
-        }
-
-        assert "function" in wf_dict or wf_dict["type"] != "atomic"
-
-        if "function" in wf_dict:
-            meta = get_function_dict(wf_dict["function"])
-            meta["identifier"] = ".".join(
-                (meta["module"], meta["qualname"], meta["version"])
-            )
-            node_dict[prefix]["function"] = meta
-        return node_dict
-
-    @classmethod
-    def _serialize_channels(cls, wf_dict: dict, prefix: str) -> dict:
-        channel_dict = {}
-        for io_type in ("inputs", "outputs"):
-            for pos, (arg, channel) in enumerate(wf_dict.get(io_type, {}).items()):
-                label = cls._remove_us(prefix, io_type, arg)
-                assert "semantikon_type" not in channel
-                if "dtype" in channel:
-                    channel.update(meta_to_dict(channel["dtype"]))
-
-                channel_dict[label] = channel | {
-                    "semantikon_type": io_type,
-                    "position": channel.get("position", pos),
-                    "arg": arg,
-                }
-        return channel_dict
-
-    @classmethod
-    def _serialize_children(
-        cls, wf_dict: dict, prefix: str
-    ) -> tuple[dict, dict, list[list[str]]]:
-        node_dict = {}
-        channel_dict = {}
-        edge_list = []
-        for key, node in wf_dict.get("nodes", {}).items():
-            child_key = cls._dot(prefix, key)
-            n, c, e = cls.flatten(node, child_key)
-            node_dict.update(n)
-            channel_dict.update(c)
-            edge_list.extend(e)
-            node_dict[child_key]["parent"] = prefix.replace(".", "-")
-        return node_dict, channel_dict, edge_list
-
-    @classmethod
-    def _serialize_edges(cls, wf_dict: dict, prefix: str) -> list[list[str]]:
-        edge_list = []
-        for edge in wf_dict.get("edges", []):
-            edge_list.append([cls._remove_us(prefix, a) for a in edge])
-        return edge_list
-
-
-class _WorkflowGraphSerializer:
-    """
-    Serializes a workflow dictionary into a NetworkX directed graph, where
-    nodes represent workflow steps and channels,
-    """
-
-    @classmethod
-    def serialize(cls, wf_dict: dict) -> nx.DiGraph:
-        node_dict, channel_dict, edge_list = _WorkflowFlattener.flatten(
-            wf_dict, wf_dict["label"]
-        )
-        G = nx.DiGraph()
-
-        cls._add_channels(G, channel_dict)
-        cls._add_nodes(G, node_dict)
-        cls._add_edges(G, edge_list)
-
-        return cls._relabel_graph(G)
-
-    @classmethod
-    def _add_channels(cls, G: nx.DiGraph, channel_dict: dict) -> None:
-        for key, data in channel_dict.items():
-            G.add_node(
-                key,
-                step=data["semantikon_type"],
-                **{k: v for k, v in data.items() if k != "semantikon_type"},
-            )
-
-    @classmethod
-    def _add_nodes(cls, G: nx.DiGraph, node_dict: dict) -> None:
-        for key, data in node_dict.items():
-            if "." not in key:
-                G.name = key
-
-            G.add_node(
-                key,
-                step="node",
-                **{k: v for k, v in data.items() if k not in {"inputs", "outputs"}},
-            )
-
-            for inp in data.get("inputs", {}):
-                G.add_edge(f"{key}.inputs.{inp}", key)
-
-            for out in data.get("outputs", {}):
-                G.add_edge(key, f"{key}.outputs.{out}")
-
-    @classmethod
-    def _add_edges(cls, G: nx.DiGraph, edge_list: list[list[str]]) -> None:
-        for edge in edge_list:
-            G.add_edge(*edge)
-
-    @staticmethod
-    def _relabel_graph(G: nx.DiGraph) -> nx.DiGraph:
-        mapping = {n: n.replace(".", "-") for n in G.nodes()}
-        return nx.relabel_nodes(G, mapping, copy=True)
 
 
 def serialize_and_convert_to_networkx(

--- a/tests/unit/test_flowrep_dict.py
+++ b/tests/unit/test_flowrep_dict.py
@@ -1,7 +1,6 @@
 """Tests for the live → nested-dict converter."""
 
 import dataclasses
-import math
 import unittest
 from typing import Annotated
 

--- a/tests/unit/test_flowrep_dict.py
+++ b/tests/unit/test_flowrep_dict.py
@@ -568,52 +568,6 @@ class TestTools(unittest.TestCase):
         meta = flowrep_dict.get_function_metadata(example_function, full_metadata=False)
         self.assertNotIn("docstring", meta)
 
-    def test_hash_function(self):
-        import math
-
-        # Test built-in function (triggers except path - no source code available)
-        self.assertEqual(
-            flowrep_dict.hash_function(math.sin)[:40],
-            "sin:0146c21ab456a735f07d62b456f003ce3dc6",
-        )
-
-        # Test regular function with source code available
-        expected_hash = "example_function:196938631e98c05e128b0b1"
-        self.assertEqual(
-            flowrep_dict.hash_function(example_function)[: len(expected_hash)],
-            expected_hash,
-        )
-
-    def test_hash_function_fallback(self):
-        """Test that hash_function falls back to signature for functions without source."""
-
-        # Built-in functions (not Python functions, so uses else branch)
-        hash_result = flowrep_dict.hash_function(math.sin)
-        self.assertTrue(hash_result.startswith("sin:"))
-        self.assertEqual(len(hash_result), 68)  # "sin:" + 64 char hex hash
-
-        # Test another built-in
-        hash_result = flowrep_dict.hash_function(len)
-        self.assertTrue(hash_result.startswith("len:"))
-        self.assertEqual(len(hash_result), 68)
-
-    def test_hash_function_except_path(self):
-        """Test that hash_function handles functions where source is unavailable (except path)."""
-        # Create a lambda function - it's a function but source is unavailable
-        hash_result = flowrep_dict.hash_function(lambda x: x * 2)
-        self.assertTrue(hash_result.startswith("<lambda>:"))
-        self.assertEqual(len(hash_result), 73)  # "<lambda>:" + 64 char hex hash
-
-        # Create a dynamically defined function using exec
-        exec_globals = {}
-        exec("def dynamic_test_func(x):\n    return x + 1", exec_globals)
-        dynamic_func = exec_globals["dynamic_test_func"]
-        hash_result = flowrep_dict.hash_function(dynamic_func)
-        self.assertTrue(hash_result.startswith("dynamic_test_func:"))
-        self.assertEqual(
-            len(hash_result), 82
-        )  # "dynamic_test_func:" + 64 char hex hash
-
 
 class TestOutputSanitizationConsistency(unittest.TestCase):
     """Edges and output dicts must agree on port names after sanitization."""

--- a/tests/unit/test_parsers.py
+++ b/tests/unit/test_parsers.py
@@ -8,6 +8,7 @@ from semantikon.converter import (
     get_function_dict,
     get_return_expressions,
     get_return_labels,
+    hash_function,
     parse_input_args,
     parse_metadata,
     parse_output_args,
@@ -20,6 +21,11 @@ if TYPE_CHECKING:
 
     class Atoms:
         pass
+
+
+def example_function(x):
+    """An example function to be hashed."""
+    return x * 2
 
 
 class TestParser(unittest.TestCase):
@@ -283,6 +289,53 @@ class TestParser(unittest.TestCase):
         self.assertEqual(to_identifier("123invalid"), "_123invalid")
         self.assertEqual(to_identifier("invalid-name!"), "invalid_name_")
         self.assertEqual(to_identifier("name with spaces"), "name_with_spaces")
+
+    def test_hash_function(self):
+        import math
+
+        # Test built-in function (triggers except path - no source code available)
+        self.assertEqual(
+            hash_function(math.sin)[:40],
+            "sin:0146c21ab456a735f07d62b456f003ce3dc6",
+        )
+
+        # Test regular function with source code available
+        expected_hash = "example_function:196938631e98c05e128b0b1"
+        self.assertEqual(
+            hash_function(example_function)[: len(expected_hash)],
+            expected_hash,
+        )
+
+    def test_hash_function_fallback(self):
+        """Test that hash_function falls back to signature for functions without source."""
+        import math
+
+        # Built-in functions (not Python functions, so uses else branch)
+        hash_result = hash_function(math.sin)
+        self.assertTrue(hash_result.startswith("sin:"))
+        self.assertEqual(len(hash_result), 68)  # "sin:" + 64 char hex hash
+
+        # Test another built-in
+        hash_result = hash_function(len)
+        self.assertTrue(hash_result.startswith("len:"))
+        self.assertEqual(len(hash_result), 68)
+
+    def test_hash_function_except_path(self):
+        """Test that hash_function handles functions where source is unavailable (except path)."""
+        # Create a lambda function - it's a function but source is unavailable
+        hash_result = hash_function(lambda x: x * 2)
+        self.assertTrue(hash_result.startswith("<lambda>:"))
+        self.assertEqual(len(hash_result), 73)  # "<lambda>:" + 64 char hex hash
+
+        # Create a dynamically defined function using exec
+        exec_globals = {}
+        exec("def dynamic_test_func(x):\n    return x + 1", exec_globals)
+        dynamic_func = exec_globals["dynamic_test_func"]
+        hash_result = hash_function(dynamic_func)
+        self.assertTrue(hash_result.startswith("dynamic_test_func:"))
+        self.assertEqual(
+            len(hash_result), 82
+        )  # "dynamic_test_func:" + 64 char hex hash
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
@liamhuber I moved the part for the conversion of flowrep dict to `nx.DiGraph` to `flowrep_dict.py`, so that we can focus on this one file to get rid of the dictionary representation

This pull request refactors how workflow graph serialization and function metadata utilities are organized and imported within the codebase. The main changes involve moving utility classes and functions from `semantikon/ontology.py` and `semantikon/flowrep_dict.py` into more appropriate modules, specifically consolidating workflow graph serialization logic into `semantikon/flowrep_dict.py` and function metadata utilities into `semantikon/converter.py`. This improves code modularity, maintainability, and reduces duplication.

Key changes include:

**Refactoring and Code Organization:**
- Moved the `_WorkflowFlattener` and `_WorkflowGraphSerializer` classes from `semantikon/ontology.py` to `semantikon/flowrep_dict.py`, and updated imports accordingly. This centralizes workflow graph serialization logic in a single module. [[1]](diffhunk://#diff-05c9c64509257364104a98638356d5f3dda8d593c626be11754319ce3a9e2d4eL26-R26) [[2]](diffhunk://#diff-05c9c64509257364104a98638356d5f3dda8d593c626be11754319ce3a9e2d4eL1271-L1404) [[3]](diffhunk://#diff-346d0a41b374d14cc6521d3828108fd29de3e1572e792b0aa72ec41a2e5a025dR634-R772)
- Relocated `get_function_metadata` and `hash_function` (and related helpers) from `semantikon/flowrep_dict.py` to `semantikon/converter.py`, ensuring all function metadata utilities are defined in one place. [[1]](diffhunk://#diff-6ea938353c6d47af12e55e640f86fa3cbd74219bcef1ac8c2ff3e8e431a5a96fL32) [[2]](diffhunk://#diff-346d0a41b374d14cc6521d3828108fd29de3e1572e792b0aa72ec41a2e5a025dR45) [[3]](diffhunk://#diff-346d0a41b374d14cc6521d3828108fd29de3e1572e792b0aa72ec41a2e5a025dL606-L677) [[4]](diffhunk://#diff-6ea938353c6d47af12e55e640f86fa3cbd74219bcef1ac8c2ff3e8e431a5a96fR380-R451)

**Dependency and Import Cleanups:**
- Updated imports across modules to reflect the new locations of the refactored utilities, removing now-unused imports and ensuring correct dependencies. [[1]](diffhunk://#diff-6ea938353c6d47af12e55e640f86fa3cbd74219bcef1ac8c2ff3e8e431a5a96fR6-R7) [[2]](diffhunk://#diff-346d0a41b374d14cc6521d3828108fd29de3e1572e792b0aa72ec41a2e5a025dL35)

These changes streamline the codebase by grouping related functionality, making it easier to maintain and extend in the future.
