### PR TITLE
feat: Include function in the workflow hashing algorithm

### DIFF
--- a/semantikon/flowrep_to_networkx.py
+++ b/semantikon/flowrep_to_networkx.py
@@ -414,10 +414,9 @@ class _HashGraph:
         for node in G.nodes:
             attrs = {}
             if "function" in G.nodes[node]:
-                if "hash" in G.nodes[node]["function"]:
-                    attrs["hash"] = G.nodes[node]["function"]["hash"]
-                elif "identifier" in G.nodes[node]["function"]:
-                    attrs["hash"] = G.nodes[node]["function"]["identifier"]
+                attrs["hash"] = G.nodes[node]["function"].get(
+                    "hash", G.nodes[node]["function"].get("identifier")
+                )
             if G.in_degree(node) == 0 and with_global_inputs:
                 if "value" in G.nodes[node]:
                     attrs["value"] = G.nodes[node]["value"]

--- a/semantikon/flowrep_to_networkx.py
+++ b/semantikon/flowrep_to_networkx.py
@@ -412,11 +412,12 @@ class _HashGraph:
         G_tmp = nx.DiGraph()
 
         for node in G.nodes:
-            attrs = {
-                key: value
-                for key, value in G.nodes[node].items()
-                if key not in {"dtype", "hash", "default", "value"}
-            }
+            attrs = {}
+            if "function" in G.nodes[node]:
+                if "hash" in G.nodes[node]["function"]:
+                    attrs["hash"] = G.nodes[node]["function"]["hash"]
+                elif "identifier" in G.nodes[node]["function"]:
+                    attrs["hash"] = G.nodes[node]["function"]["identifier"]
             if G.in_degree(node) == 0 and with_global_inputs:
                 if "value" in G.nodes[node]:
                     attrs["value"] = G.nodes[node]["value"]

--- a/semantikon/flowrep_to_networkx.py
+++ b/semantikon/flowrep_to_networkx.py
@@ -415,7 +415,7 @@ class _HashGraph:
             attrs = {
                 key: value
                 for key, value in G.nodes[node].items()
-                if key not in {"dtype", "hash", "function", "default", "value"}
+                if key not in {"dtype", "hash", "default", "value"}
             }
             if G.in_degree(node) == 0 and with_global_inputs:
                 if "value" in G.nodes[node]:

--- a/semantikon/flowrep_to_networkx.py
+++ b/semantikon/flowrep_to_networkx.py
@@ -412,11 +412,14 @@ class _HashGraph:
         G_tmp = nx.DiGraph()
 
         for node in G.nodes:
-            attrs = {}
+            attrs = {
+                key: value
+                for key, value in G.nodes[node].items()
+                if key not in {"dtype", "hash", "function", "default", "value"}
+            }
             if "function" in G.nodes[node]:
-                attrs["hash"] = G.nodes[node]["function"].get(
-                    "hash", G.nodes[node]["function"].get("identifier")
-                )
+                func = G.nodes[node]["function"]
+                attrs["function"] = func.get("hash") or func.get("identifier")
             if G.in_degree(node) == 0 and with_global_inputs:
                 if "value" in G.nodes[node]:
                     attrs["value"] = G.nodes[node]["value"]

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -544,7 +544,7 @@ class TestOntology(unittest.TestCase):
         PREFIX obi: <http://purl.obolibrary.org/obo/OBI_>
 
         ASK {{
-            ?output a sns:Wd1d86cce_my_kinetic_energy_workflow-outputs-kinetic_energy .
+            ?output a sns:Wfd606a7b_my_kinetic_energy_workflow-outputs-kinetic_energy .
             ?output ro:0000057 ?data .
             ?data qudt:hasUnit unit:J .
         }}"""

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -544,7 +544,7 @@ class TestOntology(unittest.TestCase):
         PREFIX obi: <http://purl.obolibrary.org/obo/OBI_>
 
         ASK {{
-            ?output a sns:W40d1a80f_my_kinetic_energy_workflow-outputs-kinetic_energy .
+            ?output a sns:Wd1d86cce_my_kinetic_energy_workflow-outputs-kinetic_energy .
             ?output ro:0000057 ?data .
             ?data qudt:hasUnit unit:J .
         }}"""

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -544,7 +544,7 @@ class TestOntology(unittest.TestCase):
         PREFIX obi: <http://purl.obolibrary.org/obo/OBI_>
 
         ASK {{
-            ?output a sns:Wc59275b7_my_kinetic_energy_workflow-outputs-kinetic_energy .
+            ?output a sns:W40d1a80f_my_kinetic_energy_workflow-outputs-kinetic_energy .
             ?output ro:0000057 ?data .
             ?data qudt:hasUnit unit:J .
         }}"""


### PR DESCRIPTION
I realized that the underlying python function is currently not included in the hashing algorithm for the workflows. Now I included the hash of the function or the function identifier. To be honest since it's semantikon-dependent I might not like it so much...