### PR TITLE
feat: Base ontology parsing on flowrep data class and not wf_dict

### DIFF
--- a/semantikon/flowrep_dict.py
+++ b/semantikon/flowrep_dict.py
@@ -36,6 +36,7 @@ from typing import Annotated, Any, cast, get_args, get_origin
 
 import flowrep as fr
 import networkx as nx
+from pydantic import ValidationError
 from pyiron_snippets import retrieve
 
 from semantikon.converter import (
@@ -45,6 +46,20 @@ from semantikon.converter import (
     parse_metadata,
 )
 from semantikon.datastructure import TypeMetadata
+
+
+def dict_to_nodedata(node: dict[str, Any]) -> fr.schemas.NodeData:
+    """Convert a legacy semantikon workflow dict into flowrep node data."""
+    try:
+        match node["type"]:
+            case "atomic":
+                return _dict_to_atomic_data(node)
+            case "workflow":
+                return _dict_to_workflow_data(node)
+            case other:
+                raise TypeError(f"Unsupported workflow dict node type: {other!r}")
+    except ValidationError as exc:
+        raise AssertionError(str(exc)) from exc
 
 
 def nodedata2dict(
@@ -73,6 +88,164 @@ def nodedata2dict(
             "control-flow dict, which requires unwrapping the body recipe."
         )
     raise TypeError(f"Unsupported data node type: {type(node).__name__}")
+
+
+def _dict_to_annotation(port: dict[str, Any]) -> Any | None:
+    dtype = port.get("dtype")
+    metadata = {
+        key: value
+        for key, value in port.items()
+        if key not in {"value", "dtype", "default"}
+    }
+    if dtype is None and not metadata:
+        return None
+    if metadata:
+        return Annotated[dtype if dtype is not None else Any, metadata]
+    return dtype
+
+
+def _dict_to_input_port(port: dict[str, Any]) -> fr.schemas.InputDataPort:
+    return fr.schemas.InputDataPort(
+        value=port["value"] if "value" in port else fr.schemas.NOT_DATA,
+        annotation=_dict_to_annotation(port),
+        default=port["default"] if "default" in port else fr.schemas.NOT_DATA,
+    )
+
+
+def _dict_to_output_port(port: dict[str, Any]) -> fr.schemas.OutputDataPort:
+    return fr.schemas.OutputDataPort(
+        value=port["value"] if "value" in port else fr.schemas.NOT_DATA,
+        annotation=_dict_to_annotation(port),
+    )
+
+
+def _flowrep_recipe_from_callable(function: Any, *, node_type: str):
+    if hasattr(function, "flowrep_recipe"):
+        return function.flowrep_recipe
+    decorator = fr.tools.atomic if node_type == "atomic" else fr.tools.workflow
+    return decorator(function).flowrep_recipe
+
+
+def _dict_to_atomic_recipe(node: dict[str, Any]) -> fr.schemas.AtomicRecipe:
+    function = node["function"]
+    return _flowrep_recipe_from_callable(function, node_type="atomic")
+
+
+def _dict_to_recipe(node: dict[str, Any]) -> fr.schemas.RecipeDiscrimination:
+    match node["type"]:
+        case "atomic":
+            return _dict_to_atomic_recipe(node)
+        case "workflow":
+            return _dict_to_workflow_recipe(node)
+        case other:
+            raise TypeError(f"Unsupported workflow dict node type: {other!r}")
+
+
+def _dict_to_atomic_data(node: dict[str, Any]) -> fr.schemas.AtomicData:
+    data = fr.schemas.AtomicData.from_recipe(_dict_to_atomic_recipe(node))
+    data.function = node["function"]
+    data.input_ports = {
+        label: _dict_to_input_port(port) for label, port in node.get("inputs", {}).items()
+    }
+    data.output_ports = {
+        label: _dict_to_output_port(port)
+        for label, port in node.get("outputs", {}).items()
+    }
+    return data
+
+
+def _split_endpoint(endpoint: str) -> tuple[str | None, str, str]:
+    if endpoint.startswith("inputs.") or endpoint.startswith("outputs."):
+        io, port = endpoint.split(".", 1)
+        return None, io, port
+    parts = endpoint.rsplit(".", 2)
+    if len(parts) != 3 or parts[1] not in {"inputs", "outputs"}:
+        raise ValueError(f"Malformed workflow edge endpoint: {endpoint!r}")
+    return parts[0], parts[1], parts[2]
+
+
+def _normalize_output_label(label: str, recipe_outputs: list[str]) -> str:
+    if label == "output" and recipe_outputs == ["output_0"]:
+        return "output_0"
+    return label
+
+
+def _dict_to_workflow_recipe(node: dict[str, Any]) -> fr.schemas.WorkflowRecipe:
+    function = node.get("function")
+    if function is None:
+        raise TypeError(
+            "Workflow dict entries must carry a callable."
+        )
+    base_recipe = _flowrep_recipe_from_callable(function, node_type="workflow")
+    nodes = {
+        label: _dict_to_recipe(child_node)
+        for label, child_node in node.get("nodes", {}).items()
+    }
+    input_edges: fr.schemas.InputEdges = {}
+    edges: fr.schemas.Edges = {}
+    output_edges: fr.schemas.OutputEdges = {}
+    for src, tgt in node.get("edges", []):
+        src_node, src_io, src_port = _split_endpoint(src)
+        tgt_node, tgt_io, tgt_port = _split_endpoint(tgt)
+        if src_node is None and src_io == "inputs" and tgt_node is not None and tgt_io == "inputs":
+            input_edges[fr.schemas.TargetHandle(node=tgt_node, port=tgt_port)] = (
+                fr.schemas.InputSource(port=src_port)
+            )
+        elif (
+            src_node is not None
+            and src_io == "outputs"
+            and tgt_node is not None
+            and tgt_io == "inputs"
+        ):
+            src_port = _normalize_output_label(src_port, nodes[src_node].outputs)
+            edges[fr.schemas.TargetHandle(node=tgt_node, port=tgt_port)] = (
+                fr.schemas.SourceHandle(node=src_node, port=src_port)
+            )
+        elif tgt_node is None and tgt_io == "outputs" and src_node is None and src_io == "inputs":
+            tgt_port = _normalize_output_label(tgt_port, list(base_recipe.outputs))
+            output_edges[fr.schemas.OutputTarget(port=tgt_port)] = fr.schemas.InputSource(
+                port=src_port
+            )
+        elif (
+            tgt_node is None
+            and tgt_io == "outputs"
+            and src_node is not None
+            and src_io == "outputs"
+        ):
+            src_port = _normalize_output_label(src_port, nodes[src_node].outputs)
+            tgt_port = _normalize_output_label(tgt_port, list(base_recipe.outputs))
+            output_edges[fr.schemas.OutputTarget(port=tgt_port)] = fr.schemas.SourceHandle(
+                node=src_node, port=src_port
+            )
+        else:
+            raise ValueError(f"Malformed workflow edge: {src!r} -> {tgt!r}")
+    return fr.schemas.WorkflowRecipe(
+        inputs=list(base_recipe.inputs),
+        outputs=list(base_recipe.outputs),
+        nodes=nodes,
+        input_edges=input_edges,
+        edges=edges,
+        output_edges=output_edges,
+        reference=base_recipe.reference,
+        description=base_recipe.description,
+    )
+
+
+def _dict_to_workflow_data(node: dict[str, Any]) -> fr.schemas.DagData:
+    recipe = _dict_to_workflow_recipe(node)
+    data = fr.schemas.DagData.from_recipe(recipe)
+    data.input_ports = {
+        label: _dict_to_input_port(port) for label, port in node.get("inputs", {}).items()
+    }
+    data.output_ports = {
+        label: _dict_to_output_port(port)
+        for label, port in node.get("outputs", {}).items()
+    }
+    data.nodes = {
+        label: dict_to_nodedata(child_node)
+        for label, child_node in node.get("nodes", {}).items()
+    }
+    return data
 
 
 # ---------------------------------------------------------------------------

--- a/semantikon/flowrep_dict.py
+++ b/semantikon/flowrep_dict.py
@@ -145,7 +145,8 @@ def _dict_to_atomic_data(node: dict[str, Any]) -> fr.schemas.AtomicData:
     data = fr.schemas.AtomicData.from_recipe(_dict_to_atomic_recipe(node))
     data.function = node["function"]
     data.input_ports = {
-        label: _dict_to_input_port(port) for label, port in node.get("inputs", {}).items()
+        label: _dict_to_input_port(port)
+        for label, port in node.get("inputs", {}).items()
     }
     data.output_ports = {
         label: _dict_to_output_port(port)
@@ -173,9 +174,7 @@ def _normalize_output_label(label: str, recipe_outputs: list[str]) -> str:
 def _dict_to_workflow_recipe(node: dict[str, Any]) -> fr.schemas.WorkflowRecipe:
     function = node.get("function")
     if function is None:
-        raise TypeError(
-            "Workflow dict entries must carry a callable."
-        )
+        raise TypeError("Workflow dict entries must carry a callable.")
     base_recipe = _flowrep_recipe_from_callable(function, node_type="workflow")
     nodes = {
         label: _dict_to_recipe(child_node)
@@ -187,7 +186,12 @@ def _dict_to_workflow_recipe(node: dict[str, Any]) -> fr.schemas.WorkflowRecipe:
     for src, tgt in node.get("edges", []):
         src_node, src_io, src_port = _split_endpoint(src)
         tgt_node, tgt_io, tgt_port = _split_endpoint(tgt)
-        if src_node is None and src_io == "inputs" and tgt_node is not None and tgt_io == "inputs":
+        if (
+            src_node is None
+            and src_io == "inputs"
+            and tgt_node is not None
+            and tgt_io == "inputs"
+        ):
             input_edges[fr.schemas.TargetHandle(node=tgt_node, port=tgt_port)] = (
                 fr.schemas.InputSource(port=src_port)
             )
@@ -201,10 +205,15 @@ def _dict_to_workflow_recipe(node: dict[str, Any]) -> fr.schemas.WorkflowRecipe:
             edges[fr.schemas.TargetHandle(node=tgt_node, port=tgt_port)] = (
                 fr.schemas.SourceHandle(node=src_node, port=src_port)
             )
-        elif tgt_node is None and tgt_io == "outputs" and src_node is None and src_io == "inputs":
+        elif (
+            tgt_node is None
+            and tgt_io == "outputs"
+            and src_node is None
+            and src_io == "inputs"
+        ):
             tgt_port = _normalize_output_label(tgt_port, list(base_recipe.outputs))
-            output_edges[fr.schemas.OutputTarget(port=tgt_port)] = fr.schemas.InputSource(
-                port=src_port
+            output_edges[fr.schemas.OutputTarget(port=tgt_port)] = (
+                fr.schemas.InputSource(port=src_port)
             )
         elif (
             tgt_node is None
@@ -214,8 +223,8 @@ def _dict_to_workflow_recipe(node: dict[str, Any]) -> fr.schemas.WorkflowRecipe:
         ):
             src_port = _normalize_output_label(src_port, nodes[src_node].outputs)
             tgt_port = _normalize_output_label(tgt_port, list(base_recipe.outputs))
-            output_edges[fr.schemas.OutputTarget(port=tgt_port)] = fr.schemas.SourceHandle(
-                node=src_node, port=src_port
+            output_edges[fr.schemas.OutputTarget(port=tgt_port)] = (
+                fr.schemas.SourceHandle(node=src_node, port=src_port)
             )
         else:
             raise ValueError(f"Malformed workflow edge: {src!r} -> {tgt!r}")
@@ -235,7 +244,8 @@ def _dict_to_workflow_data(node: dict[str, Any]) -> fr.schemas.DagData:
     recipe = _dict_to_workflow_recipe(node)
     data = fr.schemas.DagData.from_recipe(recipe)
     data.input_ports = {
-        label: _dict_to_input_port(port) for label, port in node.get("inputs", {}).items()
+        label: _dict_to_input_port(port)
+        for label, port in node.get("inputs", {}).items()
     }
     data.output_ports = {
         label: _dict_to_output_port(port)

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -1439,7 +1439,9 @@ def _workflow_to_networkx(
                 child,
                 child_name,
                 parent_name=node_name,
-                workflow_label=child_label if isinstance(child, fr.schemas.DagData) else None,
+                workflow_label=(
+                    child_label if isinstance(child, fr.schemas.DagData) else None
+                ),
             )
 
         child_recipes = recipe.nodes
@@ -1483,7 +1485,10 @@ def _get_hashed_node_dict_from_graph(G: SemantikonDiGraph) -> dict[str, dict[str
 
         hash_dict_tmp: dict[str, Any] = {
             "inputs": {},
-            "outputs": [G.nodes[out].get("label", out.split("-")[-1]) for out in G.successors(node)],
+            "outputs": [
+                G.nodes[out].get("label", out.split("-")[-1])
+                for out in G.successors(node)
+            ],
             "node": copy.deepcopy(data.get("function")),
         }
         if hash_dict_tmp["node"] is None:

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -27,6 +27,7 @@ from semantikon.converter import (
 )
 from semantikon.flowrep_dict import (
     _WorkflowGraphSerializer,
+    dict_to_nodedata,
     get_hashed_node_dict,
     nodedata2dict,
 )
@@ -395,16 +396,18 @@ def get_knowledge_graph(
             DeprecationWarning,
             stacklevel=2,
         )
+        wf_dict = dict_to_nodedata(wf_dict)
     if isinstance(wf_dict, fr.schemas.WorkflowRecipe):
-        wf_dict = nodedata2dict(fr.schemas.DagData.from_recipe(wf_dict))
+        wf_dict = fr.schemas.DagData.from_recipe(wf_dict)
     elif isinstance(wf_dict, fr.schemas.DagData):
-        wf_dict = nodedata2dict(wf_dict)
-    elif not isinstance(wf_dict, dict):
+        pass
+    else:
         raise TypeError(
             f"Invalid input type. Expected dict, flowrep {fr.schemas.DagData.__name__!r}, or "
             f"flowrep {fr.schemas.WorkflowRecipe.__name__!r}, but got {type(wf_dict)}."
         )
 
+    wf_dict = nodedata2dict(wf_dict)
     G = serialize_and_convert_to_networkx(wf_dict, hash_data=hash_data, prefix=prefix)
     _check_consistency_of_digraph(G)
     graph = _get_bound_graph()

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -1524,7 +1524,9 @@ def _get_hashed_node_dict_from_graph(G: SemantikonDiGraph) -> dict[str, dict[str
             json.dumps(hash_dict_tmp, sort_keys=True).encode("utf-8")
         ).hexdigest()
         for out in G.successors(node):
-            G.nodes[out]["hash"] = h + "@" + G.nodes[out].get("label", out.split("-")[-1])
+            G.nodes[out]["hash"] = (
+                h + "@" + G.nodes[out].get("label", out.split("-")[-1])
+            )
         hash_dict_tmp["hash"] = h
         hash_dict[node] = hash_dict_tmp
     return hash_dict

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -1480,7 +1480,15 @@ def _get_hashed_node_dict_from_graph(G: SemantikonDiGraph) -> dict[str, dict[str
     hash_dict: dict[str, dict[str, Any]] = {}
     for node in nx.topological_sort(G):
         data = G.nodes[node]
-        if data["step"] != "node":
+        if data.get("step") != "node":
+            for term in ("hash", "value"):
+                if term in data:
+                    continue
+                for predecessor in G.predecessors(node):
+                    predecessor_data = G.nodes[predecessor]
+                    if term in predecessor_data:
+                        data[term] = predecessor_data[term]
+                        break
             continue
 
         hash_dict_tmp: dict[str, Any] = {
@@ -1515,6 +1523,8 @@ def _get_hashed_node_dict_from_graph(G: SemantikonDiGraph) -> dict[str, dict[str
         h = sha256(
             json.dumps(hash_dict_tmp, sort_keys=True).encode("utf-8")
         ).hexdigest()
+        for out in G.successors(node):
+            G.nodes[out]["hash"] = h + "@" + G.nodes[out].get("label", out.split("-")[-1])
         hash_dict_tmp["hash"] = h
         hash_dict[node] = hash_dict_tmp
     return hash_dict

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -14,6 +14,7 @@ import bagofholding
 import flowrep as fr
 import networkx as nx
 from owlrl import DeductiveClosure, RDFS_Semantics
+from pyiron_snippets import retrieve
 from pyshacl import validate
 from rdflib import OWL, RDF, RDFS, BNode, Graph, Literal, Namespace, URIRef
 from rdflib.namespace import SH
@@ -26,10 +27,9 @@ from semantikon.converter import (
     parse_output_args,
 )
 from semantikon.flowrep_dict import (
-    _WorkflowGraphSerializer,
+    annotation_to_type_hint,
+    annotation_to_type_metadata,
     dict_to_nodedata,
-    get_hashed_node_dict,
-    nodedata2dict,
 )
 from semantikon.metadata import SemantikonURI
 from semantikon.qudt import UnitsDict
@@ -407,7 +407,6 @@ def get_knowledge_graph(
             f"flowrep {fr.schemas.WorkflowRecipe.__name__!r}, but got {type(wf_dict)}."
         )
 
-    wf_dict = nodedata2dict(wf_dict)
     G = serialize_and_convert_to_networkx(wf_dict, hash_data=hash_data, prefix=prefix)
     _check_consistency_of_digraph(G)
     graph = _get_bound_graph()
@@ -1326,31 +1325,227 @@ def _get_successor_nodes(G, node_name):
                 yield node
 
 
+def _infer_workflow_label(recipe: fr.schemas.WorkflowRecipe) -> str:
+    if recipe.reference is None:
+        return ""
+    return recipe.reference.info.fully_qualified_name.rsplit(".", 1)[-1]
+
+
+def _output_port_label(port: str, outputs: list[str]) -> str:
+    if port == "output_0" and len(outputs) == 1 and outputs[0] == "output_0":
+        return "output"
+    return port
+
+
+def _port_to_dict(
+    *,
+    value: Any,
+    annotation: Any,
+    default: Any = fr.schemas.NOT_DATA,
+) -> dict[str, Any]:
+    data: dict[str, Any] = {}
+    if not isinstance(value, fr.schemas.NotData):
+        data["value"] = value
+    if type_hint := annotation_to_type_hint(annotation):
+        data["dtype"] = type_hint
+    if type_metadata := annotation_to_type_metadata(annotation):
+        data.update(type_metadata.to_dictionary())
+    if not isinstance(default, fr.schemas.NotData):
+        data["default"] = default
+    return data
+
+
+def _node_data_to_metadata(
+    data: fr.schemas.NodeData,
+    *,
+    label: str | None = None,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    function = None
+    if isinstance(data, fr.schemas.AtomicData):
+        metadata["type"] = "atomic"
+        function = data.function
+    elif isinstance(data, fr.schemas.DagData):
+        metadata["type"] = "workflow"
+        if label is not None:
+            metadata["label"] = label
+        if data.recipe.reference is not None:
+            function = retrieve.import_from_string(
+                data.recipe.reference.info.fully_qualified_name
+            )
+    if function is not None:
+        if hasattr(function, "_semantikon_metadata"):
+            metadata.update(function._semantikon_metadata)
+        function_data = get_function_dict(function)
+        function_data["identifier"] = ".".join(
+            (
+                function_data["module"],
+                function_data["qualname"],
+                function_data["version"],
+            )
+        )
+        metadata["function"] = function_data
+    return metadata
+
+
+def _workflow_to_networkx(
+    workflow: fr.schemas.DagData,
+    *,
+    prefix: str | None = None,
+) -> SemantikonDiGraph:
+    root_label = _infer_workflow_label(workflow.recipe)
+    G = SemantikonDiGraph(prefix=prefix)
+    G.name = root_label
+
+    def _add_node(
+        node_data: fr.schemas.NodeData,
+        node_name: str,
+        *,
+        parent_name: str | None = None,
+        workflow_label: str | None = None,
+    ):
+        node_attrs = _node_data_to_metadata(node_data, label=workflow_label)
+        if parent_name is not None:
+            node_attrs["parent"] = parent_name
+        G.add_node(node_name, step="node", **node_attrs)
+
+        output_labels = list(node_data.output_ports)
+        if len(output_labels) == 1 and output_labels[0] == "output_0":
+            output_labels = ["output"]
+
+        for position, (label, port) in enumerate(node_data.input_ports.items()):
+            io_name = f"{node_name}-inputs-{label}"
+            io_data = _port_to_dict(
+                value=port.value,
+                annotation=port.annotation,
+                default=port.default,
+            )
+            G.add_node(io_name, step="inputs", arg=label, position=position, **io_data)
+            G.add_edge(io_name, node_name)
+        for position, (raw_label, port) in enumerate(node_data.output_ports.items()):
+            label = output_labels[position] if raw_label == "output_0" else raw_label
+            io_name = f"{node_name}-outputs-{label}"
+            io_data = _port_to_dict(value=port.value, annotation=port.annotation)
+            G.add_node(io_name, step="outputs", arg=label, position=position, **io_data)
+            G.add_edge(node_name, io_name)
+
+        if not isinstance(node_data, fr.schemas.DagData):
+            return
+
+        recipe = node_data.recipe
+        for child_label, child in node_data.nodes.items():
+            child_name = f"{node_name}-{child_label}"
+            _add_node(
+                child,
+                child_name,
+                parent_name=node_name,
+                workflow_label=child_label if isinstance(child, fr.schemas.DagData) else None,
+            )
+
+        child_recipes = recipe.nodes
+        for target, source in recipe.input_edges.items():
+            G.add_edge(
+                f"{node_name}-inputs-{source.port}",
+                f"{node_name}-{target.node}-inputs-{target.port}",
+            )
+        for target, source in recipe.edges.items():
+            child_outputs = list(child_recipes[source.node].outputs)
+            src_port = _output_port_label(source.port, child_outputs)
+            G.add_edge(
+                f"{node_name}-{source.node}-outputs-{src_port}",
+                f"{node_name}-{target.node}-inputs-{target.port}",
+            )
+        for target, source in recipe.output_edges.items():
+            target_port = _output_port_label(target.port, list(recipe.outputs))
+            if isinstance(source, fr.schemas.InputSource):
+                G.add_edge(
+                    f"{node_name}-inputs-{source.port}",
+                    f"{node_name}-outputs-{target_port}",
+                )
+            else:
+                child_outputs = list(child_recipes[source.node].outputs)
+                src_port = _output_port_label(source.port, child_outputs)
+                G.add_edge(
+                    f"{node_name}-{source.node}-outputs-{src_port}",
+                    f"{node_name}-outputs-{target_port}",
+                )
+
+    _add_node(workflow, root_label, workflow_label=root_label)
+    return G
+
+
+def _get_hashed_node_dict_from_graph(G: SemantikonDiGraph) -> dict[str, dict[str, Any]]:
+    hash_dict: dict[str, dict[str, Any]] = {}
+    for node in nx.topological_sort(G):
+        data = G.nodes[node]
+        if data["step"] != "node":
+            continue
+
+        hash_dict_tmp: dict[str, Any] = {
+            "inputs": {},
+            "outputs": [G.nodes[out].get("label", out.split("-")[-1]) for out in G.successors(node)],
+            "node": copy.deepcopy(data.get("function")),
+        }
+        if hash_dict_tmp["node"] is None:
+            continue
+        hash_dict_tmp["node"]["connected_inputs"] = []
+        missing_input = False
+        for inp in G.predecessors(node):
+            inp_data = G.nodes[inp]
+            inp_name = inp.split("-")[-1]
+            if "hash" in inp_data:
+                hash_dict_tmp["inputs"][inp_name] = inp_data["hash"]
+                hash_dict_tmp["node"]["connected_inputs"].append(inp_name)
+            elif "value" in inp_data:
+                value = inp_data["value"]
+                if is_dataclass(value) and not isinstance(value, type):
+                    hash_dict_tmp["inputs"][inp_name] = asdict(value)
+                else:
+                    hash_dict_tmp["inputs"][inp_name] = value
+            else:
+                missing_input = True
+                break
+        if missing_input:
+            continue
+        h = sha256(
+            json.dumps(hash_dict_tmp, sort_keys=True).encode("utf-8")
+        ).hexdigest()
+        hash_dict_tmp["hash"] = h
+        hash_dict[node] = hash_dict_tmp
+    return hash_dict
+
+
 def serialize_and_convert_to_networkx(
-    wf_dict: dict,
+    workflow: dict | fr.schemas.DagData | fr.schemas.WorkflowRecipe,
     hash_data: bool = True,
     prefix: str | None = None,
 ) -> SemantikonDiGraph:
     """
-    Serialize a workflow dictionary into a SemantikonDiGraph, optionally
+    Serialize a flowrep workflow into a SemantikonDiGraph, optionally
     hashing node data.
 
     Args:
-        wf_dict (dict): The workflow dictionary to serialize.
+        workflow (dict | DagData | WorkflowRecipe): Workflow representation.
         hash_data (bool): Whether to hash node data.
         prefix (str | None): Optional prefix for node names.
 
     Returns:
         SemantikonDiGraph: The serialized workflow graph.
     """
-    G_nx = _WorkflowGraphSerializer.serialize(wf_dict)
-    G = SemantikonDiGraph(G_nx, prefix=prefix)
+    if isinstance(workflow, dict):
+        workflow = dict_to_nodedata(workflow)
+    if isinstance(workflow, fr.schemas.WorkflowRecipe):
+        workflow = fr.schemas.DagData.from_recipe(workflow)
+    if not isinstance(workflow, fr.schemas.DagData):
+        raise TypeError(
+            f"Invalid workflow type. Expected dict, flowrep {fr.schemas.DagData.__name__!r}, or "
+            f"flowrep {fr.schemas.WorkflowRecipe.__name__!r}, but got {type(workflow)}."
+        )
+
+    G = _workflow_to_networkx(workflow, prefix=prefix)
     if hash_data:
         try:
-            hashed_dict = {}
-            for key, value in get_hashed_node_dict(wf_dict).items():
-                key = G.name + "-" + key
-                hashed_dict[key.replace(".", "-")] = value
+            hashed_dict = _get_hashed_node_dict_from_graph(G)
         except Exception as e:
             raise RuntimeError(
                 "Failed to hash workflow data - use only hashable inputs or set hash_data=False"

--- a/tests/unit/test_flowrep_dict.py
+++ b/tests/unit/test_flowrep_dict.py
@@ -127,6 +127,27 @@ def measurement_workflow(
     return result
 
 
+@frt.workflow
+def _passthrough_with_child(x):
+    _ = identity(x)
+    return x
+
+
+_passthrough_with_child.flowrep_recipe = frs.WorkflowRecipe(
+    inputs=["x"],
+    outputs=["output_0"],
+    nodes={"identity_0": identity.flowrep_recipe},
+    input_edges={
+        frs.TargetHandle(node="identity_0", port="x"): frs.InputSource(port="x"),
+    },
+    edges={},
+    output_edges={
+        frs.OutputTarget(port="output_0"): frs.InputSource(port="x"),
+    },
+    reference=_passthrough_with_child.flowrep_recipe.reference,
+)
+
+
 def _inner_workflow_with_output_0() -> frs.WorkflowRecipe:
     """A workflow whose sole output is named ``output_0``.
 
@@ -542,6 +563,20 @@ class TestOutputSanitizationConsistency(unittest.TestCase):
         parent_data = frt.run_recipe(parent, x=42)
         d = flowrep_dict.nodedata2dict(parent_data)
         self.assertEqual(d["outputs"]["result"]["value"], 42)
+
+    def test_dict_to_nodedata_normalizes_passthrough_output_name(self):
+        node = frs.DagData.from_recipe(_passthrough_with_child.flowrep_recipe)
+        d = flowrep_dict.nodedata2dict(node)
+        self.assertIn(("inputs.x", "outputs.output"), d["edges"])
+        round_tripped = flowrep_dict.dict_to_nodedata(d)
+        self.assertIn(
+            frs.OutputTarget(port="output_0"),
+            round_tripped.recipe.output_edges,
+        )
+        self.assertEqual(
+            round_tripped.recipe.output_edges[frs.OutputTarget(port="output_0")],
+            frs.InputSource(port="x"),
+        )
 
 
 class TestGetFunctionMetadata(unittest.TestCase):

--- a/tests/unit/test_flowrep_dict.py
+++ b/tests/unit/test_flowrep_dict.py
@@ -323,6 +323,20 @@ class TestWorkflowToDict(unittest.TestCase):
             self.assertIn(src_prefix, valid_prefixes, msg=f"bad edge source: {src}")
             self.assertIn(tgt_prefix, valid_prefixes, msg=f"bad edge target: {tgt}")
 
+    def test_dict_to_nodedata_round_trip(self):
+        wf_dict = flowrep_dict.nodedata2dict(
+            frt.run_recipe(_diamond_workflow.flowrep_recipe, a=3, b=7)
+        )
+        node = flowrep_dict.dict_to_nodedata(wf_dict)
+        self.assertIsInstance(node, frs.DagData)
+        self.assertEqual(node.input_ports["a"].value, 3)
+        self.assertEqual(node.input_ports["b"].value, 7)
+        self.assertEqual(node.nodes["my_add_0"].output_ports["output"].value, 10)
+        self.assertEqual(
+            flowrep_dict.nodedata2dict(node)["edges"],
+            wf_dict["edges"],
+        )
+
 
 class TestFlowControlStub(unittest.TestCase):
     def test_raises_not_implemented(self):

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -444,6 +444,11 @@ def workflow_with_wrong_derived_from_in_output(
     return result
 
 
+@workflow
+def passthrough_input_workflow(x):
+    return x
+
+
 class TestOntology(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -1175,6 +1180,48 @@ class TestOntology(unittest.TestCase):
             onto.get_knowledge_graph,
             workflow_with_wrong_derived_from_in_output.flowrep_recipe,
         )
+
+    def test_infer_workflow_label_without_reference(self):
+        recipe = fr.schemas.WorkflowRecipe(
+            inputs=["x"],
+            outputs=["y"],
+            nodes={},
+            input_edges={},
+            edges={},
+            output_edges={fr.schemas.OutputTarget(port="y"): fr.schemas.InputSource(port="x")},
+        )
+        self.assertEqual(onto._infer_workflow_label(recipe), "")
+
+    def test_serialize_workflow_recipe_with_input_passthrough(self):
+        self.assertTrue(
+            any(
+                isinstance(source, fr.schemas.InputSource)
+                for source in passthrough_input_workflow.flowrep_recipe.output_edges.values()
+            )
+        )
+        G = onto.serialize_and_convert_to_networkx(
+            passthrough_input_workflow.flowrep_recipe,
+            hash_data=False,
+        )
+        self.assertIn(
+            ("passthrough_input_workflow-inputs-x", "passthrough_input_workflow-outputs-x"),
+            G.edges,
+        )
+
+    def test_hashing_skips_nodes_without_function_metadata(self):
+        recipe = fr.schemas.WorkflowRecipe(
+            inputs=["x"],
+            outputs=["y"],
+            nodes={},
+            input_edges={},
+            edges={},
+            output_edges={fr.schemas.OutputTarget(port="y"): fr.schemas.InputSource(port="x")},
+        )
+        data = fr.schemas.DagData.from_recipe(recipe)
+        data.input_ports["x"].value = 1.0
+        G = onto._workflow_to_networkx(data)
+        hashed = onto._get_hashed_node_dict_from_graph(G)
+        self.assertEqual(hashed, {})
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -1188,7 +1188,9 @@ class TestOntology(unittest.TestCase):
             nodes={},
             input_edges={},
             edges={},
-            output_edges={fr.schemas.OutputTarget(port="y"): fr.schemas.InputSource(port="x")},
+            output_edges={
+                fr.schemas.OutputTarget(port="y"): fr.schemas.InputSource(port="x")
+            },
         )
         self.assertEqual(onto._infer_workflow_label(recipe), "")
 
@@ -1204,7 +1206,10 @@ class TestOntology(unittest.TestCase):
             hash_data=False,
         )
         self.assertIn(
-            ("passthrough_input_workflow-inputs-x", "passthrough_input_workflow-outputs-x"),
+            (
+                "passthrough_input_workflow-inputs-x",
+                "passthrough_input_workflow-outputs-x",
+            ),
             G.edges,
         )
 
@@ -1215,7 +1220,9 @@ class TestOntology(unittest.TestCase):
             nodes={},
             input_edges={},
             edges={},
-            output_edges={fr.schemas.OutputTarget(port="y"): fr.schemas.InputSource(port="x")},
+            output_edges={
+                fr.schemas.OutputTarget(port="y"): fr.schemas.InputSource(port="x")
+            },
         )
         data = fr.schemas.DagData.from_recipe(recipe)
         data.input_ports["x"].value = 1.0


### PR DESCRIPTION
well, wf_dict used to be called flowrep, but apparently things have changed a lot since then.

For the backward compatibility, wf_dict should also still be supported. It's just transformed back to flowrep data classes.