### PR TITLE
Derived from without uri

### DIFF
--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -344,7 +344,8 @@ def _check_consistency_of_digraph(G: SemantikonDiGraph):
             warnings.warn(
                 f"Node '{node}' is derived from '{data['derived_from']}' which"
                 " has a URI defined, but the node itself does not have a URI."
-                f" '{node}' remains without a URI."
+                f" '{node}' remains without a URI.",
+                UserWarning,
             )
 
 

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import json
 import unicodedata
+import warnings
 from dataclasses import asdict, dataclass, fields, is_dataclass
 from functools import cache, cached_property
 from hashlib import sha256
@@ -327,6 +328,26 @@ def _remove_data(graph: Graph) -> Graph:
     return graph
 
 
+def _check_consistency_of_digraph(G: SemantikonDiGraph):
+    for node, data in G.nodes.data():
+        if "derived_from" not in data:
+            continue
+        expected_input = node.rsplit("-outputs-", 1)[
+            0
+        ] + f"-{data['derived_from']}".replace(".", "-")
+        if expected_input not in G.nodes:
+            raise ValueError(
+                f"Node '{node}' is derived from '{data['derived_from']}' but"
+                f" expected input '{expected_input}' not found in the graph."
+            )
+        if "uri" not in data and "uri" in G.nodes[expected_input]:
+            warnings.warn(
+                f"Node '{node}' is derived from '{data['derived_from']}' which"
+                " has a URI defined, but the node itself does not have a URI."
+                f" '{node}' remains without a URI."
+            )
+
+
 def get_knowledge_graph(
     wf_dict: dict,
     include_t_box: bool = True,
@@ -356,6 +377,7 @@ def get_knowledge_graph(
         (rdflib.Graph): graph containing workflow information
     """
     G = serialize_and_convert_to_networkx(wf_dict, hash_data=hash_data, prefix=prefix)
+    _check_consistency_of_digraph(G)
     graph = _get_bound_graph()
     graph += _import_pmdco(pmdco_uri=pmdco_uri)
     if include_t_box:

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -1,6 +1,7 @@
 import copy
 import os
 import unittest
+import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
 from textwrap import dedent
@@ -406,6 +407,38 @@ def use_derived_from_wrongly_in_input(
 @workflow
 def workflow_with_wrong_derived_from(x):
     result = use_derived_from_wrongly_in_input(x)
+    return result
+
+
+@workflow
+def workflow_with_derived_from_and_no_uri(
+    x: Annotated[float, {"uri": EX.Something}],
+) -> Annotated[float, {"derived_from": "inputs.x"}]:
+    result = add_one(x)
+    return result
+
+
+@workflow
+def workflow_with_derived_from_and_with_uri(
+    x: Annotated[float, {"uri": EX.Something}],
+) -> Annotated[float, {"derived_from": "inputs.x", "uri": EX.SomethingElse}]:
+    result = add_one(x)
+    return result
+
+
+@workflow
+def workflow_with_derived_from_and_with_no_uri_at_all(
+    x: float,
+) -> Annotated[float, {"derived_from": "inputs.x"}]:
+    result = add_one(x)
+    return result
+
+
+@workflow
+def workflow_with_wrong_derived_from_in_output(
+    x,
+) -> Annotated[float, {"derived_from": "inputs.y"}]:
+    result = add_one(x)
     return result
 
 
@@ -1086,6 +1119,30 @@ class TestOntology(unittest.TestCase):
             ValueError,
             onto.get_knowledge_graph,
             workflow_with_wrong_derived_from.get_semantikon_dict(),
+        )
+
+    def test_derived_from_and_with_and_without_uri(self):
+        with self.assertWarnsRegex(
+            UserWarning,
+            "node itself does not have a URI",
+        ):
+            onto.get_knowledge_graph(
+                workflow_with_derived_from_and_no_uri.get_semantikon_dict()
+            )
+        with warnings.catch_warnings():
+            warnings.filterwarnings("error", message="node itself does not have a URI")
+            onto.get_knowledge_graph(
+                workflow_with_derived_from_and_with_uri.get_semantikon_dict()
+            )
+        with warnings.catch_warnings():
+            warnings.filterwarnings("error", message="node itself does not have a URI")
+            onto.get_knowledge_graph(
+                workflow_with_derived_from_and_with_no_uri_at_all.get_semantikon_dict()
+            )
+        self.assertRaises(
+            ValueError,
+            onto.get_knowledge_graph,
+            workflow_with_wrong_derived_from_in_output.get_semantikon_dict(),
         )
 
 


### PR DESCRIPTION
This pull request introduces consistency checks for "derived_from" relationships in the ontology's directed graph and adds corresponding unit tests to ensure correct behavior. The key changes include the implementation of a new consistency-checking function, integration of this check into the knowledge graph generation process, and expanded test coverage for edge cases involving "derived_from" and "uri" attributes.

**Ontology consistency checks:**

* Added `_check_consistency_of_digraph` function to verify that nodes with a "derived_from" attribute reference valid input nodes and to warn if a "uri" is missing when the source node has one.
* Integrated `_check_consistency_of_digraph` into `get_knowledge_graph` to enforce these checks during graph creation.
* Imported the `warnings` module in `ontology.py` to enable warning emission for missing URIs.

**Unit test enhancements:**

* Added new test workflows and a comprehensive test case (`test_derived_from_and_with_and_without_uri`) to verify correct warning and error behavior for various "derived_from" and "uri" scenarios. [[1]](diffhunk://#diff-616ca92436aca58b6686c40d1f14f5accc61707858bcbb02e893f200e803f502R413-R444) [[2]](diffhunk://#diff-616ca92436aca58b6686c40d1f14f5accc61707858bcbb02e893f200e803f502R1124-R1147)
* Imported the `warnings` module in the test file to support warning capture and assertions.