### PR TITLE
Move the location of deprecation warning for wf_dict

### DIFF
--- a/semantikon/flowrep_to_networkx.py
+++ b/semantikon/flowrep_to_networkx.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import json
 import unicodedata
+import warnings
 from dataclasses import asdict, dataclass, field, is_dataclass
 from functools import cache, cached_property
 from hashlib import sha256
@@ -486,13 +487,21 @@ def serialize_and_convert_to_networkx(
         SemantikonDiGraph: The serialized workflow graph.
     """
     if isinstance(workflow, dict):
+        warnings.warn(
+            "Passing a dict to 'serialize_and_convert_to_networkx' is deprecated"
+            " and will be removed in a future version. Please pass a 'flowrep'"
+            " object instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         workflow = dict_to_nodedata(workflow)
     if isinstance(workflow, fr.schemas.WorkflowRecipe):
         workflow = fr.schemas.DagData.from_recipe(workflow)
     if not isinstance(workflow, fr.schemas.DagData):
         raise TypeError(
-            f"Invalid workflow type. Expected dict, flowrep {fr.schemas.DagData.__name__!r}, or "
-            f"flowrep {fr.schemas.WorkflowRecipe.__name__!r}, but got {type(workflow)}."
+            f"Invalid workflow type. Expected dict, flowrep"
+            f" {fr.schemas.DagData.__name__!r}, or flowrep"
+            f" {fr.schemas.WorkflowRecipe.__name__!r}, but got {type(workflow)}."
         )
 
     G = _workflow_to_networkx(workflow, prefix=prefix)
@@ -501,7 +510,8 @@ def serialize_and_convert_to_networkx(
             hashed_dict = _get_hashed_node_dict_from_graph(G)
         except Exception as e:
             raise RuntimeError(
-                "Failed to hash workflow data - use only hashable inputs or set hash_data=False"
+                "Failed to hash workflow data - use only hashable inputs or set"
+                " hash_data=False"
             ) from e
         for node, data in hashed_dict.items():
             G.append_hash(node, data["hash"])

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -21,7 +21,6 @@ from semantikon.converter import (
     parse_input_args,
     parse_output_args,
 )
-from semantikon.flowrep_dict import dict_to_nodedata
 from semantikon.flowrep_to_networkx import (
     SemantikonDiGraph,
     _get_graph_hash,

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -289,24 +289,6 @@ def get_knowledge_graph(
     Returns:
         (rdflib.Graph): graph containing workflow information
     """
-    if isinstance(wf_dict, dict):
-        warnings.warn(
-            "Passing a dict to 'get_knowledge_graph' is deprecated and will be removed in a future version. "
-            "Please pass a 'flowrep' object instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        wf_dict = dict_to_nodedata(wf_dict)
-    if isinstance(wf_dict, fr.schemas.WorkflowRecipe):
-        wf_dict = fr.schemas.DagData.from_recipe(wf_dict)
-    elif isinstance(wf_dict, fr.schemas.DagData):
-        pass
-    else:
-        raise TypeError(
-            f"Invalid input type. Expected dict, flowrep {fr.schemas.DagData.__name__!r}, or "
-            f"flowrep {fr.schemas.WorkflowRecipe.__name__!r}, but got {type(wf_dict)}."
-        )
-
     G = serialize_and_convert_to_networkx(wf_dict, hash_data=hash_data, prefix=prefix)
     return _get_knowledge_graph_from_digraph(
         G,

--- a/tests/unit/test_flowrep_to_networkx.py
+++ b/tests/unit/test_flowrep_to_networkx.py
@@ -7,7 +7,6 @@ from rdflib import BNode, Namespace
 
 from semantikon import flowrep_to_networkx as ftn
 from semantikon.metadata import meta
-from semantikon.workflow import workflow
 
 EX: Namespace = Namespace("http://example.org/")
 PMD: Namespace = Namespace("https://w3id.org/pmd/co/PMD_")
@@ -40,7 +39,7 @@ def get_kinetic_energy(
     return 0.5 * mass * velocity**2
 
 
-@workflow
+@fr.workflow
 def my_kinetic_energy_workflow(
     distance: Annotated[float, {"uri": PMD["0040001"]}], time, mass
 ):
@@ -49,12 +48,12 @@ def my_kinetic_energy_workflow(
     return kinetic_energy
 
 
-@workflow
+@fr.workflow
 def passthrough_input_workflow(x):
     return x
 
 
-@workflow
+@fr.workflow
 def workflow_with_default_values(distance=2, time=1, mass=4):
     speed = get_speed(distance, time)
     kinetic_energy = get_kinetic_energy(mass, speed)
@@ -63,7 +62,7 @@ def workflow_with_default_values(distance=2, time=1, mass=4):
 
 class TestFlowrepToNetworkx(unittest.TestCase):
     def test_namespace_fragments_are_base_agnostic(self):
-        wf_dict = my_kinetic_energy_workflow.get_semantikon_dict()
+        wf_dict = my_kinetic_energy_workflow.flowrep_recipe
         G = ftn.serialize_and_convert_to_networkx(wf_dict, hash_data=False)
 
         self.assertIsInstance(G.t_ns, str)
@@ -81,7 +80,7 @@ class TestFlowrepToNetworkx(unittest.TestCase):
         self.assertEqual(G_prefixed.t_ns, "custom_")
 
     def test_hash(self):
-        wf_dict = my_kinetic_energy_workflow.get_semantikon_dict()
+        wf_dict = my_kinetic_energy_workflow.flowrep_recipe
         G = ftn.serialize_and_convert_to_networkx(wf_dict, hash_data=False)
         self.assertIsInstance(ftn._get_graph_hash(G), str)
         self.assertEqual(len(ftn._get_graph_hash(G)), 32)
@@ -104,8 +103,8 @@ class TestFlowrepToNetworkx(unittest.TestCase):
                 "my_kinetic_energy_workflow-get_kinetic_energy_0-outputs-kinetic_energy"
             ),
         )
-        wf_dict_one = my_kinetic_energy_workflow.run(distance=1.0, time=2.0, mass=3.0)
-        wf_dict_two = my_kinetic_energy_workflow.run(distance=4.0, time=5.0, mass=6.0)
+        wf_dict_one = fr.wfms.run_recipe(my_kinetic_energy_workflow.flowrep_recipe, distance=1.0, time=2.0, mass=3.0)
+        wf_dict_two = fr.wfms.run_recipe(my_kinetic_energy_workflow.flowrep_recipe, distance=4.0, time=5.0, mass=6.0)
         G_one = ftn.serialize_and_convert_to_networkx(wf_dict_one, hash_data=True)
         G_two = ftn.serialize_and_convert_to_networkx(wf_dict_two, hash_data=True)
         self.assertEqual(
@@ -113,8 +112,8 @@ class TestFlowrepToNetworkx(unittest.TestCase):
             ftn._get_graph_hash(G_two, with_global_inputs=False),
         )
 
-        wf_dict = workflow_with_default_values.get_semantikon_dict()
-        wf_dict_run = workflow_with_default_values.run(distance=2, time=1, mass=4)
+        wf_dict = workflow_with_default_values.flowrep_recipe
+        wf_dict_run = fr.wfms.run_recipe(workflow_with_default_values.flowrep_recipe, distance=2, time=1, mass=4)
         G = ftn.serialize_and_convert_to_networkx(wf_dict, hash_data=False)
         G_run = ftn.serialize_and_convert_to_networkx(wf_dict_run, hash_data=False)
         self.assertEqual(ftn._get_graph_hash(G), ftn._get_graph_hash(G_run))
@@ -133,9 +132,9 @@ class TestFlowrepToNetworkx(unittest.TestCase):
             ftn._get_graph_hash(G, with_global_inputs=True)
 
     def test_hash_with_value(self):
-        wf_dict = my_kinetic_energy_workflow.get_semantikon_dict()
+        wf_dict = my_kinetic_energy_workflow.flowrep_recipe
         G = ftn.serialize_and_convert_to_networkx(wf_dict, hash_data=False)
-        wf_dict = my_kinetic_energy_workflow.run(distance=1, time=2, mass=3)
+        wf_dict = fr.wfms.run_recipe(my_kinetic_energy_workflow.flowrep_recipe, distance=1, time=2, mass=3)
         G_run = ftn.serialize_and_convert_to_networkx(wf_dict, hash_data=False)
         self.assertEqual(
             ftn._get_graph_hash(G, with_global_inputs=False),

--- a/tests/unit/test_flowrep_to_networkx.py
+++ b/tests/unit/test_flowrep_to_networkx.py
@@ -103,8 +103,12 @@ class TestFlowrepToNetworkx(unittest.TestCase):
                 "my_kinetic_energy_workflow-get_kinetic_energy_0-outputs-kinetic_energy"
             ),
         )
-        wf_dict_one = fr.wfms.run_recipe(my_kinetic_energy_workflow.flowrep_recipe, distance=1.0, time=2.0, mass=3.0)
-        wf_dict_two = fr.wfms.run_recipe(my_kinetic_energy_workflow.flowrep_recipe, distance=4.0, time=5.0, mass=6.0)
+        wf_dict_one = fr.wfms.run_recipe(
+            my_kinetic_energy_workflow.flowrep_recipe, distance=1.0, time=2.0, mass=3.0
+        )
+        wf_dict_two = fr.wfms.run_recipe(
+            my_kinetic_energy_workflow.flowrep_recipe, distance=4.0, time=5.0, mass=6.0
+        )
         G_one = ftn.serialize_and_convert_to_networkx(wf_dict_one, hash_data=True)
         G_two = ftn.serialize_and_convert_to_networkx(wf_dict_two, hash_data=True)
         self.assertEqual(
@@ -113,7 +117,9 @@ class TestFlowrepToNetworkx(unittest.TestCase):
         )
 
         wf_dict = workflow_with_default_values.flowrep_recipe
-        wf_dict_run = fr.wfms.run_recipe(workflow_with_default_values.flowrep_recipe, distance=2, time=1, mass=4)
+        wf_dict_run = fr.wfms.run_recipe(
+            workflow_with_default_values.flowrep_recipe, distance=2, time=1, mass=4
+        )
         G = ftn.serialize_and_convert_to_networkx(wf_dict, hash_data=False)
         G_run = ftn.serialize_and_convert_to_networkx(wf_dict_run, hash_data=False)
         self.assertEqual(ftn._get_graph_hash(G), ftn._get_graph_hash(G_run))
@@ -134,7 +140,9 @@ class TestFlowrepToNetworkx(unittest.TestCase):
     def test_hash_with_value(self):
         wf_dict = my_kinetic_energy_workflow.flowrep_recipe
         G = ftn.serialize_and_convert_to_networkx(wf_dict, hash_data=False)
-        wf_dict = fr.wfms.run_recipe(my_kinetic_energy_workflow.flowrep_recipe, distance=1, time=2, mass=3)
+        wf_dict = fr.wfms.run_recipe(
+            my_kinetic_energy_workflow.flowrep_recipe, distance=1, time=2, mass=3
+        )
         G_run = ftn.serialize_and_convert_to_networkx(wf_dict, hash_data=False)
         self.assertEqual(
             ftn._get_graph_hash(G, with_global_inputs=False),


### PR DESCRIPTION
to inside `serialize_andconvert_to_networkx` because it could now also be used independently of `get_knowledge_graph`