### PR TITLE
[bug] Do not use hard coded "x"

### DIFF
--- a/semantikon/converter.py
+++ b/semantikon/converter.py
@@ -554,7 +554,7 @@ def with_explicit_defaults(**messages) -> Callable:
                     else:
                         warnings.warn(
                             f"'{name}' not provided,"
-                            f" using default: {sig.parameters['x'].default}"
+                            f" using default: {sig.parameters[name].default}"
                         )
 
             return func(*args, **kwargs)


### PR DESCRIPTION
I don't know how I didn't notice this mistake before.