### PR TITLE
Buff up SemantikonURI serialization

### DIFF
--- a/semantikon/metadata.py
+++ b/semantikon/metadata.py
@@ -159,6 +159,18 @@ def meta(
     return decorator
 
 
+def _rebuild_semantikon_uri(value: str, instance: BNode) -> "SemantikonURI":
+    """Reconstruct a :class:`SemantikonURI`, preserving its blank-node instance.
+
+    Used by :meth:`SemantikonURI.__reduce__` for copy/pickle support. The
+    ``instance`` cannot be passed through the constructor (``URIRef.__new__``
+    rejects the extra argument), so it is assigned after construction.
+    """
+    obj = SemantikonURI(value)
+    obj._instance = instance
+    return obj
+
+
 class SemantikonURI(URIRef):
     """A class representing a URIRef with an associated blank node instance."""
 
@@ -179,6 +191,12 @@ class SemantikonURI(URIRef):
             tag = value.split("/")[-1].split("#")[-1] + "_" + str(uuid4())
             instance = BNode(tag)
         self._instance = instance
+
+    def __reduce__(self):
+        # rdflib's URIRef.__reduce__ hard-codes URIRef as the reconstruction
+        # class, which would silently downgrade copies/unpickles of a
+        # SemantikonURI to a plain URIRef and drop the blank-node instance.
+        return (_rebuild_semantikon_uri, (str(self), self._instance))
 
     def get_class(self) -> URIRef:
         return self._uriref

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -1,0 +1,55 @@
+"""Tests for :mod:`semantikon.metadata`."""
+
+import copy
+import pickle
+import unittest
+
+from rdflib import URIRef
+
+from semantikon import metadata
+
+
+class TestSemantikonURI(unittest.TestCase):
+    """``SemantikonURI`` must survive copying and pickling.
+
+    ``rdflib.URIRef.__reduce__`` hard-codes ``URIRef`` as the reconstruction
+    class, so without an override a (deep)copy or unpickle of a
+    ``SemantikonURI`` silently degrades to a plain ``URIRef`` and loses its
+    blank-node instance. ``flowrep_dict`` now puts these into dicts that
+    ``semantikon.workflow.to_semantikon_workflow_dict`` deep-copies, so the
+    coercion would corrupt the ontology triples.
+    """
+
+    def setUp(self):
+        self.uri = metadata.SemantikonURI("http://example.org/Color")
+
+    def test_deepcopy_preserves_type(self):
+        copied = copy.deepcopy(self.uri)
+        self.assertIsInstance(copied, metadata.SemantikonURI)
+
+    def test_copy_preserves_type(self):
+        copied = copy.copy(self.uri)
+        self.assertIsInstance(copied, metadata.SemantikonURI)
+
+    def test_pickle_preserves_type(self):
+        copied = pickle.loads(pickle.dumps(self.uri))
+        self.assertIsInstance(copied, metadata.SemantikonURI)
+
+    def test_deepcopy_preserves_uri_value(self):
+        copied = copy.deepcopy(self.uri)
+        self.assertEqual(str(copied), str(self.uri))
+        self.assertEqual(copied.get_class(), self.uri.get_class())
+
+    def test_deepcopy_preserves_instance(self):
+        copied = copy.deepcopy(self.uri)
+        self.assertEqual(copied.get_instance(), self.uri.get_instance())
+
+    def test_deepcopy_inside_container_preserves_type(self):
+        """The real failure mode: nested in the metadata dict structure."""
+        data = {"triples": (URIRef("http://example.org/hasProperty"), self.uri)}
+        copied = copy.deepcopy(data)
+        self.assertIsInstance(copied["triples"][1], metadata.SemantikonURI)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I discovered this when we deepcopied the workflow dictionary, that deepcopying SemantikonURI objects gave back plain old URIRef objects. The deepcopy is gone, so it's no longer strictly necessary in this PR, but IMO it's a nice improvement.