### PR TITLE
refactor: Separate SemantikonDiGraph into a different file

### DIFF
--- a/semantikon/flowrep_to_networkx.py
+++ b/semantikon/flowrep_to_networkx.py
@@ -1,0 +1,425 @@
+from __future__ import annotations
+
+import copy
+import json
+import unicodedata
+from dataclasses import asdict, is_dataclass
+from functools import cache, cached_property
+from hashlib import sha256
+from typing import Any
+
+import flowrep as fr
+import networkx as nx
+from pyiron_snippets import retrieve
+from rdflib import BNode, Namespace
+from rdflib.term import IdentifiedNode
+
+from semantikon.converter import get_function_dict
+from semantikon.flowrep_dict import (
+    annotation_to_type_hint,
+    annotation_to_type_metadata,
+    dict_to_nodedata,
+)
+
+BASE: Namespace = Namespace("http://pyiron.org/ontology/")
+
+
+class SemantikonDiGraph(nx.DiGraph):
+    @cached_property
+    def t_ns(self):
+        h = (
+            "W" + _get_graph_hash(self, with_global_inputs=False)[:8]
+            if self.graph["prefix"] is None
+            else self.graph["prefix"]
+        )
+        return Namespace(BASE + h + "_")
+
+    @cached_property
+    def a_ns(self):
+        h = _get_graph_hash(self, with_global_inputs=True)
+        return Namespace(BASE + h + "_")
+
+    def get_a_node(self, node_name: str) -> IdentifiedNode:
+        return self.a_ns[node_name]
+
+    @cache
+    def _get_data_node(self, io: str) -> str:
+        while True:
+            candidate = [c for c in self.predecessors(io) if self.nodes[c]["step"] != "node"]
+            assert len(candidate) <= 1
+            if len(candidate) == 0:
+                return f"{io}_data"
+            io = candidate[0]
+
+    def append_hash(
+        self,
+        node: str,
+        hash_value: str,
+        label: str | None = None,
+    ):
+        """
+        Propagates a hash value through the descendants of a given node in a
+        directed graph.
+
+        This function iteratively traverses the descendants of the graph and
+        appends a hash value to each descendant node. The hash value is
+        updated based on the label of each node. Optionally, it can remove
+        specific data (e.g., "value") from the nodes.
+
+        Parameters:
+            node (str): The starting node from which the hash propagation begins.
+            hash_value (str): The initial hash value to propagate through the
+                descendants.
+            label (str | None, optional): A label to use for hash computation.
+                If not provided, the label is derived from the node's data
+                (e.g., "label" or "arg"). Defaults to None.
+
+        Notes:
+            - The function uses an iterative approach to avoid recursion,
+                making it suitable for graphs with deep hierarchies.
+            - The hash value for each node is updated in the format:
+                `parent_hash@child_label`.
+        """
+        stack = [(node, hash_value, label)]
+
+        while stack:
+            current_node, current_hash, current_label = stack.pop()
+
+            for child in self.successors(current_node):
+                if self.nodes[child]["step"] == "node":
+                    continue
+
+                child_label = current_label
+                if child_label is None:
+                    child_label = self.nodes[child].get("label", self.nodes[child]["arg"])
+
+                self.nodes[child]["hash"] = current_hash + f"@{child_label}"
+                stack.append((child, current_hash, child_label))
+
+    def get_hash_dict(self) -> dict[str, str]:
+        """
+        Get a dictionary mapping node names to their hash values.
+
+        Returns:
+            dict[str, str]: A dictionary where keys are node names and values
+                are their corresponding hash values.
+        """
+        hash_dict = {}
+        for _, data in self.nodes.data():
+            if "hash" in data and "value" in data:
+                hash_dict[data["hash"]] = data["value"]
+        return hash_dict
+
+
+def _infer_workflow_label(recipe: fr.schemas.WorkflowRecipe) -> str:
+    if recipe.reference is None:
+        return ""
+    return recipe.reference.info.fully_qualified_name.rsplit(".", 1)[-1]
+
+
+def _output_port_label(port: str, outputs: list[str]) -> str:
+    if port == "output_0" and len(outputs) == 1 and outputs[0] == "output_0":
+        return "output"
+    return port
+
+
+def _port_to_dict(
+    *,
+    value: Any,
+    annotation: Any,
+    default: Any = fr.schemas.NOT_DATA,
+) -> dict[str, Any]:
+    data: dict[str, Any] = {}
+    if not isinstance(value, fr.schemas.NotData):
+        data["value"] = value
+    if type_hint := annotation_to_type_hint(annotation):
+        data["dtype"] = type_hint
+    if type_metadata := annotation_to_type_metadata(annotation):
+        data.update(type_metadata.to_dictionary())
+    if not isinstance(default, fr.schemas.NotData):
+        data["default"] = default
+    return data
+
+
+def _node_data_to_metadata(
+    data: fr.schemas.NodeData,
+    *,
+    label: str | None = None,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    function = None
+    if isinstance(data, fr.schemas.AtomicData):
+        metadata["type"] = "atomic"
+        function = data.function
+    elif isinstance(data, fr.schemas.DagData):
+        metadata["type"] = "workflow"
+        if label is not None:
+            metadata["label"] = label
+        if data.recipe.reference is not None:
+            function = retrieve.import_from_string(
+                data.recipe.reference.info.fully_qualified_name
+            )
+    if function is not None:
+        if hasattr(function, "_semantikon_metadata"):
+            metadata.update(function._semantikon_metadata)
+        function_data = get_function_dict(function)
+        function_data["identifier"] = ".".join(
+            (function_data["module"], function_data["qualname"], function_data["version"])
+        )
+        metadata["function"] = function_data
+    return metadata
+
+
+def _workflow_to_networkx(
+    workflow: fr.schemas.DagData,
+    *,
+    prefix: str | None = None,
+) -> SemantikonDiGraph:
+    root_label = _infer_workflow_label(workflow.recipe)
+    G = SemantikonDiGraph(prefix=prefix)
+    G.name = root_label
+
+    def _add_node(
+        node_data: fr.schemas.NodeData,
+        node_name: str,
+        *,
+        parent_name: str | None = None,
+        workflow_label: str | None = None,
+    ):
+        node_attrs = _node_data_to_metadata(node_data, label=workflow_label)
+        if parent_name is not None:
+            node_attrs["parent"] = parent_name
+        G.add_node(node_name, step="node", **node_attrs)
+
+        output_labels = list(node_data.output_ports)
+        if len(output_labels) == 1 and output_labels[0] == "output_0":
+            output_labels = ["output"]
+
+        for position, (label, port) in enumerate(node_data.input_ports.items()):
+            io_name = f"{node_name}-inputs-{label}"
+            io_data = _port_to_dict(
+                value=port.value,
+                annotation=port.annotation,
+                default=port.default,
+            )
+            G.add_node(io_name, step="inputs", arg=label, position=position, **io_data)
+            G.add_edge(io_name, node_name)
+        for position, (raw_label, port) in enumerate(node_data.output_ports.items()):
+            label = output_labels[position] if raw_label == "output_0" else raw_label
+            io_name = f"{node_name}-outputs-{label}"
+            io_data = _port_to_dict(value=port.value, annotation=port.annotation)
+            G.add_node(io_name, step="outputs", arg=label, position=position, **io_data)
+            G.add_edge(node_name, io_name)
+
+        if not isinstance(node_data, fr.schemas.DagData):
+            return
+
+        recipe = node_data.recipe
+        for child_label, child in node_data.nodes.items():
+            child_name = f"{node_name}-{child_label}"
+            _add_node(
+                child,
+                child_name,
+                parent_name=node_name,
+                workflow_label=(child_label if isinstance(child, fr.schemas.DagData) else None),
+            )
+
+        child_recipes = recipe.nodes
+        for target, source in recipe.input_edges.items():
+            G.add_edge(
+                f"{node_name}-inputs-{source.port}",
+                f"{node_name}-{target.node}-inputs-{target.port}",
+            )
+        for target, source in recipe.edges.items():
+            child_outputs = list(child_recipes[source.node].outputs)
+            src_port = _output_port_label(source.port, child_outputs)
+            G.add_edge(
+                f"{node_name}-{source.node}-outputs-{src_port}",
+                f"{node_name}-{target.node}-inputs-{target.port}",
+            )
+        for target, source in recipe.output_edges.items():
+            target_port = _output_port_label(target.port, list(recipe.outputs))
+            if isinstance(source, fr.schemas.InputSource):
+                G.add_edge(
+                    f"{node_name}-inputs-{source.port}",
+                    f"{node_name}-outputs-{target_port}",
+                )
+            else:
+                child_outputs = list(child_recipes[source.node].outputs)
+                src_port = _output_port_label(source.port, child_outputs)
+                G.add_edge(
+                    f"{node_name}-{source.node}-outputs-{src_port}",
+                    f"{node_name}-outputs-{target_port}",
+                )
+
+    _add_node(workflow, root_label, workflow_label=root_label)
+    return G
+
+
+def _get_hashed_node_dict_from_graph(G: SemantikonDiGraph) -> dict[str, dict[str, Any]]:
+    hash_dict: dict[str, dict[str, Any]] = {}
+    for node in nx.topological_sort(G):
+        data = G.nodes[node]
+        if data.get("step") != "node":
+            for term in ("hash", "value"):
+                if term in data:
+                    continue
+                for predecessor in G.predecessors(node):
+                    predecessor_data = G.nodes[predecessor]
+                    if term in predecessor_data:
+                        data[term] = predecessor_data[term]
+                        break
+            continue
+
+        hash_dict_tmp: dict[str, Any] = {
+            "inputs": {},
+            "outputs": [G.nodes[out].get("label", out.split("-")[-1]) for out in G.successors(node)],
+            "node": copy.deepcopy(data.get("function")),
+        }
+        if hash_dict_tmp["node"] is None:
+            continue
+        hash_dict_tmp["node"]["connected_inputs"] = []
+        missing_input = False
+        for inp in G.predecessors(node):
+            inp_data = G.nodes[inp]
+            inp_name = inp.split("-")[-1]
+            if "hash" in inp_data:
+                hash_dict_tmp["inputs"][inp_name] = inp_data["hash"]
+                hash_dict_tmp["node"]["connected_inputs"].append(inp_name)
+            elif "value" in inp_data:
+                value = inp_data["value"]
+                if is_dataclass(value) and not isinstance(value, type):
+                    hash_dict_tmp["inputs"][inp_name] = asdict(value)
+                else:
+                    hash_dict_tmp["inputs"][inp_name] = value
+            else:
+                missing_input = True
+                break
+        if missing_input:
+            continue
+        h = sha256(json.dumps(hash_dict_tmp, sort_keys=True).encode("utf-8")).hexdigest()
+        for out in G.successors(node):
+            G.nodes[out]["hash"] = h + "@" + G.nodes[out].get("label", out.split("-")[-1])
+        hash_dict_tmp["hash"] = h
+        hash_dict[node] = hash_dict_tmp
+    return hash_dict
+
+
+def serialize_and_convert_to_networkx(
+    workflow: dict | fr.schemas.DagData | fr.schemas.WorkflowRecipe,
+    hash_data: bool = True,
+    prefix: str | None = None,
+) -> SemantikonDiGraph:
+    """
+    Serialize a flowrep workflow into a SemantikonDiGraph, optionally
+    hashing node data.
+
+    Args:
+        workflow (dict | DagData | WorkflowRecipe): Workflow representation.
+        hash_data (bool): Whether to hash node data.
+        prefix (str | None): Optional prefix for node names.
+
+    Returns:
+        SemantikonDiGraph: The serialized workflow graph.
+    """
+    if isinstance(workflow, dict):
+        workflow = dict_to_nodedata(workflow)
+    if isinstance(workflow, fr.schemas.WorkflowRecipe):
+        workflow = fr.schemas.DagData.from_recipe(workflow)
+    if not isinstance(workflow, fr.schemas.DagData):
+        raise TypeError(
+            f"Invalid workflow type. Expected dict, flowrep {fr.schemas.DagData.__name__!r}, or "
+            f"flowrep {fr.schemas.WorkflowRecipe.__name__!r}, but got {type(workflow)}."
+        )
+
+    G = _workflow_to_networkx(workflow, prefix=prefix)
+    if hash_data:
+        try:
+            hashed_dict = _get_hashed_node_dict_from_graph(G)
+        except Exception as e:
+            raise RuntimeError(
+                "Failed to hash workflow data - use only hashable inputs or set hash_data=False"
+            ) from e
+        for node, data in hashed_dict.items():
+            G.append_hash(node, data["hash"])
+    return G
+
+
+class _HashGraph:
+    def _normalize(self, obj: Any) -> Any:
+        """
+        Convert objects into a deterministic, JSON-safe representation.
+        """
+        if is_dataclass(obj) and not isinstance(obj, type):
+            return {k: self._normalize(v) for k, v in asdict(obj).items()}
+        elif isinstance(obj, dict):
+            return {k: self._normalize(v) for k, v in obj.items()}
+        elif isinstance(obj, IdentifiedNode):
+            if isinstance(obj, BNode):
+                raise TypeError("Blank nodes cannot be normalized for hashing.")
+            return {"__type__": "URIRef", "value": self._normalize(str(obj))}
+        elif isinstance(obj, (list, tuple)):
+            return [self._normalize(v) for v in obj]
+        elif isinstance(obj, str):
+            return unicodedata.normalize("NFC", obj)
+        elif isinstance(obj, (int, float, bool)) or obj is None:
+            return obj
+        else:
+            raise TypeError(f"Unsupported type for normalization: {type(obj)} of value {obj}")
+
+    def _canonical_json(self, data: dict) -> str:
+        """
+        Deterministic JSON serialization.
+        """
+        return json.dumps(
+            self._normalize(data),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+
+    def _get_graph_hash(
+        self, G: SemantikonDiGraph, with_global_inputs: bool = True
+    ) -> str:
+        """
+        Generate a deterministic hash for a graph, independent of OS,
+        Python version, and non-serializable runtime values.
+        """
+        G_tmp = nx.DiGraph()
+
+        for node in G.nodes:
+            attrs = {
+                key: value
+                for key, value in G.nodes[node].items()
+                if key not in {"dtype", "hash", "function", "default", "value"}
+            }
+            if G.in_degree(node) == 0 and with_global_inputs:
+                if "value" in G.nodes[node]:
+                    attrs["value"] = G.nodes[node]["value"]
+                elif "default" in G.nodes[node]:
+                    attrs["value"] = G.nodes[node]["default"]
+            G_tmp.add_node(node, canon=self._canonical_json(attrs))
+        for u, v in G.edges:
+            G_tmp.add_edge(u, v)
+
+        return nx.algorithms.graph_hashing.weisfeiler_lehman_graph_hash(
+            G_tmp,
+            node_attr="canon",
+        )
+
+
+def _get_graph_hash(G: SemantikonDiGraph, with_global_inputs: bool = True) -> str:
+    """
+    Generate a hash for a NetworkX graph, making sure that data types and
+    values (except for the global ones) because they can often not be
+    serialized.
+
+    Args:
+        G (SemantikonDiGraph): input graph
+        with_global_inputs (bool): if True, keep values for global inputs
+
+    Returns:
+        (str): hash of the graph
+    """
+    hasher = _HashGraph()
+    return hasher._get_graph_hash(G, with_global_inputs)

--- a/semantikon/flowrep_to_networkx.py
+++ b/semantikon/flowrep_to_networkx.py
@@ -45,7 +45,9 @@ class SemantikonDiGraph(nx.DiGraph):
     @cache
     def _get_data_node(self, io: str) -> str:
         while True:
-            candidate = [c for c in self.predecessors(io) if self.nodes[c]["step"] != "node"]
+            candidate = [
+                c for c in self.predecessors(io) if self.nodes[c]["step"] != "node"
+            ]
             assert len(candidate) <= 1
             if len(candidate) == 0:
                 return f"{io}_data"
@@ -91,7 +93,9 @@ class SemantikonDiGraph(nx.DiGraph):
 
                 child_label = current_label
                 if child_label is None:
-                    child_label = self.nodes[child].get("label", self.nodes[child]["arg"])
+                    child_label = self.nodes[child].get(
+                        "label", self.nodes[child]["arg"]
+                    )
 
                 self.nodes[child]["hash"] = current_hash + f"@{child_label}"
                 stack.append((child, current_hash, child_label))
@@ -164,7 +168,11 @@ def _node_data_to_metadata(
             metadata.update(function._semantikon_metadata)
         function_data = get_function_dict(function)
         function_data["identifier"] = ".".join(
-            (function_data["module"], function_data["qualname"], function_data["version"])
+            (
+                function_data["module"],
+                function_data["qualname"],
+                function_data["version"],
+            )
         )
         metadata["function"] = function_data
     return metadata
@@ -221,7 +229,9 @@ def _workflow_to_networkx(
                 child,
                 child_name,
                 parent_name=node_name,
-                workflow_label=(child_label if isinstance(child, fr.schemas.DagData) else None),
+                workflow_label=(
+                    child_label if isinstance(child, fr.schemas.DagData) else None
+                ),
             )
 
         child_recipes = recipe.nodes
@@ -273,7 +283,10 @@ def _get_hashed_node_dict_from_graph(G: SemantikonDiGraph) -> dict[str, dict[str
 
         hash_dict_tmp: dict[str, Any] = {
             "inputs": {},
-            "outputs": [G.nodes[out].get("label", out.split("-")[-1]) for out in G.successors(node)],
+            "outputs": [
+                G.nodes[out].get("label", out.split("-")[-1])
+                for out in G.successors(node)
+            ],
             "node": copy.deepcopy(data.get("function")),
         }
         if hash_dict_tmp["node"] is None:
@@ -297,9 +310,13 @@ def _get_hashed_node_dict_from_graph(G: SemantikonDiGraph) -> dict[str, dict[str
                 break
         if missing_input:
             continue
-        h = sha256(json.dumps(hash_dict_tmp, sort_keys=True).encode("utf-8")).hexdigest()
+        h = sha256(
+            json.dumps(hash_dict_tmp, sort_keys=True).encode("utf-8")
+        ).hexdigest()
         for out in G.successors(node):
-            G.nodes[out]["hash"] = h + "@" + G.nodes[out].get("label", out.split("-")[-1])
+            G.nodes[out]["hash"] = (
+                h + "@" + G.nodes[out].get("label", out.split("-")[-1])
+            )
         hash_dict_tmp["hash"] = h
         hash_dict[node] = hash_dict_tmp
     return hash_dict
@@ -365,7 +382,9 @@ class _HashGraph:
         elif isinstance(obj, (int, float, bool)) or obj is None:
             return obj
         else:
-            raise TypeError(f"Unsupported type for normalization: {type(obj)} of value {obj}")
+            raise TypeError(
+                f"Unsupported type for normalization: {type(obj)} of value {obj}"
+            )
 
     def _canonical_json(self, data: dict) -> str:
         """

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import copy
-import json
 import warnings
 from dataclasses import dataclass, fields, is_dataclass
 from hashlib import sha256

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -2,19 +2,15 @@ from __future__ import annotations
 
 import copy
 import json
-import unicodedata
 import warnings
-from dataclasses import asdict, dataclass, fields, is_dataclass
-from functools import cache, cached_property
+from dataclasses import dataclass, fields, is_dataclass
 from hashlib import sha256
 from pathlib import Path
 from typing import Any, Callable, TypeAlias, cast
 
 import bagofholding
 import flowrep as fr
-import networkx as nx
 from owlrl import DeductiveClosure, RDFS_Semantics
-from pyiron_snippets import retrieve
 from pyshacl import validate
 from rdflib import OWL, RDF, RDFS, BNode, Graph, Literal, Namespace, URIRef
 from rdflib.namespace import SH
@@ -26,10 +22,11 @@ from semantikon.converter import (
     parse_input_args,
     parse_output_args,
 )
-from semantikon.flowrep_dict import (
-    annotation_to_type_hint,
-    annotation_to_type_metadata,
-    dict_to_nodedata,
+from semantikon.flowrep_dict import dict_to_nodedata
+from semantikon.flowrep_to_networkx import (
+    SemantikonDiGraph,
+    _get_graph_hash,
+    serialize_and_convert_to_networkx,
 )
 from semantikon.metadata import SemantikonURI
 from semantikon.qudt import UnitsDict
@@ -99,103 +96,6 @@ def _units_to_uri(units: str | URIRef) -> URIRef:
     if key is not None:
         return key
     return URIRef(units)
-
-
-class SemantikonDiGraph(nx.DiGraph):
-    @cached_property
-    def t_ns(self):
-        h = (
-            "W" + _get_graph_hash(self, with_global_inputs=False)[:8]
-            if self.graph["prefix"] is None
-            else self.graph["prefix"]
-        )
-        return Namespace(BASE + h + "_")
-
-    @cached_property
-    def a_ns(self):
-        h = _get_graph_hash(self, with_global_inputs=True)
-        return Namespace(BASE + h + "_")
-
-    def get_a_node(self, node_name: str) -> IdentifiedNode:
-        return self.a_ns[node_name]
-
-    @cache
-    def _get_data_node(self, io: str) -> str:
-        while True:
-            candidate = [
-                c for c in self.predecessors(io) if self.nodes[c]["step"] != "node"
-            ]
-            assert len(candidate) <= 1
-            if len(candidate) == 0:
-                return f"{io}_data"
-            io = candidate[0]
-
-    def append_hash(
-        self,
-        node: str,
-        hash_value: str,
-        label: str | None = None,
-    ):
-        """
-        Propagates a hash value through the descendants of a given node in a
-        directed graph.
-
-        This function iteratively traverses the descendants of the graph and
-        appends a hash value to each descendant node. The hash value is
-        updated based on the label of each node. Optionally, it can remove
-        specific data (e.g., "value") from the nodes.
-
-        Parameters:
-            node (str): The starting node from which the hash propagation begins.
-            hash_value (str): The initial hash value to propagate through the
-                descendants.
-            label (str | None, optional): A label to use for hash computation.
-                If not provided, the label is derived from the node's data
-                (e.g., "label" or "arg"). Defaults to None.
-
-        Notes:
-            - The function uses an iterative approach to avoid recursion,
-                making it suitable for graphs with deep hierarchies.
-            - The hash value for each node is updated in the format:
-                `parent_hash@child_label`.
-
-        """
-        # Use a stack to keep track of nodes to process
-        stack = [(node, hash_value, label)]
-
-        while stack:
-            current_node, current_hash, current_label = stack.pop()
-
-            for child in self.successors(current_node):
-                if self.nodes[child]["step"] == "node":
-                    continue
-
-                # Determine the label for this specific child
-                child_label = current_label
-                if child_label is None:
-                    child_label = self.nodes[child].get(
-                        "label", self.nodes[child]["arg"]
-                    )
-
-                # Update the hash for the child node
-                self.nodes[child]["hash"] = current_hash + f"@{child_label}"
-
-                # Add the child to the stack for further processing
-                stack.append((child, current_hash, child_label))
-
-    def get_hash_dict(self) -> dict[str, str]:
-        """
-        Get a dictionary mapping node names to their hash values.
-
-        Returns:
-            dict[str, str]: A dictionary where keys are node names and values
-                are their corresponding hash values.
-        """
-        hash_dict = {}
-        for _, data in self.nodes.data():
-            if "hash" in data and "value" in data:
-                hash_dict[data["hash"]] = data["value"]
-        return hash_dict
 
 
 def _inherit_properties(graph: Graph, n_max: int = 1000):
@@ -1364,253 +1264,6 @@ def _get_successor_nodes(G, node_name):
                 yield node
 
 
-def _infer_workflow_label(recipe: fr.schemas.WorkflowRecipe) -> str:
-    if recipe.reference is None:
-        return ""
-    return recipe.reference.info.fully_qualified_name.rsplit(".", 1)[-1]
-
-
-def _output_port_label(port: str, outputs: list[str]) -> str:
-    if port == "output_0" and len(outputs) == 1 and outputs[0] == "output_0":
-        return "output"
-    return port
-
-
-def _port_to_dict(
-    *,
-    value: Any,
-    annotation: Any,
-    default: Any = fr.schemas.NOT_DATA,
-) -> dict[str, Any]:
-    data: dict[str, Any] = {}
-    if not isinstance(value, fr.schemas.NotData):
-        data["value"] = value
-    if type_hint := annotation_to_type_hint(annotation):
-        data["dtype"] = type_hint
-    if type_metadata := annotation_to_type_metadata(annotation):
-        data.update(type_metadata.to_dictionary())
-    if not isinstance(default, fr.schemas.NotData):
-        data["default"] = default
-    return data
-
-
-def _node_data_to_metadata(
-    data: fr.schemas.NodeData,
-    *,
-    label: str | None = None,
-) -> dict[str, Any]:
-    metadata: dict[str, Any] = {}
-    function = None
-    if isinstance(data, fr.schemas.AtomicData):
-        metadata["type"] = "atomic"
-        function = data.function
-    elif isinstance(data, fr.schemas.DagData):
-        metadata["type"] = "workflow"
-        if label is not None:
-            metadata["label"] = label
-        if data.recipe.reference is not None:
-            function = retrieve.import_from_string(
-                data.recipe.reference.info.fully_qualified_name
-            )
-    if function is not None:
-        if hasattr(function, "_semantikon_metadata"):
-            metadata.update(function._semantikon_metadata)
-        function_data = get_function_dict(function)
-        function_data["identifier"] = ".".join(
-            (
-                function_data["module"],
-                function_data["qualname"],
-                function_data["version"],
-            )
-        )
-        metadata["function"] = function_data
-    return metadata
-
-
-def _workflow_to_networkx(
-    workflow: fr.schemas.DagData,
-    *,
-    prefix: str | None = None,
-) -> SemantikonDiGraph:
-    root_label = _infer_workflow_label(workflow.recipe)
-    G = SemantikonDiGraph(prefix=prefix)
-    G.name = root_label
-
-    def _add_node(
-        node_data: fr.schemas.NodeData,
-        node_name: str,
-        *,
-        parent_name: str | None = None,
-        workflow_label: str | None = None,
-    ):
-        node_attrs = _node_data_to_metadata(node_data, label=workflow_label)
-        if parent_name is not None:
-            node_attrs["parent"] = parent_name
-        G.add_node(node_name, step="node", **node_attrs)
-
-        output_labels = list(node_data.output_ports)
-        if len(output_labels) == 1 and output_labels[0] == "output_0":
-            output_labels = ["output"]
-
-        for position, (label, port) in enumerate(node_data.input_ports.items()):
-            io_name = f"{node_name}-inputs-{label}"
-            io_data = _port_to_dict(
-                value=port.value,
-                annotation=port.annotation,
-                default=port.default,
-            )
-            G.add_node(io_name, step="inputs", arg=label, position=position, **io_data)
-            G.add_edge(io_name, node_name)
-        for position, (raw_label, port) in enumerate(node_data.output_ports.items()):
-            label = output_labels[position] if raw_label == "output_0" else raw_label
-            io_name = f"{node_name}-outputs-{label}"
-            io_data = _port_to_dict(value=port.value, annotation=port.annotation)
-            G.add_node(io_name, step="outputs", arg=label, position=position, **io_data)
-            G.add_edge(node_name, io_name)
-
-        if not isinstance(node_data, fr.schemas.DagData):
-            return
-
-        recipe = node_data.recipe
-        for child_label, child in node_data.nodes.items():
-            child_name = f"{node_name}-{child_label}"
-            _add_node(
-                child,
-                child_name,
-                parent_name=node_name,
-                workflow_label=(
-                    child_label if isinstance(child, fr.schemas.DagData) else None
-                ),
-            )
-
-        child_recipes = recipe.nodes
-        for target, source in recipe.input_edges.items():
-            G.add_edge(
-                f"{node_name}-inputs-{source.port}",
-                f"{node_name}-{target.node}-inputs-{target.port}",
-            )
-        for target, source in recipe.edges.items():
-            child_outputs = list(child_recipes[source.node].outputs)
-            src_port = _output_port_label(source.port, child_outputs)
-            G.add_edge(
-                f"{node_name}-{source.node}-outputs-{src_port}",
-                f"{node_name}-{target.node}-inputs-{target.port}",
-            )
-        for target, source in recipe.output_edges.items():
-            target_port = _output_port_label(target.port, list(recipe.outputs))
-            if isinstance(source, fr.schemas.InputSource):
-                G.add_edge(
-                    f"{node_name}-inputs-{source.port}",
-                    f"{node_name}-outputs-{target_port}",
-                )
-            else:
-                child_outputs = list(child_recipes[source.node].outputs)
-                src_port = _output_port_label(source.port, child_outputs)
-                G.add_edge(
-                    f"{node_name}-{source.node}-outputs-{src_port}",
-                    f"{node_name}-outputs-{target_port}",
-                )
-
-    _add_node(workflow, root_label, workflow_label=root_label)
-    return G
-
-
-def _get_hashed_node_dict_from_graph(G: SemantikonDiGraph) -> dict[str, dict[str, Any]]:
-    hash_dict: dict[str, dict[str, Any]] = {}
-    for node in nx.topological_sort(G):
-        data = G.nodes[node]
-        if data.get("step") != "node":
-            for term in ("hash", "value"):
-                if term in data:
-                    continue
-                for predecessor in G.predecessors(node):
-                    predecessor_data = G.nodes[predecessor]
-                    if term in predecessor_data:
-                        data[term] = predecessor_data[term]
-                        break
-            continue
-
-        hash_dict_tmp: dict[str, Any] = {
-            "inputs": {},
-            "outputs": [
-                G.nodes[out].get("label", out.split("-")[-1])
-                for out in G.successors(node)
-            ],
-            "node": copy.deepcopy(data.get("function")),
-        }
-        if hash_dict_tmp["node"] is None:
-            continue
-        hash_dict_tmp["node"]["connected_inputs"] = []
-        missing_input = False
-        for inp in G.predecessors(node):
-            inp_data = G.nodes[inp]
-            inp_name = inp.split("-")[-1]
-            if "hash" in inp_data:
-                hash_dict_tmp["inputs"][inp_name] = inp_data["hash"]
-                hash_dict_tmp["node"]["connected_inputs"].append(inp_name)
-            elif "value" in inp_data:
-                value = inp_data["value"]
-                if is_dataclass(value) and not isinstance(value, type):
-                    hash_dict_tmp["inputs"][inp_name] = asdict(value)
-                else:
-                    hash_dict_tmp["inputs"][inp_name] = value
-            else:
-                missing_input = True
-                break
-        if missing_input:
-            continue
-        h = sha256(
-            json.dumps(hash_dict_tmp, sort_keys=True).encode("utf-8")
-        ).hexdigest()
-        for out in G.successors(node):
-            G.nodes[out]["hash"] = (
-                h + "@" + G.nodes[out].get("label", out.split("-")[-1])
-            )
-        hash_dict_tmp["hash"] = h
-        hash_dict[node] = hash_dict_tmp
-    return hash_dict
-
-
-def serialize_and_convert_to_networkx(
-    workflow: dict | fr.schemas.DagData | fr.schemas.WorkflowRecipe,
-    hash_data: bool = True,
-    prefix: str | None = None,
-) -> SemantikonDiGraph:
-    """
-    Serialize a flowrep workflow into a SemantikonDiGraph, optionally
-    hashing node data.
-
-    Args:
-        workflow (dict | DagData | WorkflowRecipe): Workflow representation.
-        hash_data (bool): Whether to hash node data.
-        prefix (str | None): Optional prefix for node names.
-
-    Returns:
-        SemantikonDiGraph: The serialized workflow graph.
-    """
-    if isinstance(workflow, dict):
-        workflow = dict_to_nodedata(workflow)
-    if isinstance(workflow, fr.schemas.WorkflowRecipe):
-        workflow = fr.schemas.DagData.from_recipe(workflow)
-    if not isinstance(workflow, fr.schemas.DagData):
-        raise TypeError(
-            f"Invalid workflow type. Expected dict, flowrep {fr.schemas.DagData.__name__!r}, or "
-            f"flowrep {fr.schemas.WorkflowRecipe.__name__!r}, but got {type(workflow)}."
-        )
-
-    G = _workflow_to_networkx(workflow, prefix=prefix)
-    if hash_data:
-        try:
-            hashed_dict = _get_hashed_node_dict_from_graph(G)
-        except Exception as e:
-            raise RuntimeError(
-                "Failed to hash workflow data - use only hashable inputs or set hash_data=False"
-            ) from e
-        for node, data in hashed_dict.items():
-            G.append_hash(node, data["hash"])
-    return G
-
-
 def _to_owl_restriction(
     base_node: URIRef | None,
     on_property: URIRef,
@@ -1634,88 +1287,6 @@ def _to_owl_restriction(
         g.add((base_node, RDFS.subClassOf, restriction_node))
 
     return g
-
-
-class _HashGraph:
-    def _normalize(self, obj: Any) -> Any:
-        """
-        Convert objects into a deterministic, JSON-safe representation.
-        """
-        if is_dataclass(obj) and not isinstance(obj, type):
-            return {k: self._normalize(v) for k, v in asdict(obj).items()}
-        elif isinstance(obj, dict):
-            return {k: self._normalize(v) for k, v in obj.items()}
-        elif isinstance(obj, IdentifiedNode):
-            if isinstance(obj, BNode):
-                raise TypeError("Blank nodes cannot be normalized for hashing.")
-            return {"__type__": "URIRef", "value": self._normalize(str(obj))}
-        elif isinstance(obj, (list, tuple)):
-            return [self._normalize(v) for v in obj]
-        elif isinstance(obj, str):
-            return unicodedata.normalize("NFC", obj)
-        elif isinstance(obj, (int, float, bool)) or obj is None:
-            return obj
-        else:
-            raise TypeError(
-                f"Unsupported type for normalization: {type(obj)} of value {obj}"
-            )
-
-    def _canonical_json(self, data: dict) -> str:
-        """
-        Deterministic JSON serialization.
-        """
-        return json.dumps(
-            self._normalize(data),
-            sort_keys=True,
-            separators=(",", ":"),
-            ensure_ascii=False,
-        )
-
-    def _get_graph_hash(
-        self, G: SemantikonDiGraph, with_global_inputs: bool = True
-    ) -> str:
-        """
-        Generate a deterministic hash for a graph, independent of OS,
-        Python version, and non-serializable runtime values.
-        """
-        G_tmp = nx.DiGraph()
-
-        for node in G.nodes:
-            attrs = {
-                key: value
-                for key, value in G.nodes[node].items()
-                if key not in {"dtype", "hash", "function", "default", "value"}
-            }
-            if G.in_degree(node) == 0 and with_global_inputs:
-                if "value" in G.nodes[node]:
-                    attrs["value"] = G.nodes[node]["value"]
-                elif "default" in G.nodes[node]:
-                    attrs["value"] = G.nodes[node]["default"]
-            G_tmp.add_node(node, canon=self._canonical_json(attrs))
-        for u, v in G.edges:
-            G_tmp.add_edge(u, v)
-
-        return nx.algorithms.graph_hashing.weisfeiler_lehman_graph_hash(
-            G_tmp,
-            node_attr="canon",
-        )
-
-
-def _get_graph_hash(G: SemantikonDiGraph, with_global_inputs: bool = True) -> str:
-    """
-    Generate a hash for a NetworkX graph, making sure that data types and
-    values (except for the global ones) because they can often not be
-    serialized.
-
-    Args:
-        G (SemantikonDiGraph): input graph
-        with_global_inputs (bool): if True, keep values for global inputs
-
-    Returns:
-        (str): hash of the graph
-    """
-    hasher = _HashGraph()
-    return hasher._get_graph_hash(G, with_global_inputs)
 
 
 def _get_undefined_connections(g, term):

--- a/tests/unit/test_flowrep_to_networkx.py
+++ b/tests/unit/test_flowrep_to_networkx.py
@@ -1,0 +1,129 @@
+import unittest
+
+import flowrep as fr
+from rdflib import BNode
+
+from semantikon import flowrep_to_networkx as ftn
+from tests.unit.test_ontology import (
+    NewSpeedData,
+    my_kinetic_energy_workflow,
+    passthrough_input_workflow,
+    workflow_with_default_values,
+)
+
+
+class TestFlowrepToNetworkx(unittest.TestCase):
+    def test_hash(self):
+        wf_dict = my_kinetic_energy_workflow.get_semantikon_dict()
+        G = ftn.serialize_and_convert_to_networkx(wf_dict, hash_data=False)
+        self.assertIsInstance(ftn._get_graph_hash(G), str)
+        self.assertEqual(len(ftn._get_graph_hash(G)), 32)
+        self.assertIn(
+            "dtype",
+            G.nodes["my_kinetic_energy_workflow-get_speed_0-inputs-distance"],
+            msg="dtype should not be deleted after hashing",
+        )
+        self.assertEqual(
+            G._get_data_node("my_kinetic_energy_workflow-get_kinetic_energy_0-inputs-velocity"),
+            G._get_data_node("my_kinetic_energy_workflow-get_speed_0-outputs-speed"),
+        )
+        self.assertNotEqual(
+            G._get_data_node("my_kinetic_energy_workflow-get_kinetic_energy_0-inputs-velocity"),
+            G._get_data_node(
+                "my_kinetic_energy_workflow-get_kinetic_energy_0-outputs-kinetic_energy"
+            ),
+        )
+        wf_dict_one = my_kinetic_energy_workflow.run(distance=1.0, time=2.0, mass=3.0)
+        wf_dict_two = my_kinetic_energy_workflow.run(distance=4.0, time=5.0, mass=6.0)
+        G_one = ftn.serialize_and_convert_to_networkx(wf_dict_one, hash_data=True)
+        G_two = ftn.serialize_and_convert_to_networkx(wf_dict_two, hash_data=True)
+        self.assertEqual(
+            ftn._get_graph_hash(G_one, with_global_inputs=False),
+            ftn._get_graph_hash(G_two, with_global_inputs=False),
+        )
+
+        wf_dict = workflow_with_default_values.get_semantikon_dict()
+        wf_dict_run = workflow_with_default_values.run(distance=2, time=1, mass=4)
+        G = ftn.serialize_and_convert_to_networkx(wf_dict, hash_data=False)
+        G_run = ftn.serialize_and_convert_to_networkx(wf_dict_run, hash_data=False)
+        self.assertEqual(ftn._get_graph_hash(G), ftn._get_graph_hash(G_run))
+        G_hash = ftn.serialize_and_convert_to_networkx(wf_dict_run, hash_data=True)
+        self.assertDictEqual(
+            {key.split("@")[1]: value for key, value in G_hash.get_hash_dict().items()},
+            {"kinetic_energy": 8.0, "speed": 2.0},
+        )
+        with self.assertRaises(TypeError):
+            wf_dict["inputs"]["distance"]["default"] = NewSpeedData
+            G = ftn.serialize_and_convert_to_networkx(wf_dict, hash_data=True)
+            ftn._get_graph_hash(G, with_global_inputs=True)
+        with self.assertRaises(TypeError):
+            wf_dict["inputs"]["distance"]["default"] = BNode()
+            G = ftn.serialize_and_convert_to_networkx(wf_dict, hash_data=True)
+            ftn._get_graph_hash(G, with_global_inputs=True)
+
+    def test_hash_with_value(self):
+        wf_dict = my_kinetic_energy_workflow.get_semantikon_dict()
+        G = ftn.serialize_and_convert_to_networkx(wf_dict, hash_data=False)
+        wf_dict = my_kinetic_energy_workflow.run(distance=1, time=2, mass=3)
+        G_run = ftn.serialize_and_convert_to_networkx(wf_dict, hash_data=False)
+        self.assertEqual(
+            ftn._get_graph_hash(G, with_global_inputs=False),
+            ftn._get_graph_hash(G_run, with_global_inputs=False),
+        )
+        self.assertNotEqual(
+            ftn._get_graph_hash(G_run, with_global_inputs=False),
+            ftn._get_graph_hash(G_run, with_global_inputs=True),
+        )
+
+    def test_infer_workflow_label_without_reference(self):
+        recipe = fr.schemas.WorkflowRecipe(
+            inputs=["x"],
+            outputs=["y"],
+            nodes={},
+            input_edges={},
+            edges={},
+            output_edges={
+                fr.schemas.OutputTarget(port="y"): fr.schemas.InputSource(port="x")
+            },
+        )
+        self.assertEqual(ftn._infer_workflow_label(recipe), "")
+
+    def test_serialize_workflow_recipe_with_input_passthrough(self):
+        self.assertTrue(
+            any(
+                isinstance(source, fr.schemas.InputSource)
+                for source in passthrough_input_workflow.flowrep_recipe.output_edges.values()
+            )
+        )
+        G = ftn.serialize_and_convert_to_networkx(
+            passthrough_input_workflow.flowrep_recipe,
+            hash_data=False,
+        )
+        self.assertIn(
+            (
+                "passthrough_input_workflow-inputs-x",
+                "passthrough_input_workflow-outputs-x",
+            ),
+            G.edges,
+        )
+
+    def test_hashing_skips_nodes_without_function_metadata(self):
+        recipe = fr.schemas.WorkflowRecipe(
+            inputs=["x"],
+            outputs=["y"],
+            nodes={},
+            input_edges={},
+            edges={},
+            output_edges={
+                fr.schemas.OutputTarget(port="y"): fr.schemas.InputSource(port="x")
+            },
+        )
+        data = fr.schemas.DagData.from_recipe(recipe)
+        data.input_ports["x"].value = 1.0
+        G = ftn._workflow_to_networkx(data)
+        hashed = ftn._get_hashed_node_dict_from_graph(G)
+        self.assertEqual(hashed, {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_flowrep_to_networkx.py
+++ b/tests/unit/test_flowrep_to_networkx.py
@@ -24,11 +24,15 @@ class TestFlowrepToNetworkx(unittest.TestCase):
             msg="dtype should not be deleted after hashing",
         )
         self.assertEqual(
-            G._get_data_node("my_kinetic_energy_workflow-get_kinetic_energy_0-inputs-velocity"),
+            G._get_data_node(
+                "my_kinetic_energy_workflow-get_kinetic_energy_0-inputs-velocity"
+            ),
             G._get_data_node("my_kinetic_energy_workflow-get_speed_0-outputs-speed"),
         )
         self.assertNotEqual(
-            G._get_data_node("my_kinetic_energy_workflow-get_kinetic_energy_0-inputs-velocity"),
+            G._get_data_node(
+                "my_kinetic_energy_workflow-get_kinetic_energy_0-inputs-velocity"
+            ),
             G._get_data_node(
                 "my_kinetic_energy_workflow-get_kinetic_energy_0-outputs-kinetic_energy"
             ),

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -12,7 +12,7 @@ from pyshacl import validate
 from rdflib import OWL, RDF, RDFS, SH, BNode, Graph, Literal, Namespace, compare
 from rdflib.compare import graph_diff
 
-from semantikon import flowrep_to_networkx as ftn
+
 from semantikon import kg_to_flowrep as kgf
 from semantikon import ontology as onto
 from semantikon.metadata import SemantikonURI, meta
@@ -635,72 +635,6 @@ class TestOntology(unittest.TestCase):
                 len(in_first), 0, msg=f"Unexpected triples: {in_first.serialize()}"
             )
 
-    def test_hash(self):
-        wf_dict = my_kinetic_energy_workflow.get_semantikon_dict()
-        G = ftn.serialize_and_convert_to_networkx(wf_dict, hash_data=False)
-        self.assertIsInstance(ftn._get_graph_hash(G), str)
-        self.assertEqual(len(ftn._get_graph_hash(G)), 32)
-        self.assertIn(
-            "dtype",
-            G.nodes["my_kinetic_energy_workflow-get_speed_0-inputs-distance"],
-            msg="dtype should not be deleted after hashing",
-        )
-        self.assertEqual(
-            G._get_data_node(
-                "my_kinetic_energy_workflow-get_kinetic_energy_0-inputs-velocity"
-            ),
-            G._get_data_node("my_kinetic_energy_workflow-get_speed_0-outputs-speed"),
-        )
-        self.assertNotEqual(
-            G._get_data_node(
-                "my_kinetic_energy_workflow-get_kinetic_energy_0-inputs-velocity"
-            ),
-            G._get_data_node(
-                "my_kinetic_energy_workflow-get_kinetic_energy_0-outputs-kinetic_energy"
-            ),
-        )
-        wf_dict_one = my_kinetic_energy_workflow.run(distance=1.0, time=2.0, mass=3.0)
-        wf_dict_two = my_kinetic_energy_workflow.run(distance=4.0, time=5.0, mass=6.0)
-        G_one = ftn.serialize_and_convert_to_networkx(wf_dict_one, hash_data=True)
-        G_two = ftn.serialize_and_convert_to_networkx(wf_dict_two, hash_data=True)
-        self.assertEqual(
-            ftn._get_graph_hash(G_one, with_global_inputs=False),
-            ftn._get_graph_hash(G_two, with_global_inputs=False),
-        )
-
-        wf_dict = workflow_with_default_values.get_semantikon_dict()
-        wf_dict_run = workflow_with_default_values.run(distance=2, time=1, mass=4)
-        G = ftn.serialize_and_convert_to_networkx(wf_dict, hash_data=False)
-        G_run = ftn.serialize_and_convert_to_networkx(wf_dict_run, hash_data=False)
-        self.assertEqual(ftn._get_graph_hash(G), ftn._get_graph_hash(G_run))
-        G_hash = ftn.serialize_and_convert_to_networkx(wf_dict_run, hash_data=True)
-        self.assertDictEqual(
-            {key.split("@")[1]: value for key, value in G_hash.get_hash_dict().items()},
-            {"kinetic_energy": 8.0, "speed": 2.0},
-        )
-        with self.assertRaises(TypeError):
-            wf_dict["inputs"]["distance"]["default"] = NewSpeedData
-            G = ftn.serialize_and_convert_to_networkx(wf_dict, hash_data=True)
-            ftn._get_graph_hash(G, with_global_inputs=True)
-        with self.assertRaises(TypeError):
-            wf_dict["inputs"]["distance"]["default"] = BNode()
-            G = ftn.serialize_and_convert_to_networkx(wf_dict, hash_data=True)
-            ftn._get_graph_hash(G, with_global_inputs=True)
-
-    def test_hash_with_value(self):
-        wf_dict = my_kinetic_energy_workflow.get_semantikon_dict()
-        G = ftn.serialize_and_convert_to_networkx(wf_dict, hash_data=False)
-        wf_dict = my_kinetic_energy_workflow.run(distance=1, time=2, mass=3)
-        G_run = ftn.serialize_and_convert_to_networkx(wf_dict, hash_data=False)
-        self.assertEqual(
-            ftn._get_graph_hash(G, with_global_inputs=False),
-            ftn._get_graph_hash(G_run, with_global_inputs=False),
-        )
-        self.assertNotEqual(
-            ftn._get_graph_hash(G_run, with_global_inputs=False),
-            ftn._get_graph_hash(G_run, with_global_inputs=True),
-        )
-
     def test_shacl_validation(self):
         g = onto.get_knowledge_graph(my_kinetic_energy_workflow.flowrep_recipe)
         shacl = onto.owl_restrictions_to_shacl(g)
@@ -1217,56 +1151,6 @@ class TestOntology(unittest.TestCase):
             onto.get_knowledge_graph,
             workflow_with_wrong_derived_from_in_output.flowrep_recipe,
         )
-
-    def test_infer_workflow_label_without_reference(self):
-        recipe = fr.schemas.WorkflowRecipe(
-            inputs=["x"],
-            outputs=["y"],
-            nodes={},
-            input_edges={},
-            edges={},
-            output_edges={
-                fr.schemas.OutputTarget(port="y"): fr.schemas.InputSource(port="x")
-            },
-        )
-        self.assertEqual(ftn._infer_workflow_label(recipe), "")
-
-    def test_serialize_workflow_recipe_with_input_passthrough(self):
-        self.assertTrue(
-            any(
-                isinstance(source, fr.schemas.InputSource)
-                for source in passthrough_input_workflow.flowrep_recipe.output_edges.values()
-            )
-        )
-        G = ftn.serialize_and_convert_to_networkx(
-            passthrough_input_workflow.flowrep_recipe,
-            hash_data=False,
-        )
-        self.assertIn(
-            (
-                "passthrough_input_workflow-inputs-x",
-                "passthrough_input_workflow-outputs-x",
-            ),
-            G.edges,
-        )
-
-    def test_hashing_skips_nodes_without_function_metadata(self):
-        recipe = fr.schemas.WorkflowRecipe(
-            inputs=["x"],
-            outputs=["y"],
-            nodes={},
-            input_edges={},
-            edges={},
-            output_edges={
-                fr.schemas.OutputTarget(port="y"): fr.schemas.InputSource(port="x")
-            },
-        )
-        data = fr.schemas.DagData.from_recipe(recipe)
-        data.input_ports["x"].value = 1.0
-        G = ftn._workflow_to_networkx(data)
-        hashed = ftn._get_hashed_node_dict_from_graph(G)
-        self.assertEqual(hashed, {})
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -12,8 +12,8 @@ from pyshacl import validate
 from rdflib import OWL, RDF, RDFS, SH, BNode, Graph, Literal, Namespace, compare
 from rdflib.compare import graph_diff
 
-from semantikon import kg_to_flowrep as kgf
 from semantikon import flowrep_to_networkx as ftn
+from semantikon import kg_to_flowrep as kgf
 from semantikon import ontology as onto
 from semantikon.metadata import SemantikonURI, meta
 from semantikon.visualize import visualize_recipe

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -9,9 +9,8 @@ from typing import Annotated
 
 import flowrep as fr
 from pyshacl import validate
-from rdflib import OWL, RDF, RDFS, SH, BNode, Graph, Literal, Namespace, compare
+from rdflib import OWL, RDF, RDFS, SH, Graph, Literal, Namespace, compare
 from rdflib.compare import graph_diff
-
 
 from semantikon import kg_to_flowrep as kgf
 from semantikon import ontology as onto

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -1152,5 +1152,6 @@ class TestOntology(unittest.TestCase):
             workflow_with_wrong_derived_from_in_output.flowrep_recipe,
         )
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -13,6 +13,7 @@ from rdflib import OWL, RDF, RDFS, SH, BNode, Graph, Literal, Namespace, compare
 from rdflib.compare import graph_diff
 
 from semantikon import kg_to_flowrep as kgf
+from semantikon import flowrep_to_networkx as ftn
 from semantikon import ontology as onto
 from semantikon.metadata import SemantikonURI, meta
 from semantikon.visualize import visualize_recipe
@@ -636,9 +637,9 @@ class TestOntology(unittest.TestCase):
 
     def test_hash(self):
         wf_dict = my_kinetic_energy_workflow.get_semantikon_dict()
-        G = onto.serialize_and_convert_to_networkx(wf_dict, hash_data=False)
-        self.assertIsInstance(onto._get_graph_hash(G), str)
-        self.assertEqual(len(onto._get_graph_hash(G)), 32)
+        G = ftn.serialize_and_convert_to_networkx(wf_dict, hash_data=False)
+        self.assertIsInstance(ftn._get_graph_hash(G), str)
+        self.assertEqual(len(ftn._get_graph_hash(G)), 32)
         self.assertIn(
             "dtype",
             G.nodes["my_kinetic_energy_workflow-get_speed_0-inputs-distance"],
@@ -660,44 +661,44 @@ class TestOntology(unittest.TestCase):
         )
         wf_dict_one = my_kinetic_energy_workflow.run(distance=1.0, time=2.0, mass=3.0)
         wf_dict_two = my_kinetic_energy_workflow.run(distance=4.0, time=5.0, mass=6.0)
-        G_one = onto.serialize_and_convert_to_networkx(wf_dict_one, hash_data=True)
-        G_two = onto.serialize_and_convert_to_networkx(wf_dict_two, hash_data=True)
+        G_one = ftn.serialize_and_convert_to_networkx(wf_dict_one, hash_data=True)
+        G_two = ftn.serialize_and_convert_to_networkx(wf_dict_two, hash_data=True)
         self.assertEqual(
-            onto._get_graph_hash(G_one, with_global_inputs=False),
-            onto._get_graph_hash(G_two, with_global_inputs=False),
+            ftn._get_graph_hash(G_one, with_global_inputs=False),
+            ftn._get_graph_hash(G_two, with_global_inputs=False),
         )
 
         wf_dict = workflow_with_default_values.get_semantikon_dict()
         wf_dict_run = workflow_with_default_values.run(distance=2, time=1, mass=4)
-        G = onto.serialize_and_convert_to_networkx(wf_dict, hash_data=False)
-        G_run = onto.serialize_and_convert_to_networkx(wf_dict_run, hash_data=False)
-        self.assertEqual(onto._get_graph_hash(G), onto._get_graph_hash(G_run))
-        G_hash = onto.serialize_and_convert_to_networkx(wf_dict_run, hash_data=True)
+        G = ftn.serialize_and_convert_to_networkx(wf_dict, hash_data=False)
+        G_run = ftn.serialize_and_convert_to_networkx(wf_dict_run, hash_data=False)
+        self.assertEqual(ftn._get_graph_hash(G), ftn._get_graph_hash(G_run))
+        G_hash = ftn.serialize_and_convert_to_networkx(wf_dict_run, hash_data=True)
         self.assertDictEqual(
             {key.split("@")[1]: value for key, value in G_hash.get_hash_dict().items()},
             {"kinetic_energy": 8.0, "speed": 2.0},
         )
         with self.assertRaises(TypeError):
             wf_dict["inputs"]["distance"]["default"] = NewSpeedData
-            G = onto.serialize_and_convert_to_networkx(wf_dict, hash_data=True)
-            onto._get_graph_hash(G, with_global_inputs=True)
+            G = ftn.serialize_and_convert_to_networkx(wf_dict, hash_data=True)
+            ftn._get_graph_hash(G, with_global_inputs=True)
         with self.assertRaises(TypeError):
             wf_dict["inputs"]["distance"]["default"] = BNode()
-            G = onto.serialize_and_convert_to_networkx(wf_dict, hash_data=True)
-            onto._get_graph_hash(G, with_global_inputs=True)
+            G = ftn.serialize_and_convert_to_networkx(wf_dict, hash_data=True)
+            ftn._get_graph_hash(G, with_global_inputs=True)
 
     def test_hash_with_value(self):
         wf_dict = my_kinetic_energy_workflow.get_semantikon_dict()
-        G = onto.serialize_and_convert_to_networkx(wf_dict, hash_data=False)
+        G = ftn.serialize_and_convert_to_networkx(wf_dict, hash_data=False)
         wf_dict = my_kinetic_energy_workflow.run(distance=1, time=2, mass=3)
-        G_run = onto.serialize_and_convert_to_networkx(wf_dict, hash_data=False)
+        G_run = ftn.serialize_and_convert_to_networkx(wf_dict, hash_data=False)
         self.assertEqual(
-            onto._get_graph_hash(G, with_global_inputs=False),
-            onto._get_graph_hash(G_run, with_global_inputs=False),
+            ftn._get_graph_hash(G, with_global_inputs=False),
+            ftn._get_graph_hash(G_run, with_global_inputs=False),
         )
         self.assertNotEqual(
-            onto._get_graph_hash(G_run, with_global_inputs=False),
-            onto._get_graph_hash(G_run, with_global_inputs=True),
+            ftn._get_graph_hash(G_run, with_global_inputs=False),
+            ftn._get_graph_hash(G_run, with_global_inputs=True),
         )
 
     def test_shacl_validation(self):
@@ -1228,7 +1229,7 @@ class TestOntology(unittest.TestCase):
                 fr.schemas.OutputTarget(port="y"): fr.schemas.InputSource(port="x")
             },
         )
-        self.assertEqual(onto._infer_workflow_label(recipe), "")
+        self.assertEqual(ftn._infer_workflow_label(recipe), "")
 
     def test_serialize_workflow_recipe_with_input_passthrough(self):
         self.assertTrue(
@@ -1237,7 +1238,7 @@ class TestOntology(unittest.TestCase):
                 for source in passthrough_input_workflow.flowrep_recipe.output_edges.values()
             )
         )
-        G = onto.serialize_and_convert_to_networkx(
+        G = ftn.serialize_and_convert_to_networkx(
             passthrough_input_workflow.flowrep_recipe,
             hash_data=False,
         )
@@ -1262,8 +1263,8 @@ class TestOntology(unittest.TestCase):
         )
         data = fr.schemas.DagData.from_recipe(recipe)
         data.input_ports["x"].value = 1.0
-        G = onto._workflow_to_networkx(data)
-        hashed = onto._get_hashed_node_dict_from_graph(G)
+        G = ftn._workflow_to_networkx(data)
+        hashed = ftn._get_hashed_node_dict_from_graph(G)
         self.assertEqual(hashed, {})
 
 


### PR DESCRIPTION
Currently, `ontology.py` does the conversion from flowrep to `SemantikonDiGraph` and then a conversion from `SemantikonDiGraph` to KG. I separated out the first part into a different file.