### PR TITLE
[bug] Allow workflow followed by atomic

### DIFF
--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -667,9 +667,7 @@ def _input_is_connected(io: str, G: SemantikonDiGraph) -> bool:
             return True
         return _input_is_connected(candidate[0], G)
     elif n_predecessors == 2 and _is_macro_output(io, G, tuple(candidate)):
-        return _input_is_connected(candidate[0], G) and _input_is_connected(
-            candidate[1], G
-        )
+        return all([_input_is_connected(cc, G) for cc in candidate if G.nodes[cc]["step"] != "node"])
     else:
         predecessor_steps = {c: G.nodes[c]["step"] for c in candidate}
         step_type = G.nodes[io]["step"]

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -667,7 +667,13 @@ def _input_is_connected(io: str, G: SemantikonDiGraph) -> bool:
             return True
         return _input_is_connected(candidate[0], G)
     elif n_predecessors == 2 and _is_macro_output(io, G, tuple(candidate)):
-        return all([_input_is_connected(cc, G) for cc in candidate if G.nodes[cc]["step"] != "node"])
+        return all(
+            [
+                _input_is_connected(cc, G)
+                for cc in candidate
+                if G.nodes[cc]["step"] != "node"
+            ]
+        )
     else:
         predecessor_steps = {c: G.nodes[c]["step"] for c in candidate}
         step_type = G.nodes[io]["step"]

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -156,7 +156,8 @@ def wf_triples(a, b):
 @workflow
 def wf_nested_triples(a, b):
     result = wf_triples(a, b)
-    return result
+    one = add_one(result)
+    return one
 
 
 class Meal:


### PR DESCRIPTION
This pull request makes targeted improvements to both the ontology graph traversal logic and the corresponding unit tests. The main change enhances how macro outputs are handled in the connectivity check, and the related test now validates this updated logic.

**Ontology graph traversal logic:**

* Updated the `_input_is_connected` function in `ontology.py` to use a more general approach for checking connectivity when a node has two predecessors and is a macro output. Instead of checking both predecessors explicitly, it now checks all candidate predecessors except those with the `"step"` attribute set to `"node"`.

**Unit test updates:**

* Modified the `wf_nested_triples` test workflow in `test_ontology.py` to return the result of `add_one(result)` instead of just `result`, ensuring the test reflects the new expected behavior.