### PR TITLE
fix: rename get_knowledge_graph to serialize_and_convert_to_networkx

### DIFF
--- a/semantikon/cwl.py
+++ b/semantikon/cwl.py
@@ -12,7 +12,7 @@ except ModuleNotFoundError as exc:  # pragma: no cover
 from semantikon import ontology
 
 
-def get_knowledge_graph(uri: str | Path) -> ontology.SemantikonDiGraph:
+def serialize_and_convert_to_networkx(uri: str | Path) -> ontology.SemantikonDiGraph:
     """
     Parse a CWL document and build a knowledge graph.
 

--- a/tests/unit/test_cwl.py
+++ b/tests/unit/test_cwl.py
@@ -20,19 +20,19 @@ class TestCWL(unittest.TestCase):
         cls.static_dir = Path(__file__).parent.parent / "static"
 
     def test_returns_semantikon_digraph(self):
-        g = cwl.get_knowledge_graph(
+        g = cwl.serialize_and_convert_to_networkx(
             self.static_dir / "cwl" / "kinetic_energy_workflow.cwl"
         )
         self.assertIsInstance(g, SemantikonDiGraph)
 
     def test_graph_prefix(self):
-        g = cwl.get_knowledge_graph(
+        g = cwl.serialize_and_convert_to_networkx(
             self.static_dir / "cwl" / "kinetic_energy_workflow.cwl"
         )
         self.assertEqual(g.graph["prefix"], "kinetic_energy_workflow")
 
     def test_workflow_input_nodes(self):
-        g = cwl.get_knowledge_graph(
+        g = cwl.serialize_and_convert_to_networkx(
             self.static_dir / "cwl" / "kinetic_energy_workflow.cwl"
         )
         expected_inputs = {
@@ -43,20 +43,20 @@ class TestCWL(unittest.TestCase):
         self.assertTrue(expected_inputs.issubset(set(g.nodes)))
 
     def test_workflow_output_nodes(self):
-        g = cwl.get_knowledge_graph(
+        g = cwl.serialize_and_convert_to_networkx(
             self.static_dir / "cwl" / "kinetic_energy_workflow.cwl"
         )
         self.assertIn("kinetic_energy_workflow-outputs-kinetic_energy", g.nodes)
 
     def test_step_nodes(self):
-        g = cwl.get_knowledge_graph(
+        g = cwl.serialize_and_convert_to_networkx(
             self.static_dir / "cwl" / "kinetic_energy_workflow.cwl"
         )
         self.assertIn("kinetic_energy_workflow-get_speed", g.nodes)
         self.assertIn("kinetic_energy_workflow-get_kinetic_energy", g.nodes)
 
     def test_node_step_attributes(self):
-        g = cwl.get_knowledge_graph(
+        g = cwl.serialize_and_convert_to_networkx(
             self.static_dir / "cwl" / "kinetic_energy_workflow.cwl"
         )
         self.assertEqual(
@@ -68,7 +68,7 @@ class TestCWL(unittest.TestCase):
         self.assertEqual(g.nodes["kinetic_energy_workflow-get_speed"]["step"], "node")
 
     def test_input_binding_position(self):
-        g = cwl.get_knowledge_graph(
+        g = cwl.serialize_and_convert_to_networkx(
             self.static_dir / "cwl" / "kinetic_energy_workflow.cwl"
         )
         self.assertEqual(
@@ -79,7 +79,7 @@ class TestCWL(unittest.TestCase):
         )
 
     def test_data_flow_edges(self):
-        g = cwl.get_knowledge_graph(
+        g = cwl.serialize_and_convert_to_networkx(
             self.static_dir / "cwl" / "kinetic_energy_workflow.cwl"
         )
         # distance flows from workflow input -> get_speed input -> get_speed step


### PR DESCRIPTION
`get_knowledge_graph` is used in ontology.py to get the knowledge graph, while the one in cwl was returning a `SemantikonDiGraph`, which would correspond to `serialize_and_convert_to_networkx` in ontology.py