### PR TITLE
Handle functionless workflows

### DIFF
--- a/semantikon/flowrep_dict.py
+++ b/semantikon/flowrep_dict.py
@@ -173,9 +173,19 @@ def _normalize_output_label(label: str, recipe_outputs: list[str]) -> str:
 
 def _dict_to_workflow_recipe(node: dict[str, Any]) -> fr.schemas.WorkflowRecipe:
     function = node.get("function")
-    if function is None:
-        raise TypeError("Workflow dict entries must carry a callable.")
-    base_recipe = _flowrep_recipe_from_callable(function, node_type="workflow")
+    if function is not None:
+        base_recipe = _flowrep_recipe_from_callable(function, node_type="workflow")
+        inputs = list(base_recipe.inputs)
+        outputs = list(base_recipe.outputs)
+        reference = base_recipe.reference
+        description = base_recipe.description
+    else:
+        # Function-less workflows (e.g. pyiron_workflow generic ``Workflow``s) map
+        # to reference-free flowrep workflows; take IO from the dict itself.
+        inputs = list(node.get("inputs", {}))
+        outputs = list(node.get("outputs", {}))
+        reference = None
+        description = None
     nodes = {
         label: _dict_to_recipe(child_node)
         for label, child_node in node.get("nodes", {}).items()
@@ -211,7 +221,7 @@ def _dict_to_workflow_recipe(node: dict[str, Any]) -> fr.schemas.WorkflowRecipe:
             and src_node is None
             and src_io == "inputs"
         ):
-            tgt_port = _normalize_output_label(tgt_port, list(base_recipe.outputs))
+            tgt_port = _normalize_output_label(tgt_port, outputs)
             output_edges[fr.schemas.OutputTarget(port=tgt_port)] = (
                 fr.schemas.InputSource(port=src_port)
             )
@@ -222,21 +232,21 @@ def _dict_to_workflow_recipe(node: dict[str, Any]) -> fr.schemas.WorkflowRecipe:
             and src_io == "outputs"
         ):
             src_port = _normalize_output_label(src_port, nodes[src_node].outputs)
-            tgt_port = _normalize_output_label(tgt_port, list(base_recipe.outputs))
+            tgt_port = _normalize_output_label(tgt_port, outputs)
             output_edges[fr.schemas.OutputTarget(port=tgt_port)] = (
                 fr.schemas.SourceHandle(node=src_node, port=src_port)
             )
         else:
             raise ValueError(f"Malformed workflow edge: {src!r} -> {tgt!r}")
     return fr.schemas.WorkflowRecipe(
-        inputs=list(base_recipe.inputs),
-        outputs=list(base_recipe.outputs),
+        inputs=inputs,
+        outputs=outputs,
         nodes=nodes,
         input_edges=input_edges,
         edges=edges,
         output_edges=output_edges,
-        reference=base_recipe.reference,
-        description=base_recipe.description,
+        reference=reference,
+        description=description,
     )
 
 

--- a/tests/unit/test_flowrep_dict.py
+++ b/tests/unit/test_flowrep_dict.py
@@ -5,9 +5,15 @@ import unittest
 
 from flowrep.api import schemas as frs
 from flowrep.api import tools as frt
+from rdflib import RDF, RDFS
 
 from semantikon import datastructure, flowrep_dict
 from semantikon.metadata import u
+from semantikon.ontology import PMD, get_knowledge_graph
+
+# PMD terms probed below; see https://w3id.org/pmd/co
+PMD_PROCESS = PMD["0000010"]
+PMD_FUNCTION_NAME = PMD["0000100"]
 
 
 @frt.atomic
@@ -356,6 +362,69 @@ class TestWorkflowToDict(unittest.TestCase):
         self.assertEqual(
             flowrep_dict.nodedata2dict(node)["edges"],
             wf_dict["edges"],
+        )
+
+
+class TestFunctionlessWorkflow(unittest.TestCase):
+    """A workflow dict without a ``function`` key (e.g. a pyiron_workflow generic
+    ``Workflow``) is a reference-free flowrep workflow: IO is taken from the dict."""
+
+    def _wf_dict(self):
+        return {
+            "type": "workflow",
+            "label": "manual_wf",
+            "inputs": {"a": {}, "b": {}},
+            "outputs": {"total": {}},
+            "nodes": {
+                "add": {
+                    "type": "atomic",
+                    "function": my_add,
+                    "inputs": {"a": {}, "b": {}},
+                    "outputs": {"output": {}},
+                },
+            },
+            "edges": [
+                ("inputs.a", "add.inputs.a"),
+                ("inputs.b", "add.inputs.b"),
+                ("add.outputs.output", "outputs.total"),
+            ],
+        }
+
+    def test_recipe_is_reference_free(self):
+        recipe = flowrep_dict._dict_to_workflow_recipe(self._wf_dict())
+        self.assertIsInstance(recipe, frs.WorkflowRecipe)
+        self.assertIsNone(recipe.reference)
+        self.assertEqual(list(recipe.inputs), ["a", "b"])
+        self.assertEqual(list(recipe.outputs), ["total"])
+
+    def test_dict_to_nodedata(self):
+        node = flowrep_dict.dict_to_nodedata(self._wf_dict())
+        self.assertIsInstance(node, frs.DagData)
+        self.assertEqual(list(node.input_ports), ["a", "b"])
+        self.assertEqual(list(node.output_ports), ["total"])
+
+    def test_knowledge_graph_is_populated(self):
+        """The reference-free workflow still yields a real, non-empty graph: its
+        own IO ports and its child atomic's process are all represented."""
+        g = get_knowledge_graph(flowrep_dict._dict_to_workflow_recipe(self._wf_dict()))
+        self.assertGreater(len(g), 0)
+        labels = {str(o) for _, p, o in g if p == RDFS.label}
+        # the child atomic, carrying its function semantics, is in the graph
+        self.assertIn("Function name 'my_add'", labels)
+
+    def test_knowledge_graph_omits_workflow_process(self):
+        """ "Simple": a reference-free workflow contributes structure but no process
+        of its own. Only the child atomic appears as a process/function -- a
+        function-bearing workflow would additionally represent the workflow itself
+        (e.g. the diamond workflow yields four such nodes, one per child plus root)."""
+        g = get_knowledge_graph(flowrep_dict._dict_to_workflow_recipe(self._wf_dict()))
+        processes = [s for s, p, o in g if p == RDF.type and o == PMD_PROCESS]
+        function_names = [
+            s for s, p, o in g if p == RDF.type and o == PMD_FUNCTION_NAME
+        ]
+        self.assertEqual(len(processes), 1, "only the child atomic is a process")
+        self.assertEqual(
+            len(function_names), 1, "the workflow root carries no function"
         )
 
 


### PR DESCRIPTION
@samwaseda, 1.4.0 regressively breaks the parsing of workflows without an underlying python reference function with these lines:

https://github.com/pyiron/semantikon/blob/528fbff1af198046081382accd64a9887b4d419d/semantikon/flowrep_dict.py#L174-L177

Now, we don't currently have a way to attach any ontological information to those, so any KG/onto information on them is going to be really boring, and maybe this was on purpose. On the other hand, their worst crime is just being boring, so maybe this regression was an accident.

I got Claude to put together a little patch. AFAIK I don't actually need this functionality at present, but if the fallout radius here was bigger than intended we can mend the lost functionality here. Up to you, the patch came almost for free from getting the AI to try and debug anything that could be done on the pwf side so I thought I might as well pass it on.