### PR TITLE
Add custom upper bounds

### DIFF
--- a/.ci_support/upper_bound.yml
+++ b/.ci_support/upper_bound.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+dependencies:
+  - bagofholding =0.2.0
+  - flowrep =0.6.0
+  - pyiron_snippets =2.0.0


### PR DESCRIPTION
To dependencies we control. This overrides the default behaviour of semver->pinned to minor; v0->pinned to patch. There are packages _we_ control, so we trust ourselves to actually provide compatibility and trust one further layer: semver->pinned to major; v0->pinned to minor.