### PR TITLE
feat: get rid of BASE from SemantikonDiGraph

### DIFF
--- a/semantikon/flowrep_to_networkx.py
+++ b/semantikon/flowrep_to_networkx.py
@@ -11,7 +11,7 @@ from typing import Any
 import flowrep as fr
 import networkx as nx
 from pyiron_snippets import retrieve
-from rdflib import BNode, Namespace, URIRef
+from rdflib import BNode
 from rdflib.term import IdentifiedNode
 
 from semantikon.converter import get_function_dict
@@ -21,26 +21,30 @@ from semantikon.flowrep_dict import (
     dict_to_nodedata,
 )
 
-BASE: Namespace = Namespace("http://pyiron.org/ontology/")
-
 
 class SemantikonDiGraph(nx.DiGraph):
+    """Workflow graph with deterministic namespace fragments.
+
+    The graph only stores suffix fragments (e.g. ``abc123_``) for type- and
+    assertion-level identifiers. Ontology-specific base namespaces are applied
+    later by the ontology serialization layer.
+    """
+
     @cached_property
-    def t_ns(self) -> Namespace:
+    def t_ns(self) -> str:
+        """Type-level namespace fragment for this graph."""
         h = (
             "W" + _get_graph_hash(self, with_global_inputs=False)[:8]
             if self.graph["prefix"] is None
             else self.graph["prefix"]
         )
-        return Namespace(BASE + h + "_")
+        return h + "_"
 
     @cached_property
-    def a_ns(self) -> Namespace:
+    def a_ns(self) -> str:
+        """Assertion-level namespace fragment for this graph."""
         h = _get_graph_hash(self, with_global_inputs=True)
-        return Namespace(BASE + h + "_")
-
-    def get_a_node(self, node_name: str) -> URIRef:
-        return self.a_ns[node_name]
+        return h + "_"
 
     @cache
     def _get_data_node(self, io: str) -> str:
