### PR TITLE
Parse flowrep constants

### DIFF
--- a/semantikon/flowrep_to_networkx.py
+++ b/semantikon/flowrep_to_networkx.py
@@ -34,8 +34,8 @@ class TNode:
     extras: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
-        if self.type not in {"atomic", "workflow"}:
-            raise ValueError("type must be either 'atomic' or 'workflow'")
+        if self.type not in {"atomic", "constant", "workflow"}:
+            raise ValueError("type must be either 'atomic', 'constant', or 'workflow'")
 
     def to_attrs(self) -> dict[str, Any]:
         attrs: dict[str, Any] = {
@@ -301,6 +301,11 @@ def _workflow_to_networkx(
         if isinstance(node_data, fr.schemas.AtomicData):
             metadata["type"] = "atomic"
             function = node_data.function
+        elif isinstance(node_data, fr.schemas.ConstantData):
+            metadata["type"] = "constant"
+            metadata["constant_value"] = node_data.output_ports[
+                fr.schemas.ConstantRecipe.std_label
+            ].value
         else:
             metadata["type"] = "workflow"
             if workflow_label is not None:

--- a/semantikon/kg_to_flowrep.py
+++ b/semantikon/kg_to_flowrep.py
@@ -14,7 +14,7 @@ from rdflib.query import ResultRow
 from rdflib.term import IdentifiedNode, Node
 
 from semantikon.flowrep_dict import _flowrep_recipe_from_callable
-from semantikon.ontology import SNS
+from semantikon.ontology import SNS, _literal_to_constant
 
 
 def _graph_to_function(graph: Graph, f_node: URIRef) -> dict[str, Any]:
@@ -213,6 +213,8 @@ def _networkx_to_dict(G: nx.DiGraph) -> fr.schemas.WorkflowRecipe:
     def _process_node(node_name: str) -> fr.schemas.RecipeDiscrimination:
         node_data = G.nodes[node_name]
         node_type = node_data.get("type", "atomic")
+        if node_type == "constant":
+            return fr.schemas.ConstantRecipe(constant=node_data["constant_value"])
         if "function" not in node_data:
             raise ValueError(f"Node {node_name!r} is missing function metadata.")
         func_obj = _get_function_from_dict(node_data["function"])
@@ -398,6 +400,27 @@ def _node_functions(graph: Graph) -> dict[URIRef, URIRef]:
     return dict(graph.query(query))
 
 
+def _node_constants(graph: Graph) -> dict[URIRef, Any]:
+    """
+    Map each constant workflow node onto the value it emits.
+
+    Constant nodes have no function to concretize; their value is instead
+    attached to the node class itself by ``_wf_node_to_graph``.
+    """
+    query = f"""SELECT ?node ?value WHERE {{
+        ?node <{RDFS.subClassOf}> <{SNS.workflow_node}> .
+        ?node <{RDFS.subClassOf}> ?bnode .
+        ?bnode a <{OWL.Restriction}> .
+        ?bnode <{OWL.hasValue}> ?value .
+        ?bnode <{OWL.onProperty}> <{SNS.has_value}> .
+    }}"""
+    constants: dict[URIRef, Any] = {}
+    for row in graph.query(query):
+        node, value = cast(ResultRow, row)
+        constants[cast(URIRef, node)] = _literal_to_constant(cast(Literal, value))
+    return constants
+
+
 def _reorganize_output_edges(
     graph: nx.DiGraph, node: URIRef, position: dict[URIRef, int]
 ):
@@ -443,6 +466,7 @@ def _add_io_nodes(
     function_dict: dict[URIRef, dict[str, Any]],
     node_function_dict: dict[URIRef, URIRef],
     io_type: str,
+    node_constant_dict: dict[URIRef, Any] | None = None,
 ):
     if io_type == "input":
         io_query = graph.query(
@@ -460,6 +484,21 @@ def _add_io_nodes(
             workflow_graph.add_edge(io_node, node)
         else:
             workflow_graph.add_edge(node, io_node)
+
+        if node_constant_dict is not None and node in node_constant_dict:
+            workflow_graph.add_node(
+                node,
+                step="node",
+                type="constant",
+                constant_value=node_constant_dict[cast(URIRef, node)],
+            )
+            workflow_graph.add_node(
+                io_node,
+                step=f"{io_type}s",
+                arg=_identifier(graph, cast(URIRef, io_node)),
+                position=0,
+            )
+            continue
 
         func_node = node_function_dict.get(cast(URIRef, node))
         function_data = function_dict.get(func_node) if func_node is not None else None
@@ -487,14 +526,18 @@ def _build_workflow_graph(graph: Graph) -> nx.DiGraph:
         f_node: _graph_to_function(graph, f_node) for f_node in function_nodes
     }
     node_function_dict = _node_functions(graph)
+    node_constant_dict = _node_constants(graph)
 
     workflow_graph = nx.DiGraph()
-    _add_io_nodes(
-        graph, workflow_graph, function_dict, node_function_dict, io_type="input"
-    )
-    _add_io_nodes(
-        graph, workflow_graph, function_dict, node_function_dict, io_type="output"
-    )
+    for io_type in ("input", "output"):
+        _add_io_nodes(
+            graph,
+            workflow_graph,
+            function_dict,
+            node_function_dict,
+            io_type=io_type,
+            node_constant_dict=node_constant_dict,
+        )
 
     for row in graph.query(
         _get_connection_query(

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import json
 import warnings
 from collections.abc import Callable
 from dataclasses import dataclass, fields, is_dataclass
@@ -86,6 +87,28 @@ TripleList: TypeAlias = list[
 
 
 RestrictionTuple: TypeAlias = tuple[tuple[URIRef, URIRef], ...]
+
+
+def _constant_to_literal(value: fr.schemas.JSONABLE) -> Literal:
+    """
+    Represent a flowrep constant as an RDF literal.
+
+    Scalars become typed literals, so they stay queryable as numbers, booleans
+    and strings. ``None`` and containers have no XSD counterpart -- and rdflib
+    silently degrades them to their ``repr`` on serialization -- so they are
+    written as ``rdf:JSON``. flowrep guarantees constants are JSONable, so this
+    covers every legal value.
+    """
+    if value is None or isinstance(value, (list, dict)):
+        return Literal(json.dumps(value), datatype=RDF.JSON)
+    return Literal(value)
+
+
+def _literal_to_constant(literal: Literal) -> Any:
+    """Invert :func:`_constant_to_literal`."""
+    if literal.datatype == RDF.JSON:
+        return json.loads(str(literal))
+    return literal.toPython()
 
 
 def _units_to_uri(units: str | URIRef) -> URIRef:
@@ -542,6 +565,13 @@ def _wf_node_to_graph(
                 node,
                 SNS.concretizes,
                 f_node,
+                restriction_type=OWL.hasValue,
+            )
+        if data.get("type") == "constant":
+            g += _to_owl_restriction(
+                node,
+                SNS.has_value,
+                _constant_to_literal(data["constant_value"]),
                 restriction_type=OWL.hasValue,
             )
         g.add((node, RDFS.label, Literal(node_name)))
@@ -1255,7 +1285,7 @@ def _get_successor_nodes(G, node_name):
 def _to_owl_restriction(
     base_node: URIRef | None,
     on_property: URIRef,
-    target_class: URIRef,
+    target_class: URIRef | Literal,
     restriction_type: URIRef = OWL.someValuesFrom,
 ) -> Graph:
     g = _get_bound_graph()

--- a/semantikon/visualize.py
+++ b/semantikon/visualize.py
@@ -3,7 +3,7 @@ from typing import cast
 
 import networkx as nx
 from graphviz import Digraph
-from rdflib import OWL, RDF, RDFS, Graph, URIRef
+from rdflib import OWL, RDF, RDFS, Graph, Literal, URIRef
 from rdflib.query import ResultRow
 
 subclass_color_dict = {
@@ -31,6 +31,13 @@ def _get_triples(graph: Graph):
     for style, rest in rest_types.items():
         for row in graph.query(query.replace("R_TYPE", rest)):
             subj, pred, obj = cast(ResultRow, row)
+            if isinstance(obj, Literal):
+                # `owl:hasValue` may target an individual *or* a literal. This is
+                # a diagram of classes and individuals, and a literal is neither:
+                # it has no qname to draw and no identity to draw it at (two
+                # constants of `2` are the same literal but different nodes).
+                # Constant nodes still appear via their other restrictions.
+                continue
             yield subj, pred, obj, style
 
 

--- a/semantikon/visualize.py
+++ b/semantikon/visualize.py
@@ -1,10 +1,13 @@
 from hashlib import sha256
+from html import escape
 from typing import cast
 
 import networkx as nx
 from graphviz import Digraph
 from rdflib import OWL, RDF, RDFS, Graph, Literal, URIRef
 from rdflib.query import ResultRow
+
+from semantikon.ontology import _literal_to_constant
 
 subclass_color_dict = {
     "pmdco:0000011": "lightpink",
@@ -31,13 +34,6 @@ def _get_triples(graph: Graph):
     for style, rest in rest_types.items():
         for row in graph.query(query.replace("R_TYPE", rest)):
             subj, pred, obj = cast(ResultRow, row)
-            if isinstance(obj, Literal):
-                # `owl:hasValue` may target an individual *or* a literal. This is
-                # a diagram of classes and individuals, and a literal is neither:
-                # it has no qname to draw and no identity to draw it at (two
-                # constants of `2` are the same literal but different nodes).
-                # Constant nodes still appear via their other restrictions.
-                continue
             yield subj, pred, obj, style
 
 
@@ -47,6 +43,7 @@ def _rename_predicate(pred: str) -> str:
         "bfo:0000063": "bfo:precedes",
         "iao:0000235": "iao:denoted_by",
         "obi:0001927": "obi:specifies_values_of",
+        "pmdco:0000006": "pmdco:has_value",
         "ro:0000057": "ro:has_participant",
         "ro:0000059": "ro:concretizes",
     }
@@ -59,10 +56,32 @@ def _color_predicate(pred: str) -> str:
         "bfo:precedes": "brown",
         "iao:denoted_by": "darkgreen",
         "obi:specifies_values_of": "darkviolet",
+        "pmdco:has_value": "darkred",
         "ro:has_participant": "darkorange",
         "ro:concretizes": "darkcyan",
     }
     return edge_dict.get(pred, "black")
+
+
+def _node_key(term: URIRef | Literal, owner: URIRef, graph: Graph) -> str:
+    """
+    Drawing-unique identity for a term.
+
+    Literals have no identity of their own -- two constants of ``2`` are the
+    same RDF literal -- so a literal is keyed on the class whose restriction
+    points at it. That gives one value box per constant node instead of one
+    shared box per distinct value.
+    """
+    if isinstance(term, Literal):
+        return graph.qname(owner) + "-value"
+    return graph.qname(term)
+
+
+def _node_text(term: URIRef | Literal, graph: Graph) -> str:
+    """Text drawn inside a term's box."""
+    if isinstance(term, Literal):
+        return repr(_literal_to_constant(term))
+    return graph.qname(term)
 
 
 def _get_parent_class(comp: URIRef, graph: Graph) -> str:
@@ -99,21 +118,24 @@ def _is_class(term: URIRef, graph: Graph) -> bool:
 def _rdflib_to_nx(graph: Graph) -> nx.DiGraph:
     G = nx.DiGraph()
     for subj, pred, obj, style in _get_triples(graph):
+        keys = []
         for part in [subj, obj]:
-            if part in G.nodes:
+            key = _node_key(part, subj, graph)
+            keys.append(key)
+            if key in G.nodes:
                 continue
             G.add_node(
-                graph.qname(part),
+                key,
                 fillcolor=_get_node_color(part, graph),
                 style="filled" if _is_class(part, graph) else "filled,rounded,dashed",
                 shape="box",
                 parent_class=_get_parent_class(part, graph),
+                text=_node_text(part, graph),
             )
         label = _rename_predicate(graph.qname(pred))
         color = _color_predicate(label)
         G.add_edge(
-            graph.qname(subj),
-            graph.qname(obj),
+            *keys,
             label=label,
             style=style,
             color=color,
@@ -122,7 +144,7 @@ def _rdflib_to_nx(graph: Graph) -> nx.DiGraph:
     return G
 
 
-def _to_node(key: str, parent_class: str) -> str:
+def _to_node(text: str, parent_class: str) -> str:
     translation = {
         "pmdco:0000011": "workflow_node",
         "obi:0001933": "value_specification",
@@ -131,10 +153,12 @@ def _to_node(key: str, parent_class: str) -> str:
         "iao:0000591": "software_method",
     }
     rows = '<<table border="0" cellborder="0" cellspacing="0">'
-    rows += f"<tr><td align='center'><U>{key}</U></td></tr>"
+    # Constant values are arbitrary user data, so escape: an unescaped `<` or
+    # `&` makes the whole HTML-like label malformed and graphviz refuses it.
+    rows += f"<tr><td align='center'><U>{escape(text)}</U></td></tr>"
     if len(parent_class) > 0:
-        text = translation.get(parent_class, parent_class) + " / " + parent_class
-        rows += f"<tr><td><I>{text}</I></td></tr>"
+        subtitle = translation.get(parent_class, parent_class) + " / " + parent_class
+        rows += f"<tr><td><I>{escape(subtitle)}</I></td></tr>"
     rows += "</table>>"
     return rows
 
@@ -143,7 +167,7 @@ def visualize_recipe(graph: Graph) -> Digraph:
     G = _rdflib_to_nx(graph)
     dot = Digraph()
     for node, data in G.nodes.data():
-        cell = _to_node(node, data.pop("parent_class"))
+        cell = _to_node(data.pop("text"), data.pop("parent_class"))
         dot.node(sha256(node.encode()).hexdigest(), cell, **data)
     for subj, obj, data in G.edges.data():
         dot.edge(

--- a/tests/integration/test_constants_roundtrip.py
+++ b/tests/integration/test_constants_roundtrip.py
@@ -1,0 +1,86 @@
+import unittest
+
+import flowrep as fr
+import semantikon
+from semantikon.ontology import SNS
+
+
+@fr.workflow
+def wf(x):
+    doubled = fr.std.mul(2, x)
+    return doubled
+
+
+class TestConstants(unittest.TestCase):
+
+    def test_roundtrip(self):
+        recipe = wf.flowrep_recipe
+
+        # Probe representation in the knowledge graph
+        kg = semantikon.get_knowledge_graph(wf.flowrep_recipe)
+
+        with self.subTest(msg="Verify in A-box"):
+            abox_constants = kg.query(f"""
+              SELECT ?port ?value WHERE {{
+                  ?port <{SNS.has_participant}> ?data .
+                  ?data <{SNS.has_value}> ?value .
+              }}
+            """)
+            self.assertEqual(
+                len(abox_constants),
+                2,
+                "The constant should appear as output of one node and input of "
+                "the other",
+            )
+
+            # We don't care about what order the two query results come, so use a sets
+            ports_holding_constant = set()
+            for query_result in abox_constants:
+                port, literal = query_result
+                discovered_port = port.rsplit(f"{wf.__name__}-")[1]
+                ports_holding_constant.add(discovered_port)
+
+            self.assertSetEqual(
+                {"constant_0-outputs-constant", "mul_0-inputs-a"},
+                ports_holding_constant,
+                msg="The constant should appear as output of one node and input of the "
+                "other",
+            )
+
+        with self.subTest(msg="Verify in T-box"):
+            tbox_constants = kg.query(f"""
+              SELECT ?node ?value WHERE {{
+                  ?node rdfs:subClassOf ?r .
+                  ?r a owl:Restriction ;
+                     owl:onProperty <{SNS.has_value}> ;
+                     owl:hasValue ?value .
+              }}
+            """)
+            self.assertEqual(len(tbox_constants), 1)
+
+            node, literal = next(iter(tbox_constants))
+            node_label = node.rsplit(f"{wf.__name__}-")[1]
+            self.assertEqual(
+                "constant_0",
+                node_label,
+                msg="The constant should be attached to the constant node, like "
+                "function references are to atomic nodes",
+            )
+
+        with self.subTest(msg="Visualization should not crash"):
+            semantikon.visualize_recipe(kg)
+            # We don't inspect it here, but it ought at least not crash
+
+        with self.subTest(msg="Verify recipe roundtrip"):
+            roundtrip_recipe = semantikon.kg2recipe(kg)
+            self.assertEqual(
+                recipe,
+                roundtrip_recipe,
+                msg="The KG should recompile into the same recipe",
+            )
+            self.assertEqual(6, recipe(x=3), msg="sanity check")
+            self.assertEqual(
+                recipe(x=3),
+                roundtrip_recipe(x=3),
+                msg="The re-constituted recipe should execute to the same value",
+            )

--- a/tests/integration/test_constants_roundtrip.py
+++ b/tests/integration/test_constants_roundtrip.py
@@ -1,6 +1,7 @@
 import unittest
 
 import flowrep as fr
+
 import semantikon
 from semantikon.ontology import SNS
 

--- a/tests/integration/test_constants_roundtrip.py
+++ b/tests/integration/test_constants_roundtrip.py
@@ -37,7 +37,7 @@ class TestConstants(unittest.TestCase):
             # We don't care about what order the two query results come, so use a sets
             ports_holding_constant = set()
             for query_result in abox_constants:
-                port, literal = query_result
+                port, _ = query_result
                 discovered_port = port.rsplit(f"{wf.__name__}-")[1]
                 ports_holding_constant.add(discovered_port)
 

--- a/tests/integration/test_constants_roundtrip.py
+++ b/tests/integration/test_constants_roundtrip.py
@@ -59,7 +59,7 @@ class TestConstants(unittest.TestCase):
             """)
             self.assertEqual(len(tbox_constants), 1)
 
-            node, literal = next(iter(tbox_constants))
+            node, _ = next(iter(tbox_constants))
             node_label = node.rsplit(f"{wf.__name__}-")[1]
             self.assertEqual(
                 "constant_0",

--- a/tests/unit/test_flowrep_to_networkx.py
+++ b/tests/unit/test_flowrep_to_networkx.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 from dataclasses import dataclass, field
 from typing import Annotated
@@ -51,6 +52,12 @@ def my_kinetic_energy_workflow(
 @fr.workflow
 def passthrough_input_workflow(x):
     return x
+
+
+@fr.workflow
+def workflow_with_constant(x):
+    doubled = fr.std.mul(2, x)
+    return doubled
 
 
 @fr.workflow
@@ -151,6 +158,50 @@ class TestFlowrepToNetworkx(unittest.TestCase):
         self.assertNotEqual(
             ftn._get_graph_hash(G_run, with_global_inputs=False),
             ftn._get_graph_hash(G_run, with_global_inputs=True),
+        )
+
+    def test_constant_node_carries_its_value(self):
+        G = ftn.serialize_and_convert_to_networkx(
+            workflow_with_constant.flowrep_recipe,
+            hash_data=False,
+        )
+        constants = [
+            node
+            for node, data in G.nodes.data()
+            if data.get("step") == "node" and data.get("type") == "constant"
+        ]
+        self.assertEqual(
+            constants,
+            ["workflow_with_constant-constant_0"],
+            msg="The literal 2 should show up as exactly one constant node",
+        )
+        constant = constants[0]
+
+        self.assertEqual(
+            G.nodes[constant]["constant_value"],
+            2,
+            msg="The node metadata should hold the constant itself, not a port, "
+            "annotation, or other proxy for it",
+        )
+        self.assertEqual(
+            json.loads(json.dumps(G.nodes[constant]["constant_value"])),
+            2,
+            msg="flowrep guarantees constants are JSONable, so the metadata must "
+            "survive a serialization round trip",
+        )
+
+        (output_port,) = G.successors(constant)
+        self.assertEqual(
+            G.nodes[output_port]["value"],
+            G.nodes[constant]["constant_value"],
+            msg="The node metadata should agree with the value on the constant's "
+            "output port",
+        )
+        (consumer,) = G.successors(output_port)
+        self.assertEqual(
+            consumer,
+            "workflow_with_constant-mul_0-inputs-a",
+            msg="The constant should feed the argument it was written for",
         )
 
     def test_infer_workflow_label_without_reference(self):

--- a/tests/unit/test_kg_to_flowrep.py
+++ b/tests/unit/test_kg_to_flowrep.py
@@ -43,7 +43,58 @@ def multiply_by_two(x=2):
     return result
 
 
+@fr.workflow
+def double_via_constant(x):
+    doubled = fr.std.mul(2, x)
+    return doubled
+
+
+def pick(options: list, index: int) -> int:
+    return options[index]
+
+
+@fr.workflow
+def pick_from_constant_list(i):
+    chosen = pick([10, 20, 30], i)
+    return chosen
+
+
+@fr.workflow
+def compare_to_constant_none(x):
+    missing = fr.std.is_(x, None)
+    return missing
+
+
 class TestKgToFlowrep(unittest.TestCase):
+    def test_round_trip_with_a_constant_node(self):
+        graph = get_knowledge_graph(double_via_constant.flowrep_recipe)
+        reconstructed = kg2recipe(graph)
+
+        constants = {
+            label: node
+            for label, node in reconstructed.nodes.items()
+            if isinstance(node, fr.schemas.ConstantRecipe)
+        }
+        self.assertEqual(
+            list(constants),
+            ["constant_0"],
+            msg="The constant node should survive the round trip as a constant, "
+            "not be dropped or demoted to an atomic node",
+        )
+        self.assertEqual(
+            constants["constant_0"].constant,
+            2,
+            msg="The reconstructed constant should carry the original value",
+        )
+
+        original = fr.tools.run_recipe(double_via_constant.flowrep_recipe, x=3)
+        converted = fr.tools.run_recipe(reconstructed, x=3)
+        self.assertEqual(
+            original.output_ports["doubled"].value,
+            converted.output_ports["doubled"].value,
+            msg="The reconstructed recipe should compute what the original does",
+        )
+
     def test_round_trip_from_knowledge_graph(self):
         graph = get_knowledge_graph(my_workflow.flowrep_recipe)
         reconstructed = kg2recipe(graph)
@@ -53,6 +104,48 @@ class TestKgToFlowrep(unittest.TestCase):
         self.assertEqual(
             original_result.output_ports["result"].value,
             converted_result.output_ports["result"].value,
+        )
+
+    def test_round_trip_with_a_container_constant(self):
+        graph = get_knowledge_graph(pick_from_constant_list.flowrep_recipe)
+        # Serialize and reparse: an in-memory rdflib Literal secretly keeps the
+        # original Python object, so only a persisted graph proves the value
+        # actually survives as RDF.
+        graph = Graph().parse(data=graph.serialize(format="turtle"), format="turtle")
+        reconstructed = kg2recipe(graph)
+
+        (constant,) = [
+            node
+            for node in reconstructed.nodes.values()
+            if isinstance(node, fr.schemas.ConstantRecipe)
+        ]
+        self.assertEqual(
+            constant.constant,
+            [10, 20, 30],
+            msg="A JSONable container constant should come back as the container "
+            "itself, not as its string repr",
+        )
+
+        original = fr.tools.run_recipe(pick_from_constant_list.flowrep_recipe, i=1)
+        converted = fr.tools.run_recipe(reconstructed, i=1)
+        self.assertEqual(
+            original.output_ports["chosen"].value,
+            converted.output_ports["chosen"].value,
+        )
+
+    def test_round_trip_with_a_none_constant(self):
+        graph = get_knowledge_graph(compare_to_constant_none.flowrep_recipe)
+        graph = Graph().parse(data=graph.serialize(format="turtle"), format="turtle")
+        reconstructed = kg2recipe(graph)
+
+        (constant,) = [
+            node
+            for node in reconstructed.nodes.values()
+            if isinstance(node, fr.schemas.ConstantRecipe)
+        ]
+        self.assertIsNone(
+            constant.constant,
+            msg="A None constant should come back as None, not the string 'None'",
         )
 
     def test_requires_disambiguation_for_multiple_workflows(self):

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -451,6 +451,23 @@ def workflow_with_constant(x):
     return doubled
 
 
+@fr.workflow
+def workflow_with_two_identical_constants(x):
+    doubled = fr.std.mul(2, x)
+    shifted = fr.std.add(2, doubled)
+    return shifted
+
+
+def tag(text: str, body: str) -> str:
+    return text + body
+
+
+@fr.workflow
+def workflow_with_markup_constant(body):
+    tagged = tag("<b> & </b>", body)
+    return tagged
+
+
 class TestOntology(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -765,11 +782,41 @@ class TestOntology(unittest.TestCase):
             dot.source,
             msg="The constant node itself should still be drawn",
         )
-        self.assertNotIn(
+        self.assertIn(
             "<U>2</U>",
             dot.source,
-            msg="The constant's value is a literal, not a class, so it should not "
-            "become a node of its own",
+            msg="The constant's value should be drawn in its own box, the way a "
+            "function node draws the function it concretizes",
+        )
+        self.assertIn(
+            "pmdco:has_value",
+            dot.source,
+            msg="The edge to the value box should be labelled like the other "
+            "renamed predicates, not by its bare PMD number",
+        )
+
+    def test_visualize_draws_one_value_box_per_constant_node(self):
+        g = onto.get_knowledge_graph(
+            workflow_with_two_identical_constants.flowrep_recipe
+        )
+        dot = visualize_recipe(g)
+
+        self.assertEqual(
+            dot.source.count("<U>2</U>"),
+            2,
+            msg="Two constant nodes that happen to hold the same value are one "
+            "RDF literal but two workflow nodes, so they need two boxes",
+        )
+
+    def test_visualize_escapes_constant_values(self):
+        g = onto.get_knowledge_graph(workflow_with_markup_constant.flowrep_recipe)
+        dot = visualize_recipe(g)
+
+        self.assertIn(
+            "&lt;b&gt; &amp; &lt;/b&gt;",
+            dot.source,
+            msg="Constant values are drawn inside an HTML-like label, so markup "
+            "in them must be escaped or the label is malformed",
         )
 
     def test_docstring(self):

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -9,7 +9,7 @@ from typing import Annotated
 
 import flowrep as fr
 from pyshacl import validate
-from rdflib import OWL, RDF, RDFS, SH, Graph, Literal, Namespace, compare
+from rdflib import OWL, RDF, RDFS, SH, XSD, Graph, Literal, Namespace, compare
 from rdflib.compare import graph_diff
 
 from semantikon import kg_to_flowrep as kgf
@@ -445,6 +445,12 @@ def passthrough_input_workflow(x):
     return x
 
 
+@fr.workflow
+def workflow_with_constant(x):
+    doubled = fr.std.mul(2, x)
+    return doubled
+
+
 class TestOntology(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -750,6 +756,22 @@ class TestOntology(unittest.TestCase):
 
         self.assertIsInstance(visualize_recipe(g), Digraph)
 
+    def test_visualize_with_constant(self):
+        g = onto.get_knowledge_graph(workflow_with_constant.flowrep_recipe)
+        dot = visualize_recipe(g)
+
+        self.assertIn(
+            "workflow_with_constant-constant_0",
+            dot.source,
+            msg="The constant node itself should still be drawn",
+        )
+        self.assertNotIn(
+            "<U>2</U>",
+            dot.source,
+            msg="The constant's value is a literal, not a class, so it should not "
+            "become a node of its own",
+        )
+
     def test_docstring(self):
         g = onto.get_knowledge_graph(my_kinetic_energy_workflow.flowrep_recipe)
         bnode = list(g.subjects(RDF.type, onto.SNS.textual_entity))
@@ -995,6 +1017,36 @@ class TestOntology(unittest.TestCase):
         graph = onto.function_to_knowledge_graph(get_speed)
         with self.assertRaisesRegex(ValueError, "is not present in the graph"):
             _ = kgf._graph_to_function(graph, EX.missing_function)
+
+    def test_constant_literals_survive_serialization(self):
+        for value in (2, 1.5, "two", True, False, None, [10, 20, 30], {"a": [1, None]}):
+            with self.subTest(value=value):
+                literal = onto._constant_to_literal(value)
+                graph = Graph()
+                graph.add((EX.subject, EX.predicate, literal))
+                reparsed = Graph().parse(
+                    data=graph.serialize(format="turtle"), format="turtle"
+                )
+                (reloaded,) = reparsed.objects()
+                self.assertEqual(
+                    onto._literal_to_constant(reloaded),
+                    value,
+                    msg=f"{value!r} should round trip through serialized RDF",
+                )
+
+    def test_constant_scalars_keep_their_xsd_types(self):
+        for value, datatype in (
+            (2, XSD.integer),
+            (1.5, XSD.double),
+            (True, XSD.boolean),
+        ):
+            with self.subTest(value=value):
+                self.assertEqual(
+                    onto._constant_to_literal(value).datatype,
+                    datatype,
+                    msg="Scalar constants should stay queryable as typed literals "
+                    "rather than being flattened into JSON strings",
+                )
 
     def test_unhashable(self):
         uh = Unhashable()


### PR DESCRIPTION
Parses flowrep constant nodes into both the A-box and T-box in analogy to how existing nodes treat function references. In contrast to the `rdflib.URIRef` function reference, the new constant reference uses `rdflib.Literal`. Then this is propagated through so the resulting recipes still round-trip, and things still visualize pleasantly.

**On main:**

```python
import flowrep as fr
import semantikon

@fr.atomic
def two():
    return 2

@fr.workflow
def wf_main(x):
    scalar_two = two()
    doubled = fr.std.mul(scalar_two, x)
    return doubled

kg_main = semantikon.get_knowledge_graph(wf_main.flowrep_recipe)
semantikon.visualize_recipe(kg_main)
```

<img width="2251" height="823" alt="atomic_output" src="https://github.com/user-attachments/assets/246a9bce-e657-4643-a065-51cef0b54934" />

**Here:**

```python
@fr.workflow
def wf(x):
    doubled = fr.std.mul(2, x)
    return doubled

kg = semantikon.get_knowledge_graph(wf.flowrep_recipe)
semantikon.visualize_recipe(kg)
```

You can see in the visualization that new constant node behaves just like the existing nodes, but instead of "concretizes" for a function reference, it "has_value" of a literal


<img width="1923" height="704" alt="constant_output" src="https://github.com/user-attachments/assets/f9ce2e19-beff-4940-b105-770e78640826" />

The resulting KG round-trips back to the original recipe

```python
>>> round_trip_recipe = semantikon.kg2recipe(kg)
>>> print(round_trip_recipe.model_dump_json(indent=2))
{
  "type": "workflow",
  "inputs": [
    "x"
  ],
  "outputs": [
    "doubled"
  ],
  "description": null,
  "nodes": {
    "mul_0": {
      "type": "atomic",
      "inputs": [
        "a",
        "b"
      ],
      "outputs": [
        "product"
      ],
      "description": null,
      "reference": {
        "info": {
          "module": "flowrep.std",
          "qualname": "mul",
          "version": null
        },
        "inputs_with_defaults": [],
        "restricted_input_kinds": {
          "a": "POSITIONAL_ONLY",
          "b": "POSITIONAL_ONLY"
        }
      }
    },
    "constant_0": {
      "type": "constant",
      "inputs": [],
      "outputs": [
        "constant"
      ],
      "description": null,
      "constant": 2
    }
  },
  "input_edges": {
    "mul_0.b": "x"
  },
  "edges": {
    "mul_0.a": "constant_0.constant"
  },
  "output_edges": {
    "doubled": "mul_0.product"
  },
  "reference": {
    "info": {
      "module": "__main__",
      "qualname": "wf",
      "version": null
    },
    "inputs_with_defaults": [],
    "restricted_input_kinds": {}
  }
}

```

Where round-tripped recipes retain their functionality

```python
print(round_trip_recipe(x=3))
>>> 3
```

And the KG keeps the constant information in both the A-box

```python
from semantikon.ontology import SNS

# A-box — every value that flowed on a port. Includes the constant's output
# port AND the inlined copy on the consumer's input port.
res = kg.query(f"""
  SELECT ?port ?value WHERE {{
      ?port <{SNS.has_participant}> ?data .
      ?data <{SNS.has_value}> ?value .
  }}
""")
print(res.serialize(format="txt").decode())
```

```
                                            port                                            |                     value                     
---------------------------------------------------------------------------------------------------------------------------------------------
<http://pyiron.org/ontology/aa642a653eae052d9288d31df181105e_wf-constant_0-outputs-constant>|"2"^^<http://www.w3.org/2001/XMLSchema#integer>
<http://pyiron.org/ontology/aa642a653eae052d9288d31df181105e_wf-mul_0-inputs-a>             |"2"^^<http://www.w3.org/2001/XMLSchema#integer>
```

And the T-box

```python
# T-box — constants only, straight off the node class (added by this patch)
res = kg.query(f"""
  SELECT ?node ?value WHERE {{
      ?node rdfs:subClassOf ?r .
      ?r a owl:Restriction ;
         owl:onProperty <{SNS.has_value}> ;
         owl:hasValue ?value .
  }}
""")
print(res.serialize(format="txt").decode())
```

```
                        node                        |                     value                     
-----------------------------------------------------------------------------------------------------
<http://pyiron.org/ontology/Waa642a65_wf-constant_0>|"2"^^<http://www.w3.org/2001/XMLSchema#integer>
```


I'm not fully confident I haven't overlooked something, but I find it very reassuring the way the new constant node slots into the KG just like the more verbose no-input-static-return atomic node would.

Closes #507 
