### PR TITLE
Pin python>=3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ name = "semantikon"
 description = "semantikon - Ontological type system"
 readme = "docs/README.md"
 keywords = [ "pyiron",]
-requires-python = ">=3.10, <3.15"
+requires-python = ">=3.11, <3.15"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Topic :: Scientific/Engineering",


### PR DESCRIPTION
I noticed this last time I managed a conda-forge feedstock PR; the pyproject.toml python pin is out of sync with the classifiers and env.yml content.