@@ -334,7 +338,8 @@ def serialize_and_convert_to_networkx(
     Args:
         workflow (dict | DagData | WorkflowRecipe): Workflow representation.
         hash_data (bool): Whether to hash node data.
-        prefix (str | None): Optional prefix for node names.
+        prefix (str | None): Optional fixed prefix for type-level namespace
+            fragments.
 
     Returns:
         SemantikonDiGraph: The serialized workflow graph.

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -546,15 +546,15 @@ def _wf_node_to_graph(
                 uri=data.get("uri"),
             )
     if t_box:
-        node = G.t_ns[node_name]
+        node = BASE[G.t_ns + node_name]
         for io in [G.predecessors(node_name), G.successors(node_name)]:
             for item in io:
                 g += _to_owl_restriction(
                     node,
                     SNS.has_part,
-                    G.t_ns[item],
+                    BASE[G.t_ns + item],
                 )
-        g.add((G.t_ns[node_name], RDFS.subClassOf, SNS.workflow_node))
+        g.add((BASE[G.t_ns + node_name], RDFS.subClassOf, SNS.workflow_node))
         if "function" in data:
             g += _to_owl_restriction(
                 node,
@@ -566,21 +566,21 @@ def _wf_node_to_graph(
         g.add((node, SNS.local_identifier, Literal(node_name.split("-")[-1])))
         if "parent" in data:
             g += _to_owl_restriction(
-                G.t_ns[data["parent"]],
+                BASE[G.t_ns + data["parent"]],
                 SNS.has_part,
                 node,
             )
     else:
-        node = G.get_a_node(node_name)
-        g.add((node, RDF.type, G.t_ns[node_name]))
+        node = BASE[G.a_ns + node_name]
+        g.add((node, RDF.type, BASE[G.t_ns + node_name]))
         for inp in G.predecessors(node_name):
-            g.add((node, SNS.has_part, G.get_a_node(inp)))
+            g.add((node, SNS.has_part, BASE[G.a_ns + inp]))
         for out in G.successors(node_name):
-            g.add((node, SNS.has_part, G.get_a_node(out)))
+            g.add((node, SNS.has_part, BASE[G.a_ns + out]))
         if "function" in data:
             g.add((node, SNS.concretizes, f_node))
         if "parent" in data:
-            g.add((G.get_a_node(data["parent"]), SNS.has_part, node))
+            g.add((BASE[G.a_ns + data["parent"]], SNS.has_part, node))
     return g
 
 
@@ -669,7 +669,7 @@ def _translate_triples(
         else:
             assert isinstance(t, str)
             io = _detect_io_from_str(G=G, seeked_io=t, ref_io=node_name)
-            return G.t_ns[io] if t_box else G.get_a_node(io)
+            return BASE[G.t_ns + io] if t_box else BASE[G.a_ns + io]
 
     g = _get_bound_graph()
     for triple in triples:
@@ -765,7 +765,7 @@ def _wf_input_to_graph(
             " supported for inputs."
         )
     if t_box:
-        data_node = G.t_ns[G._get_data_node(io=node_name)]
+        data_node = BASE[G.t_ns + G._get_data_node(io=node_name)]
         if _input_is_connected(node_name, G):
             out = list(G.predecessors(node_name))
             assert len(out) <= 1
@@ -773,7 +773,7 @@ def _wf_input_to_graph(
                 assert G.nodes[out[0]]["step"] in ["outputs", "inputs"]
                 if G.nodes[out[0]]["step"] == "outputs":
                     g += _to_owl_restriction(
-                        G.t_ns[out[0]], SNS.has_participant, data_node
+                        BASE[G.t_ns + out[0]], SNS.has_participant, data_node
                     )
         if units is not None:
             g += _to_owl_restriction(
@@ -792,7 +792,7 @@ def _wf_input_to_graph(
         if "restrictions" in data:
             g += _restrictions_to_triples(data["restrictions"], data_node=data_node)
     else:
-        data_node = G.get_a_node(G._get_data_node(io=node_name))
+        data_node = BASE[G.a_ns + G._get_data_node(io=node_name)]
         if not _input_is_connected(node_name, G):
             if units is not None:
                 g.add((data_node, QUDT.hasUnit, _units_to_uri(units)))
@@ -820,7 +820,7 @@ def _wf_output_to_graph(
 ) -> Graph:
     g = _get_bound_graph()
     if t_box:
-        data_node = G.t_ns[G._get_data_node(io=node_name)]
+        data_node = BASE[G.t_ns + G._get_data_node(io=node_name)]
         if not _output_is_connected(node_name, G):
             if "uri" in data:
                 g += _to_owl_restriction(
@@ -838,7 +838,7 @@ def _wf_output_to_graph(
                     restriction_type=OWL.hasValue,
                 )
     else:
-        data_node = G.get_a_node(G._get_data_node(io=node_name))
+        data_node = BASE[G.a_ns + G._get_data_node(io=node_name)]
         units = data.get("units", data.get("unit"))
         if units is not None:
             g.add((data_node, QUDT.hasUnit, _units_to_uri(units)))
@@ -867,7 +867,7 @@ def _wf_io_to_graph(
     has_specified_io: URIRef,
     t_box: bool,
 ) -> Graph:
-    node = G.t_ns[node_name] if t_box else G.get_a_node(node_name)
+    node = BASE[G.t_ns + node_name] if t_box else BASE[G.a_ns + node_name]
     g = _get_bound_graph()
     g.add((node, RDFS.label, Literal(node_name)))
     g.add((node, SNS.local_identifier, Literal(node_name.split("-")[-1])))
@@ -878,12 +878,12 @@ def _wf_io_to_graph(
         if "hash" in data:
             g += _to_owl_restriction(data_node, SNS.denoted_by, SNS.identifier)
     else:
-        g.add((data_node, RDF.type, G.t_ns[G._get_data_node(io=node_name)]))
+        g.add((data_node, RDF.type, BASE[G.t_ns + G._get_data_node(io=node_name)]))
         g.add((node, has_specified_io, data_node))
         if "value" in data and g.value(data_node, SNS.has_value) is None:
             g.add((data_node, SNS.has_value, Literal(data["value"])))
         if "hash" in data:
-            hash_bnode = G.get_a_node(G._get_data_node(io=node_name) + "_hash")
+            hash_bnode = BASE[G.a_ns + G._get_data_node(io=node_name) + "_hash"]
             g.add((data_node, SNS.denoted_by, hash_bnode))
             g.add((hash_bnode, RDF.type, SNS.identifier))
             g.add((hash_bnode, SNS.has_value, Literal(data["hash"])))
@@ -914,17 +914,17 @@ def _parse_precedes(
             if t_box:
                 for succ in successors:
                     g += _to_owl_restriction(
-                        G.t_ns[node[0]],
+                        BASE[G.t_ns + node[0]],
                         SNS.precedes,
-                        G.t_ns[succ],
+                        BASE[G.t_ns + succ],
                     )
             else:
                 for succ in successors:
                     g.add(
                         (
-                            G.get_a_node(node[0]),
+                            BASE[G.a_ns + node[0]],
                             SNS.precedes,
-                            G.get_a_node(succ),
+                            BASE[G.a_ns + succ],
                         )
                     )
     return g
@@ -950,10 +950,10 @@ def _parse_global_io(
                 g += _to_owl_restriction(
                     workflow_node,
                     SNS.has_part,
-                    G.t_ns[io[0]],
+                    BASE[G.t_ns + io[0]],
                 )
             else:
-                g.add((workflow_node, SNS.has_part, G.get_a_node(io[0])))
+                g.add((workflow_node, SNS.has_part, BASE[G.a_ns + io[0]]))
     return g
 
 
@@ -963,9 +963,9 @@ def _nx_to_kg(G: SemantikonDiGraph, t_box: bool) -> Graph:
         data = data.copy()
         step = data.pop("step")
         if t_box:
-            g.add((G.t_ns[node_name], RDF.type, OWL.Class))
+            g.add((BASE[G.t_ns + node_name], RDF.type, OWL.Class))
         else:
-            g.add((G.get_a_node(node_name), RDF.type, G.t_ns[node_name]))
+            g.add((BASE[G.a_ns + node_name], RDF.type, BASE[G.t_ns + node_name]))
         assert step in ["node", "inputs", "outputs"], f"Unknown step: {step}"
         if step == "node":
             g += _wf_node_to_graph(

--- a/tests/unit/test_flowrep_to_networkx.py
+++ b/tests/unit/test_flowrep_to_networkx.py
@@ -13,6 +13,24 @@ from tests.unit.test_ontology import (
 
 
 class TestFlowrepToNetworkx(unittest.TestCase):
+    def test_namespace_fragments_are_base_agnostic(self):
+        wf_dict = my_kinetic_energy_workflow.get_semantikon_dict()
+        G = ftn.serialize_and_convert_to_networkx(wf_dict, hash_data=False)
+
+        self.assertIsInstance(G.t_ns, str)
+        self.assertIsInstance(G.a_ns, str)
+        self.assertTrue(G.t_ns.endswith("_"))
+        self.assertTrue(G.a_ns.endswith("_"))
+        self.assertNotIn("http://", G.t_ns)
+        self.assertNotIn("http://", G.a_ns)
+
+        G_prefixed = ftn.serialize_and_convert_to_networkx(
+            wf_dict,
+            hash_data=False,
+            prefix="custom",
+        )
+        self.assertEqual(G_prefixed.t_ns, "custom_")
+
     def test_hash(self):
         wf_dict = my_kinetic_energy_workflow.get_semantikon_dict()
         G = ftn.serialize_and_convert_to_networkx(wf_dict, hash_data=False)


### PR DESCRIPTION
This pull request refactors how namespace fragments are managed and used in the workflow graph and ontology serialization. The main change is that the `SemantikonDiGraph` now stores only the suffix fragments (like `abc123_`) for type- and assertion-level identifiers, and the ontology serialization layer is responsible for applying the ontology-specific base namespace. This makes the code more flexible and decouples the graph structure from any particular base URI. Several usages throughout the ontology serialization code have been updated to reflect this change, and new tests have been added to ensure the fragments are base-agnostic.

**Namespace management refactor:**

* The `SemantikonDiGraph` class now has `t_ns` and `a_ns` as string fragments instead of `Namespace` objects, and no longer includes the base URI directly. [[1]](diffhunk://#diff-b2730e56fa40d37a1634cdc51fd196a76f42893f8a104a8a731b6a2d96196aabL14-R14) [[2]](diffhunk://#diff-b2730e56fa40d37a1634cdc51fd196a76f42893f8a104a8a731b6a2d96196aabL24-R47)
* All usages of `G.t_ns[...]` and `G.get_a_node(...)` in `semantikon/ontology.py` are replaced with explicit concatenation of the base URI (`BASE[...]`) and the namespace fragment, ensuring the base is only applied at serialization. [[1]](diffhunk://#diff-05c9c64509257364104a98638356d5f3dda8d593c626be11754319ce3a9e2d4eL549-R557) [[2]](diffhunk://#diff-05c9c64509257364104a98638356d5f3dda8d593c626be11754319ce3a9e2d4eL569-R583) [[3]](diffhunk://#diff-05c9c64509257364104a98638356d5f3dda8d593c626be11754319ce3a9e2d4eL672-R672) [[4]](diffhunk://#diff-05c9c64509257364104a98638356d5f3dda8d593c626be11754319ce3a9e2d4eL768-R776) [[5]](diffhunk://#diff-05c9c64509257364104a98638356d5f3dda8d593c626be11754319ce3a9e2d4eL795-R795) [[6]](diffhunk://#diff-05c9c64509257364104a98638356d5f3dda8d593c626be11754319ce3a9e2d4eL823-R823) [[7]](diffhunk://#diff-05c9c64509257364104a98638356d5f3dda8d593c626be11754319ce3a9e2d4eL841-R841) [[8]](diffhunk://#diff-05c9c64509257364104a98638356d5f3dda8d593c626be11754319ce3a9e2d4eL870-R870) [[9]](diffhunk://#diff-05c9c64509257364104a98638356d5f3dda8d593c626be11754319ce3a9e2d4eL881-R886) [[10]](diffhunk://#diff-05c9c64509257364104a98638356d5f3dda8d593c626be11754319ce3a9e2d4eL917-R927) [[11]](diffhunk://#diff-05c9c64509257364104a98638356d5f3dda8d593c626be11754319ce3a9e2d4eL953-R956) [[12]](diffhunk://#diff-05c9c64509257364104a98638356d5f3dda8d593c626be11754319ce3a9e2d4eL966-R968)

**Testing improvements:**

* Added a new unit test to verify that the namespace fragments in `SemantikonDiGraph` are base-agnostic, are strings, and do not contain the base URI, and that a custom prefix is handled correctly.

**Documentation and API clarity:**

* Updated docstrings and argument descriptions to clarify the meaning of the `prefix` parameter and namespace fragment behavior.

These changes make the codebase more modular and better suited for reuse in different ontology contexts.