### PR TITLE
Add `parse_metadata` and metadata dataclasses to api

### DIFF
--- a/semantikon/__init__.py
+++ b/semantikon/__init__.py
@@ -9,9 +9,12 @@ except importlib.metadata.PackageNotFoundError:
 
 
 from semantikon.api import (
+    FunctionMetadata,
     SemantikonURI,
+    TypeMetadata,
     get_knowledge_graph,
     meta,
+    parse_metadata,
     query_io_completer,
     request_values,
     semantikon_dataclass,
@@ -21,12 +24,15 @@ from semantikon.api import (
 )
 
 __all__ = [
+    "FunctionMetadata",
     "SemantikonURI",
-    "semantikon_dataclass",
+    "TypeMetadata",
     "get_knowledge_graph",
     "meta",
+    "parse_metadata",
     "query_io_completer",
     "request_values",
+    "semantikon_dataclass",
     "u",
     "validate_values",
     "visualize_recipe",

--- a/semantikon/api.py
+++ b/semantikon/api.py
@@ -1,6 +1,6 @@
 from semantikon.analysis import query_io_completer, request_values
-from semantikon.datastructure import FunctionMetadata, TypeMetadata
 from semantikon.converter import parse_metadata, semantikon_dataclass
+from semantikon.datastructure import FunctionMetadata, TypeMetadata
 from semantikon.metadata import SemantikonURI, meta, u
 from semantikon.ontology import get_knowledge_graph, validate_values
 from semantikon.visualize import visualize_recipe

--- a/semantikon/api.py
+++ b/semantikon/api.py
@@ -1,16 +1,20 @@
 from semantikon.analysis import query_io_completer, request_values
-from semantikon.converter import semantikon_dataclass
+from semantikon.datastructure import FunctionMetadata, TypeMetadata
+from semantikon.converter import parse_metadata, semantikon_dataclass
 from semantikon.metadata import SemantikonURI, meta, u
 from semantikon.ontology import get_knowledge_graph, validate_values
 from semantikon.visualize import visualize_recipe
 
 __all__ = [
+    "FunctionMetadata",
     "SemantikonURI",
-    "semantikon_dataclass",
+    "TypeMetadata",
     "get_knowledge_graph",
     "meta",
+    "parse_metadata",
     "query_io_completer",
     "request_values",
+    "semantikon_dataclass",
     "u",
     "validate_values",
     "visualize_recipe",


### PR DESCRIPTION
Closes https://github.com/pyiron/semantikon/issues/448.

I took the liberty of alphabetizing "semantikon_dataclass" in the `__all__` list while I'm here.

@samwaseda, I'm also exporting `FunctionMetadata` alongside `TypeMetadata`. I don't actually presently need it, but the rationale for exposing it is identical.