### PR TITLE
Bump flowrep

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -14,7 +14,7 @@ dependencies:
 - python-graphviz =0.21
 - requests =2.34.2
 - typeguard =4.5.2
-- flowrep =0.5.2
+- flowrep =0.6.0
 - networkx =3.6.1
 - bagofholding =0.1.12
 - cwltool =3.2.20260413085819

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -14,6 +14,6 @@ dependencies:
 - python-graphviz =0.21
 - requests =2.34.2
 - typeguard =4.5.2
-- flowrep =0.5.2
+- flowrep =0.6.0
 - networkx =3.6.1
 - bagofholding =0.1.12

--- a/.ci_support/lower_bound.yml
+++ b/.ci_support/lower_bound.yml
@@ -14,7 +14,7 @@ dependencies:
 - python-graphviz =0.20.3
 - requests =2.28.0
 - typeguard =4.0.0
-- flowrep =0.5.1
+- flowrep =0.6.0
 - networkx =3.4.2
 - networkx =3.5
 - bagofholding =0.1.5

--- a/.ci_support/upper_bound.yml
+++ b/.ci_support/upper_bound.yml
@@ -2,5 +2,5 @@ channels:
   - conda-forge
 dependencies:
   - bagofholding =0.2.0
-  - flowrep =0.6.0
+  - flowrep =0.7.0
   - pyiron_snippets =2.0.0

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -20,7 +20,7 @@ dependencies:
 - python-graphviz =0.21
 - requests =2.34.2
 - typeguard =4.5.2
-- flowrep =0.5.2
+- flowrep =0.6.0
 - networkx =3.6.1
 - bagofholding =0.1.12
 - cwltool =3.2.20260413085819

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "pyshacl==0.31.0",
     "requests==2.34.2",
     "typeguard==4.5.2",
-    "flowrep==0.5.2",
+    "flowrep==0.6.0",
     "networkx==3.6.1",
     "bagofholding==0.1.12",
 ]

--- a/tests/unit/test_flowrep_dict.py
+++ b/tests/unit/test_flowrep_dict.py
@@ -364,7 +364,7 @@ class TestFlowControlStub(unittest.TestCase):
         recipe = frs.ForEachRecipe(
             inputs=["xs"],
             outputs=["ys"],
-            body_node=frs.LabeledRecipe(label="body", node=negate.flowrep_recipe),
+            body_node=frs.LabeledRecipe(label="body", recipe=negate.flowrep_recipe),
             input_edges={
                 frs.TargetHandle(node="body", port="x"): frs.InputSource(port="xs")
             },


### PR DESCRIPTION
It won't be available on the GitHub machines quite yet, but as soon as it is this should do the trick.

Only change was `..., node=...` to `... recipe=...` in one test building a `LabeledRecipe` object.