### PR TITLE
feat: Include validation logic inside SemantikonDiGraph

### DIFF
--- a/semantikon/cwl.py
+++ b/semantikon/cwl.py
@@ -74,13 +74,21 @@ def _add_node(
     if G is None:
         G = ontology.SemantikonDiGraph(prefix=prefix)
 
-    for inp in wf.inputs:
-        metadata: dict[str, str | int] = {"step": "inputs"}
-        if inp.inputBinding is not None:
+    for position, inp in enumerate(wf.inputs):
+        metadata: dict[str, str | int] = {
+            "step": "inputs",
+            "arg": _get_name(inp.id),
+            "position": position,
+        }
+        if inp.inputBinding is not None and inp.inputBinding.position is not None:
             metadata["position"] = inp.inputBinding.position
         G.add_node(f"{prefix}-inputs-{_get_name(inp.id)}", **metadata)
-    for out in wf.outputs:
-        metadata = {"step": "outputs"}
+    for position, out in enumerate(wf.outputs):
+        metadata = {
+            "step": "outputs",
+            "arg": _get_name(out.id),
+            "position": position,
+        }
         G.add_node(f"{prefix}-outputs-{_get_name(out.id)}", **metadata)
 
     if isinstance(wf, parser.CommandLineTool):
@@ -88,7 +96,9 @@ def _add_node(
 
     for step in wf.steps:
         node_name = f"{prefix}-{_get_name(step.id)}"
-        G.add_node(node_name, step="node")
+        run_doc = parser.load_document_by_uri(step.run)
+        node_type = "workflow" if isinstance(run_doc, parser.Workflow) else "atomic"
+        G.add_node(node_name, step="node", type=node_type)
         for inp in step.in_:
             source = _get_name(inp.source)
             source = (
@@ -104,7 +114,7 @@ def _add_node(
             if "/" in out_name:
                 out_name = out_name.split("/")[-1]
             G.add_edge(node_name, f"{node_name}-outputs-{out_name}")
-        G = _add_node(parser.load_document_by_uri(step.run), G, prefix=node_name)
+        G = _add_node(run_doc, G, prefix=node_name)
     for out in wf.outputs:
         G.add_edge(
             f"{prefix}-{_get_name(out.outputSource.replace('/', '-outputs-'))}",

--- a/semantikon/flowrep_to_networkx.py
+++ b/semantikon/flowrep_to_networkx.py
@@ -3,14 +3,13 @@ from __future__ import annotations
 import copy
 import json
 import unicodedata
-from dataclasses import asdict, is_dataclass
+from dataclasses import asdict, dataclass, field, is_dataclass
 from functools import cache, cached_property
 from hashlib import sha256
 from typing import Any
 
 import flowrep as fr
 import networkx as nx
-import pydantic
 from pyiron_snippets import retrieve
 from rdflib import BNode
 from rdflib.term import IdentifiedNode
@@ -23,21 +22,76 @@ from semantikon.flowrep_dict import (
 )
 
 
-class TNode(pydantic.BaseModel):
-    model_config = pydantic.ConfigDict(frozen=True)
-
+@dataclass(frozen=True, slots=True)
+class TNode:
     type: str
     step: str = "node"
     identifier: str | None = None
     label: str | None = None
     function: dict | None = None
     parent: str | None = None
+    extras: dict[str, Any] = field(default_factory=dict)
 
-    @pydantic.field_validator("type")
-    def validate_type(cls, v: str) -> str:
-        if v not in {"atomic", "workflow"}:
+    def __post_init__(self):
+        if self.type not in {"atomic", "workflow"}:
             raise ValueError("type must be either 'atomic' or 'workflow'")
-        return v
+
+    def to_attrs(self) -> dict[str, Any]:
+        attrs = {
+            "type": self.type,
+            "step": self.step,
+        }
+        if self.identifier is not None:
+            attrs["identifier"] = self.identifier
+        if self.label is not None:
+            attrs["label"] = self.label
+        if self.function is not None:
+            attrs["function"] = self.function
+        if self.parent is not None:
+            attrs["parent"] = self.parent
+        attrs.update(self.extras)
+        return attrs
+
+
+@dataclass(frozen=True, slots=True)
+class TIO:
+    arg: str
+    position: int
+    dtype: Any | None = None
+    value: Any | None = None
+    has_value: bool = False
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_attrs(self) -> dict[str, Any]:
+        attrs = {
+            "step": self.step,
+            "arg": self.arg,
+            "position": self.position,
+        }
+        if self.dtype is not None:
+            attrs["dtype"] = self.dtype
+        if self.has_value:
+            attrs["value"] = self.value
+        attrs.update(self.metadata)
+        return attrs
+
+
+@dataclass(frozen=True, slots=True)
+class TInput(TIO):
+    step: str = field(default="inputs", init=False)
+    default: Any | None = None
+    has_default: bool = False
+
+    def to_attrs(self) -> dict[str, Any]:
+        attrs = super().to_attrs()
+        if self.has_default:
+            attrs["default"] = self.default
+        return attrs
+
+
+@dataclass(frozen=True, slots=True)
+class TOutput(TIO):
+    step: str = field(default="outputs", init=False)
 
 
 class SemantikonDiGraph(nx.DiGraph):
@@ -151,20 +205,30 @@ def _output_port_label(port: str, outputs: list[str]) -> str:
 
 def _port_to_dict(
     *,
+    step: str,
+    arg: str,
+    position: int,
     value: Any,
     annotation: Any,
     default: Any = fr.schemas.NOT_DATA,
-) -> dict[str, Any]:
-    data: dict[str, Any] = {}
+) -> TInput | TOutput:
+    data: dict[str, Any] = {"arg": arg, "position": position}
     if not isinstance(value, fr.schemas.NotData):
         data["value"] = value
+        data["has_value"] = True
     if type_hint := annotation_to_type_hint(annotation):
         data["dtype"] = type_hint
+    metadata = {}
     if type_metadata := annotation_to_type_metadata(annotation):
-        data.update(type_metadata.to_dictionary())
+        metadata = type_metadata.to_dictionary()
+    if metadata:
+        data["metadata"] = metadata
     if not isinstance(default, fr.schemas.NotData):
         data["default"] = default
-    return data
+        data["has_default"] = True
+    if step == "inputs":
+        return TInput(**data)
+    return TOutput(**data)
 
 
 def _node_data_to_metadata(
@@ -172,7 +236,7 @@ def _node_data_to_metadata(
     *,
     label: str | None = None,
     parent: str | None = None,
-) -> dict[str, Any]:
+) -> TNode:
     metadata: dict[str, Any] = {"step": "node"}
     function = None
     if isinstance(data, fr.schemas.AtomicData):
@@ -200,7 +264,16 @@ def _node_data_to_metadata(
         metadata["function"] = function_data
     if parent is not None:
         metadata["parent"] = parent
-    return TNode(**metadata).model_dump()
+    known = {"type", "step", "identifier", "label", "function", "parent"}
+    return TNode(
+        type=metadata["type"],
+        step=metadata.get("step", "node"),
+        identifier=metadata.get("identifier"),
+        label=metadata.get("label"),
+        function=metadata.get("function"),
+        parent=metadata.get("parent"),
+        extras={k: v for k, v in metadata.items() if k not in known},
+    )
 
 
 def _workflow_to_networkx(
@@ -222,7 +295,7 @@ def _workflow_to_networkx(
         node_attrs = _node_data_to_metadata(
             node_data, label=workflow_label, parent=parent_name
         )
-        G.add_node(node_name, **node_attrs)
+        G.add_node(node_name, **node_attrs.to_attrs())
 
         output_labels = list(node_data.output_ports)
         if len(output_labels) == 1 and output_labels[0] == "output_0":
@@ -231,17 +304,26 @@ def _workflow_to_networkx(
         for position, (label, port) in enumerate(node_data.input_ports.items()):
             io_name = f"{node_name}-inputs-{label}"
             io_data = _port_to_dict(
+                step="inputs",
+                arg=label,
+                position=position,
                 value=port.value,
                 annotation=port.annotation,
                 default=port.default,
             )
-            G.add_node(io_name, step="inputs", arg=label, position=position, **io_data)
+            G.add_node(io_name, **io_data.to_attrs())
             G.add_edge(io_name, node_name)
         for position, (raw_label, port) in enumerate(node_data.output_ports.items()):
             label = output_labels[position] if raw_label == "output_0" else raw_label
             io_name = f"{node_name}-outputs-{label}"
-            io_data = _port_to_dict(value=port.value, annotation=port.annotation)
-            G.add_node(io_name, step="outputs", arg=label, position=position, **io_data)
+            io_data = _port_to_dict(
+                step="outputs",
+                arg=label,
+                position=position,
+                value=port.value,
+                annotation=port.annotation,
+            )
+            G.add_node(io_name, **io_data.to_attrs())
             G.add_edge(node_name, io_name)
 
         if not isinstance(node_data, fr.schemas.DagData):

--- a/semantikon/flowrep_to_networkx.py
+++ b/semantikon/flowrep_to_networkx.py
@@ -23,7 +23,7 @@ from semantikon.flowrep_dict import (
 )
 
 
-class NodeData(pydantic.BaseModel):
+class TNode(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(frozen=True)
 
     type: str
@@ -200,7 +200,7 @@ def _node_data_to_metadata(
         metadata["function"] = function_data
     if parent is not None:
         metadata["parent"] = parent
-    return NodeData(**metadata).model_dump()
+    return TNode(**metadata).model_dump()
 
 
 def _workflow_to_networkx(

--- a/semantikon/flowrep_to_networkx.py
+++ b/semantikon/flowrep_to_networkx.py
@@ -102,6 +102,58 @@ class SemantikonDiGraph(nx.DiGraph):
     later by the ontology serialization layer.
     """
 
+    def _validate_semantikon_attrs(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        if "step" not in attrs:
+            return attrs
+
+        step = attrs["step"]
+        if step == "node":
+            known = {"type", "step", "identifier", "label", "function", "parent"}
+            node_meta = TNode(
+                type=attrs["type"],
+                step=step,
+                identifier=attrs.get("identifier"),
+                label=attrs.get("label"),
+                function=attrs.get("function"),
+                parent=attrs.get("parent"),
+                extras={k: v for k, v in attrs.items() if k not in known},
+            )
+            return node_meta.to_attrs()
+
+        if step == "inputs":
+            known = {"step", "arg", "position", "dtype", "value", "default"}
+            input_meta = TInput(
+                arg=attrs["arg"],
+                position=attrs["position"],
+                dtype=attrs.get("dtype"),
+                value=attrs.get("value"),
+                has_value="value" in attrs,
+                default=attrs.get("default"),
+                has_default="default" in attrs,
+                metadata={k: v for k, v in attrs.items() if k not in known},
+            )
+            return input_meta.to_attrs()
+
+        if step == "outputs":
+            known = {"step", "arg", "position", "dtype", "value"}
+            output_meta = TOutput(
+                arg=attrs["arg"],
+                position=attrs["position"],
+                dtype=attrs.get("dtype"),
+                value=attrs.get("value"),
+                has_value="value" in attrs,
+                metadata={k: v for k, v in attrs.items() if k not in known},
+            )
+            return output_meta.to_attrs()
+
+        raise ValueError(
+            f"Unknown step {step!r}. Expected one of 'node', 'inputs', or 'outputs'."
+        )
+
+    def add_node(self, node_for_adding, **attr):  # type: ignore[override]
+        normalized_attr = self._validate_semantikon_attrs(attr)
+        super().add_node(node_for_adding, **normalized_attr)
+
     @cached_property
     def t_ns(self) -> str:
         """Type-level namespace fragment for this graph."""
@@ -203,79 +255,6 @@ def _output_port_label(port: str, outputs: list[str]) -> str:
     return port
 
 
-def _port_to_dict(
-    *,
-    step: str,
-    arg: str,
-    position: int,
-    value: Any,
-    annotation: Any,
-    default: Any = fr.schemas.NOT_DATA,
-) -> TInput | TOutput:
-    data: dict[str, Any] = {"arg": arg, "position": position}
-    if not isinstance(value, fr.schemas.NotData):
-        data["value"] = value
-        data["has_value"] = True
-    if type_hint := annotation_to_type_hint(annotation):
-        data["dtype"] = type_hint
-    metadata = {}
-    if type_metadata := annotation_to_type_metadata(annotation):
-        metadata = type_metadata.to_dictionary()
-    if metadata:
-        data["metadata"] = metadata
-    if not isinstance(default, fr.schemas.NotData):
-        data["default"] = default
-        data["has_default"] = True
-    if step == "inputs":
-        return TInput(**data)
-    return TOutput(**data)
-
-
-def _node_data_to_metadata(
-    data: fr.schemas.NodeData,
-    *,
-    label: str | None = None,
-    parent: str | None = None,
-) -> TNode:
-    metadata: dict[str, Any] = {"step": "node"}
-    function = None
-    if isinstance(data, fr.schemas.AtomicData):
-        metadata["type"] = "atomic"
-        function = data.function
-    elif isinstance(data, fr.schemas.DagData):
-        metadata["type"] = "workflow"
-        if label is not None:
-            metadata["label"] = label
-        if data.recipe.reference is not None:
-            function = retrieve.import_from_string(
-                data.recipe.reference.info.fully_qualified_name
-            )
-    if function is not None:
-        if hasattr(function, "_semantikon_metadata"):
-            metadata.update(function._semantikon_metadata)
-        function_data = get_function_dict(function)
-        function_data["identifier"] = ".".join(
-            (
-                function_data["module"],
-                function_data["qualname"],
-                function_data["version"],
-            )
-        )
-        metadata["function"] = function_data
-    if parent is not None:
-        metadata["parent"] = parent
-    known = {"type", "step", "identifier", "label", "function", "parent"}
-    return TNode(
-        type=metadata["type"],
-        step=metadata.get("step", "node"),
-        identifier=metadata.get("identifier"),
-        label=metadata.get("label"),
-        function=metadata.get("function"),
-        parent=metadata.get("parent"),
-        extras={k: v for k, v in metadata.items() if k not in known},
-    )
-
-
 def _workflow_to_networkx(
     workflow: fr.schemas.DagData,
     *,
@@ -292,10 +271,35 @@ def _workflow_to_networkx(
         parent_name: str | None = None,
         workflow_label: str | None = None,
     ):
-        node_attrs = _node_data_to_metadata(
-            node_data, label=workflow_label, parent=parent_name
-        )
-        G.add_node(node_name, **node_attrs.to_attrs())
+        metadata: dict[str, Any] = {"step": "node"}
+        function = None
+        if isinstance(node_data, fr.schemas.AtomicData):
+            metadata["type"] = "atomic"
+            function = node_data.function
+        else:
+            metadata["type"] = "workflow"
+            if workflow_label is not None:
+                metadata["label"] = workflow_label
+            if node_data.recipe.reference is not None:
+                function = retrieve.import_from_string(
+                    node_data.recipe.reference.info.fully_qualified_name
+                )
+
+        if function is not None:
+            if hasattr(function, "_semantikon_metadata"):
+                metadata.update(function._semantikon_metadata)
+            function_data = get_function_dict(function)
+            function_data["identifier"] = ".".join(
+                (
+                    function_data["module"],
+                    function_data["qualname"],
+                    function_data["version"],
+                )
+            )
+            metadata["function"] = function_data
+        if parent_name is not None:
+            metadata["parent"] = parent_name
+        G.add_node(node_name, **metadata)
 
         output_labels = list(node_data.output_ports)
         if len(output_labels) == 1 and output_labels[0] == "output_0":
@@ -303,27 +307,36 @@ def _workflow_to_networkx(
 
         for position, (label, port) in enumerate(node_data.input_ports.items()):
             io_name = f"{node_name}-inputs-{label}"
-            io_data = _port_to_dict(
-                step="inputs",
-                arg=label,
-                position=position,
-                value=port.value,
-                annotation=port.annotation,
-                default=port.default,
-            )
-            G.add_node(io_name, **io_data.to_attrs())
+            io_data: dict[str, Any] = {
+                "step": "inputs",
+                "arg": label,
+                "position": position,
+            }
+            if not isinstance(port.value, fr.schemas.NotData):
+                io_data["value"] = port.value
+            if type_hint := annotation_to_type_hint(port.annotation):
+                io_data["dtype"] = type_hint
+            if type_metadata := annotation_to_type_metadata(port.annotation):
+                io_data.update(type_metadata.to_dictionary())
+            if not isinstance(port.default, fr.schemas.NotData):
+                io_data["default"] = port.default
+            G.add_node(io_name, **io_data)
             G.add_edge(io_name, node_name)
         for position, (raw_label, port) in enumerate(node_data.output_ports.items()):
             label = output_labels[position] if raw_label == "output_0" else raw_label
             io_name = f"{node_name}-outputs-{label}"
-            io_data = _port_to_dict(
-                step="outputs",
-                arg=label,
-                position=position,
-                value=port.value,
-                annotation=port.annotation,
-            )
-            G.add_node(io_name, **io_data.to_attrs())
+            io_data = {
+                "step": "outputs",
+                "arg": label,
+                "position": position,
+            }
+            if not isinstance(port.value, fr.schemas.NotData):
+                io_data["value"] = port.value
+            if type_hint := annotation_to_type_hint(port.annotation):
+                io_data["dtype"] = type_hint
+            if type_metadata := annotation_to_type_metadata(port.annotation):
+                io_data.update(type_metadata.to_dictionary())
+            G.add_node(io_name, **io_data)
             G.add_edge(node_name, io_name)
 
         if not isinstance(node_data, fr.schemas.DagData):

--- a/semantikon/flowrep_to_networkx.py
+++ b/semantikon/flowrep_to_networkx.py
@@ -83,7 +83,7 @@ class TInput(TIO):
     has_default: bool = False
 
     def to_attrs(self) -> dict[str, Any]:
-        attrs = super().to_attrs()
+        attrs = super(TInput, self).to_attrs()
         if self.has_default:
             attrs["default"] = self.default
         return attrs

--- a/semantikon/flowrep_to_networkx.py
+++ b/semantikon/flowrep_to_networkx.py
@@ -37,7 +37,7 @@ class TNode:
             raise ValueError("type must be either 'atomic' or 'workflow'")
 
     def to_attrs(self) -> dict[str, Any]:
-        attrs = {
+        attrs: dict[str, Any] = {
             "type": self.type,
             "step": self.step,
         }
@@ -57,13 +57,14 @@ class TNode:
 class TIO:
     arg: str
     position: int
+    step: str = field(default="", init=False)
     dtype: Any | None = None
     value: Any | None = None
     has_value: bool = False
     metadata: dict[str, Any] = field(default_factory=dict)
 
     def to_attrs(self) -> dict[str, Any]:
-        attrs = {
+        attrs: dict[str, Any] = {
             "step": self.step,
             "arg": self.arg,
             "position": self.position,

--- a/tests/unit/test_flowrep_to_networkx.py
+++ b/tests/unit/test_flowrep_to_networkx.py
@@ -146,6 +146,23 @@ class TestFlowrepToNetworkx(unittest.TestCase):
         hashed = ftn._get_hashed_node_dict_from_graph(G)
         self.assertEqual(hashed, {})
 
+    def test_add_node_validates_semantikon_metadata(self):
+        G = ftn.SemantikonDiGraph()
+        G.add_node("n", step="node", type="atomic")
+        self.assertEqual(G.nodes["n"]["step"], "node")
+        self.assertEqual(G.nodes["n"]["type"], "atomic")
+
+        G.add_node("in", step="inputs", arg="x", position=0, value=None)
+        self.assertIn("value", G.nodes["in"])
+        self.assertIsNone(G.nodes["in"]["value"])
+
+    def test_add_node_rejects_invalid_semantikon_metadata(self):
+        G = ftn.SemantikonDiGraph()
+        with self.assertRaises(ValueError):
+            G.add_node("n", step="node", type="invalid")
+        with self.assertRaises(ValueError):
+            G.add_node("n", step="banana")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_flowrep_to_networkx.py
+++ b/tests/unit/test_flowrep_to_networkx.py
@@ -1,15 +1,64 @@
 import unittest
+from dataclasses import dataclass, field
+from typing import Annotated
 
 import flowrep as fr
-from rdflib import BNode
+from rdflib import BNode, Namespace
 
 from semantikon import flowrep_to_networkx as ftn
-from tests.unit.test_ontology import (
-    NewSpeedData,
-    my_kinetic_energy_workflow,
-    passthrough_input_workflow,
-    workflow_with_default_values,
-)
+from semantikon.metadata import meta
+from semantikon.workflow import workflow
+
+EX: Namespace = Namespace("http://example.org/")
+PMD: Namespace = Namespace("https://w3id.org/pmd/co/PMD_")
+
+
+@dataclass
+class NewSpeedData:
+    distance: Annotated[float, {"uri": PMD["0040001"], "units": "meter"}]
+    time: float = field(metadata={"units": "second"})
+
+
+def get_speed(
+    distance: Annotated[
+        float, {"uri": PMD["0040001"], "units": "meter", "label": "Distance"}
+    ],
+    time: Annotated[float, {"units": "second"}],
+) -> Annotated[float, {"units": "meter/second", "uri": EX.Velocity, "label": "speed"}]:
+    """some random docstring"""
+    speed = distance / time
+    return speed
+
+
+@meta(uri=EX.get_kinetic_energy)
+def get_kinetic_energy(
+    mass: Annotated[float, {"uri": PMD["0020133"], "units": "kilogram"}],
+    velocity: Annotated[float, {"units": "meter/second", "uri": EX.Velocity}],
+) -> Annotated[
+    float, {"uri": PMD["0020142"], "units": "joule", "label": "kinetic_energy"}
+]:
+    return 0.5 * mass * velocity**2
+
+
+@workflow
+def my_kinetic_energy_workflow(
+    distance: Annotated[float, {"uri": PMD["0040001"]}], time, mass
+):
+    speed = get_speed(distance, time)
+    kinetic_energy = get_kinetic_energy(mass, speed)
+    return kinetic_energy
+
+
+@workflow
+def passthrough_input_workflow(x):
+    return x
+
+
+@workflow
+def workflow_with_default_values(distance=2, time=1, mass=4):
+    speed = get_speed(distance, time)
+    kinetic_energy = get_kinetic_energy(mass, speed)
+    return kinetic_energy
 
 
 class TestFlowrepToNetworkx(unittest.TestCase):


### PR DESCRIPTION
This pull request refactors the way node and port metadata are represented and validated in the `semantikon/flowrep_to_networkx.py` module. The main improvement is replacing the previous Pydantic-based model with new frozen dataclasses for node and port types, and introducing a validation layer that enforces correct metadata structure when adding nodes to the graph. The workflow-to-networkx conversion logic is also updated to use these new types, and corresponding tests are added.

**Data model and validation improvements:**

* Replaced the `NodeData` Pydantic model with frozen dataclasses: `TNode`, `TIO`, `TInput`, and `TOutput`, each encapsulating the relevant metadata for nodes and ports. These dataclasses provide validation and a method to convert themselves into attribute dictionaries.
* Added a `_validate_semantikon_attrs` method to `SemantikonDiGraph`, which validates and normalizes node attributes according to their type (`node`, `inputs`, `outputs`) before adding them to the graph. This ensures that all nodes have valid and consistent metadata.
* Updated the `add_node` method in `SemantikonDiGraph` to use the new validation logic, so that all nodes are checked for correct metadata upon insertion.

**Workflow conversion logic:**

* Refactored the workflow-to-networkx conversion by inlining and simplifying the logic for building node and port metadata, removing the old `_node_data_to_metadata` and `_port_to_dict` helpers, and directly constructing attribute dictionaries in place. [[1]](diffhunk://#diff-b2730e56fa40d37a1634cdc51fd196a76f42893f8a104a8a731b6a2d96196aabL152-R287) [[2]](diffhunk://#diff-b2730e56fa40d37a1634cdc51fd196a76f42893f8a104a8a731b6a2d96196aabL201-R339)

**Testing:**

* Added unit tests to verify that node metadata validation works as expected, including checks for valid and invalid metadata when adding nodes to the graph.