### PR TITLE
Use data classes for SemantikonDiGraph

### DIFF
--- a/semantikon/analysis.py
+++ b/semantikon/analysis.py
@@ -16,7 +16,7 @@ from rdflib.query import ResultRow
 
 from semantikon.converter import to_identifier
 from semantikon.flowrep_dict import dict_to_nodedata
-from semantikon.flowrep_to_networkx import IO, Input, Node, Output
+from semantikon.flowrep_to_networkx import Input, Node, Output
 from semantikon.ontology import SNS, serialize_and_convert_to_networkx
 
 

--- a/semantikon/analysis.py
+++ b/semantikon/analysis.py
@@ -16,6 +16,7 @@ from rdflib.query import ResultRow
 
 from semantikon.converter import to_identifier
 from semantikon.flowrep_dict import dict_to_nodedata
+from semantikon.flowrep_to_networkx import IO, Input, Node, Output
 from semantikon.ontology import SNS, serialize_and_convert_to_networkx
 
 
@@ -100,18 +101,30 @@ def request_values(
     hashes: set[str] = set()
 
     for node, data in G.nodes.data():
-        if data.get("step") == "node":
+        if isinstance(node, Node):
             continue
         if "hash" in data and "value" not in data:
             node_hash = data["hash"]
             hashes.add(node_hash)
-            keys = node.split("-")[1:]
-            hash_nodes.append(
-                {
-                    "hash": node_hash,
-                    "keys": keys,
-                }
-            )
+            # Extract keys based on node type
+            if isinstance(node, (Input, Output)):
+                io_type = "inputs" if isinstance(node, Input) else "outputs"
+                node_obj = node.node  # This is a Node object
+
+                # Build keys based on node hierarchy
+                if node_obj.parent is None:
+                    # Top-level IO
+                    keys = [io_type, node.arg]
+                else:
+                    # Nested IO - use the immediate child name
+                    keys = [node_obj.name, io_type, node.arg]
+
+                hash_nodes.append(
+                    {
+                        "hash": node_hash,
+                        "keys": keys,
+                    }
+                )
 
     # If there are no hashes to resolve, return early.
     if not hashes:

--- a/semantikon/analysis.py
+++ b/semantikon/analysis.py
@@ -114,10 +114,10 @@ def request_values(
                 # Build keys based on node hierarchy
                 if node_obj.parent is None:
                     # Top-level IO
-                    keys = [io_type, node.arg]
+                    keys = [io_type, node.port]
                 else:
                     # Nested IO - use the immediate child name
-                    keys = [node_obj.name, io_type, node.arg]
+                    keys = [node_obj.name, io_type, node.port]
 
                 hash_nodes.append(
                     {

--- a/semantikon/cwl.py
+++ b/semantikon/cwl.py
@@ -72,9 +72,11 @@ def _add_node(
     """
     if prefix is None:
         prefix = wf.id.split("/")[-1].replace(".cwl", "")
+        parent = Node(name=prefix)
+    else:
+        parent = prefix
     if G is None:
         G = ontology.SemantikonDiGraph(prefix=prefix)
-    parent = Node(name=prefix)
 
     for position, inp in enumerate(wf.inputs):
         inp_node = Input(node=parent, port=_get_name(inp.id))
@@ -102,8 +104,8 @@ def _add_node(
                 source = Output(node=Node(parent=parent, name=n), port=p)
             else:
                 source = Input(node=parent, port=s)
-            dest = Input(node=node, port=_get_name(inp.id).split("/")[-1])
-            assert source in G.nodes
+            n, p = _get_name(inp.id).split("/")
+            dest = Input(node=Node(parent=parent, name=n), port=p)
             G.add_edge(source, dest)
             G.add_edge(dest, node)
         for out in step.out:

--- a/semantikon/cwl.py
+++ b/semantikon/cwl.py
@@ -113,7 +113,6 @@ def _add_node(
                 G.add_edge(node, Output(node=node, port=out_name))
         G = _add_node(run_doc, G, prefix=node)
 
-
     for out in wf.outputs:
         n, p = _get_name(out.outputSource).split("/")
         G.add_edge(

--- a/semantikon/cwl.py
+++ b/semantikon/cwl.py
@@ -111,7 +111,7 @@ def _add_node(
         for out in step.out:
             out_name = _get_name(out)
             if "/" in out_name:
-                n, p = out_name.split("/") 
+                n, p = out_name.split("/")
                 dest = Output(node=Node(parent=parent, name=n), port=p)
             else:
                 dest = Output(node=Node(name=node), port=out_name)

--- a/semantikon/cwl.py
+++ b/semantikon/cwl.py
@@ -10,6 +10,7 @@ except ModuleNotFoundError as exc:  # pragma: no cover
     ) from exc
 
 from semantikon import ontology
+from semantikon.flowrep_to_networkx import Input, Node, Output
 
 
 def serialize_and_convert_to_networkx(uri: str | Path) -> ontology.SemantikonDiGraph:
@@ -45,6 +46,25 @@ def _get_name(tag: str) -> str:
     return tag.split("#")[-1]
 
 
+def _to_node(node_str: str) -> Node | Input | Output:
+    """Convert a compound node name to the appropriate dataclass key.
+
+    Args:
+        node_str (str): A node name string, e.g. ``"prefix-inputs-port"`` or
+            ``"prefix-outputs-port"`` or ``"prefix-step"``.
+
+    Returns:
+        Node | Input | Output: The corresponding dataclass instance.
+    """
+    if "-inputs-" in node_str:
+        node_part, port_part = node_str.split("-inputs-", 1)
+        return Input(node=node_part, port=port_part)
+    elif "-outputs-" in node_str:
+        node_part, port_part = node_str.split("-outputs-", 1)
+        return Output(node=node_part, port=port_part)
+    return Node(name=node_str)
+
+
 def _add_node(
     wf: parser.CommandLineTool | parser.Workflow,
     G: ontology.SemantikonDiGraph | None = None,
@@ -75,21 +95,14 @@ def _add_node(
         G = ontology.SemantikonDiGraph(prefix=prefix)
 
     for position, inp in enumerate(wf.inputs):
-        metadata: dict[str, str | int] = {
-            "step": "inputs",
-            "arg": _get_name(inp.id),
-            "position": position,
-        }
+        inp_node = Input(node=prefix, port=_get_name(inp.id))
+        inp_position = position
         if inp.inputBinding is not None and inp.inputBinding.position is not None:
-            metadata["position"] = inp.inputBinding.position
-        G.add_node(f"{prefix}-inputs-{_get_name(inp.id)}", **metadata)
+            inp_position = inp.inputBinding.position
+        G.add_node(inp_node, step="inputs", position=inp_position)
     for position, out in enumerate(wf.outputs):
-        metadata = {
-            "step": "outputs",
-            "arg": _get_name(out.id),
-            "position": position,
-        }
-        G.add_node(f"{prefix}-outputs-{_get_name(out.id)}", **metadata)
+        out_node = Output(node=prefix, port=_get_name(out.id))
+        G.add_node(out_node, step="outputs", position=position)
 
     if isinstance(wf, parser.CommandLineTool):
         return G
@@ -98,7 +111,7 @@ def _add_node(
         node_name = f"{prefix}-{_get_name(step.id)}"
         run_doc = parser.load_document_by_uri(step.run)
         node_type = "workflow" if isinstance(run_doc, parser.Workflow) else "atomic"
-        G.add_node(node_name, step="node", type=node_type)
+        G.add_node(Node(name=node_name), type=node_type, step="node")
         for inp in step.in_:
             source = _get_name(inp.source)
             source = (
@@ -107,17 +120,19 @@ def _add_node(
                 else f"inputs-{source}"
             )
             dest = f"{prefix}-{_get_name(inp.id).replace('/', '-inputs-')}"
-            G.add_edge(f"{prefix}-{source}", dest)
-            G.add_edge(dest, node_name)
+            G.add_edge(_to_node(f"{prefix}-{source}"), _to_node(dest))
+            G.add_edge(_to_node(dest), Node(name=node_name))
         for out in step.out:
             out_name = _get_name(out)
             if "/" in out_name:
                 out_name = out_name.split("/")[-1]
-            G.add_edge(node_name, f"{node_name}-outputs-{out_name}")
+            G.add_edge(Node(name=node_name), Output(node=node_name, port=out_name))
         G = _add_node(run_doc, G, prefix=node_name)
     for out in wf.outputs:
         G.add_edge(
-            f"{prefix}-{_get_name(out.outputSource.replace('/', '-outputs-'))}",
-            f"{prefix}-outputs-{_get_name(out.id)}",
+            _to_node(
+                f"{prefix}-{_get_name(out.outputSource.replace('/', '-outputs-'))}"
+            ),
+            Output(node=prefix, port=_get_name(out.id)),
         )
     return G

--- a/semantikon/cwl.py
+++ b/semantikon/cwl.py
@@ -10,7 +10,7 @@ except ModuleNotFoundError as exc:  # pragma: no cover
     ) from exc
 
 from semantikon import ontology
-from semantikon.flowrep_to_networkx import IO, Input, Node, Output
+from semantikon.flowrep_to_networkx import Input, Node, Output
 
 
 def serialize_and_convert_to_networkx(uri: str | Path) -> ontology.SemantikonDiGraph:

--- a/semantikon/cwl.py
+++ b/semantikon/cwl.py
@@ -58,10 +58,10 @@ def _to_node(node_str: str) -> Node | Input | Output:
     """
     if "-inputs-" in node_str:
         node_part, port_part = node_str.split("-inputs-", 1)
-        return Input(node=node_part, port=port_part)
+        return Input(node=Node(name=node_part), port=port_part)
     elif "-outputs-" in node_str:
         node_part, port_part = node_str.split("-outputs-", 1)
-        return Output(node=node_part, port=port_part)
+        return Output(node=Node(name=node_part), port=port_part)
     return Node(name=node_str)
 
 
@@ -95,13 +95,13 @@ def _add_node(
         G = ontology.SemantikonDiGraph(prefix=prefix)
 
     for position, inp in enumerate(wf.inputs):
-        inp_node = Input(node=prefix, port=_get_name(inp.id))
+        inp_node = Input(node=Node(name=prefix), port=_get_name(inp.id))
         inp_position = position
         if inp.inputBinding is not None and inp.inputBinding.position is not None:
             inp_position = inp.inputBinding.position
         G.add_node(inp_node, step="inputs", position=inp_position)
     for position, out in enumerate(wf.outputs):
-        out_node = Output(node=prefix, port=_get_name(out.id))
+        out_node = Output(node=Node(name=prefix), port=_get_name(out.id))
         G.add_node(out_node, step="outputs", position=position)
 
     if isinstance(wf, parser.CommandLineTool):
@@ -126,13 +126,13 @@ def _add_node(
             out_name = _get_name(out)
             if "/" in out_name:
                 out_name = out_name.split("/")[-1]
-            G.add_edge(Node(name=node_name), Output(node=node_name, port=out_name))
+            G.add_edge(Node(name=node_name), Output(node=Node(name=node_name), port=out_name))
         G = _add_node(run_doc, G, prefix=node_name)
     for out in wf.outputs:
         G.add_edge(
             _to_node(
                 f"{prefix}-{_get_name(out.outputSource.replace('/', '-outputs-'))}"
             ),
-            Output(node=prefix, port=_get_name(out.id)),
+            Output(node=Node(name=prefix), port=_get_name(out.id)),
         )
     return G

--- a/semantikon/cwl.py
+++ b/semantikon/cwl.py
@@ -126,7 +126,9 @@ def _add_node(
             out_name = _get_name(out)
             if "/" in out_name:
                 out_name = out_name.split("/")[-1]
-            G.add_edge(Node(name=node_name), Output(node=Node(name=node_name), port=out_name))
+            G.add_edge(
+                Node(name=node_name), Output(node=Node(name=node_name), port=out_name)
+            )
         G = _add_node(run_doc, G, prefix=node_name)
     for out in wf.outputs:
         G.add_edge(

--- a/semantikon/cwl.py
+++ b/semantikon/cwl.py
@@ -112,10 +112,12 @@ def _add_node(
             else:
                 G.add_edge(node, Output(node=node, port=out_name))
         G = _add_node(run_doc, G, prefix=node)
+
+
 for out in wf.outputs:
     n, p = _get_name(out.outputSource).split("/")
     G.add_edge(
-            Output(node=Node(parent=prefix, name=n), port=p),
-            Output(node=prefix, port=_get_name(out.id)),
-        )
+        Output(node=Node(parent=prefix, name=n), port=p),
+        Output(node=prefix, port=_get_name(out.id)),
+    )
     return G

--- a/semantikon/cwl.py
+++ b/semantikon/cwl.py
@@ -112,10 +112,9 @@ def _add_node(
             else:
                 G.add_edge(node, Output(node=node, port=out_name))
         G = _add_node(run_doc, G, prefix=node)
-    for out in wf.outputs:
-        node = Node(parent=prefix, name=_get_name(out.id))
-        n, p = _get_name(out.outputSource).split("/")
-        G.add_edge(
+for out in wf.outputs:
+    n, p = _get_name(out.outputSource).split("/")
+    G.add_edge(
             Output(node=Node(parent=prefix, name=n), port=p),
             Output(node=prefix, port=_get_name(out.id)),
         )

--- a/semantikon/cwl.py
+++ b/semantikon/cwl.py
@@ -103,6 +103,7 @@ def _add_node(
             else:
                 source = Input(node=parent, port=s)
             dest = Input(node=node, port=_get_name(inp.id).split("/")[-1])
+            assert source in G.nodes
             G.add_edge(source, dest)
             G.add_edge(dest, node)
         for out in step.out:

--- a/semantikon/cwl.py
+++ b/semantikon/cwl.py
@@ -114,10 +114,10 @@ def _add_node(
         G = _add_node(run_doc, G, prefix=node)
 
 
-for out in wf.outputs:
-    n, p = _get_name(out.outputSource).split("/")
-    G.add_edge(
-        Output(node=Node(parent=prefix, name=n), port=p),
-        Output(node=prefix, port=_get_name(out.id)),
-    )
+    for out in wf.outputs:
+        n, p = _get_name(out.outputSource).split("/")
+        G.add_edge(
+            Output(node=Node(parent=prefix, name=n), port=p),
+            Output(node=prefix, port=_get_name(out.id)),
+        )
     return G

--- a/semantikon/cwl.py
+++ b/semantikon/cwl.py
@@ -10,7 +10,7 @@ except ModuleNotFoundError as exc:  # pragma: no cover
     ) from exc
 
 from semantikon import ontology
-from semantikon.flowrep_to_networkx import Input, Node, Output
+from semantikon.flowrep_to_networkx import IO, Input, Node, Output
 
 
 def serialize_and_convert_to_networkx(uri: str | Path) -> ontology.SemantikonDiGraph:
@@ -49,7 +49,7 @@ def _get_name(tag: str) -> str:
 def _add_node(
     wf: parser.CommandLineTool | parser.Workflow,
     G: ontology.SemantikonDiGraph | None = None,
-    prefix: str | None = None,
+    prefix: Node | None = None,
 ) -> ontology.SemantikonDiGraph:
     """
     Recursively add nodes and edges for a CWL process to the knowledge graph.
@@ -71,57 +71,52 @@ def _add_node(
         ontology.SemantikonDiGraph: The populated knowledge graph.
     """
     if prefix is None:
-        prefix = wf.id.split("/")[-1].replace(".cwl", "")
-        parent = Node(name=prefix)
-    else:
-        parent = prefix
+        prefix = Node(name=wf.id.split("/")[-1].replace(".cwl", ""))
     if G is None:
-        G = ontology.SemantikonDiGraph(prefix=prefix)
+        G = ontology.SemantikonDiGraph(prefix=str(prefix))
 
     for position, inp in enumerate(wf.inputs):
-        inp_node = Input(node=parent, port=_get_name(inp.id))
+        inp_node = Input(node=prefix, port=_get_name(inp.id))
         inp_position = position
         if inp.inputBinding is not None and inp.inputBinding.position is not None:
             inp_position = inp.inputBinding.position
         G.add_node(inp_node, position=inp_position)
 
     for position, out in enumerate(wf.outputs):
-        out_node = Output(node=parent, port=_get_name(out.id))
+        out_node = Output(node=prefix, port=_get_name(out.id))
         G.add_node(out_node, position=position)
 
     if isinstance(wf, parser.CommandLineTool):
         return G
 
     for step in wf.steps:
-        node = Node(parent=parent, name=_get_name(step.id))
+        node = Node(parent=prefix, name=_get_name(step.id))
         run_doc = parser.load_document_by_uri(step.run)
         node_type = "workflow" if isinstance(run_doc, parser.Workflow) else "atomic"
         G.add_node(node, type=node_type)
         for inp in step.in_:
+            n, p = _get_name(inp.id).split("/")
+            dest = Input(node=Node(parent=prefix, name=n), port=p)
             s = _get_name(inp.source)
             if "/" in s:
                 n, p = s.split("/")
-                source = Output(node=Node(parent=parent, name=n), port=p)
+                G.add_edge(Output(node=Node(parent=prefix, name=n), port=p), dest)
             else:
-                source = Input(node=parent, port=s)
-            n, p = _get_name(inp.id).split("/")
-            dest = Input(node=Node(parent=parent, name=n), port=p)
-            G.add_edge(source, dest)
+                G.add_edge(Input(node=prefix, port=s), dest)
             G.add_edge(dest, node)
         for out in step.out:
             out_name = _get_name(out)
             if "/" in out_name:
                 n, p = out_name.split("/")
-                dest = Output(node=Node(parent=parent, name=n), port=p)
+                G.add_edge(node, Output(node=Node(parent=prefix, name=n), port=p))
             else:
-                dest = Output(node=Node(name=node), port=out_name)
-            G.add_edge(node, dest)
+                G.add_edge(node, Output(node=node, port=out_name))
         G = _add_node(run_doc, G, prefix=node)
     for out in wf.outputs:
-        node = Node(parent=parent, name=_get_name(out.id))
+        node = Node(parent=prefix, name=_get_name(out.id))
         n, p = _get_name(out.outputSource).split("/")
         G.add_edge(
-            Output(node=Node(parent=parent, name=n), port=p),
-            Output(node=parent, port=_get_name(out.id)),
+            Output(node=Node(parent=prefix, name=n), port=p),
+            Output(node=prefix, port=_get_name(out.id)),
         )
     return G

--- a/semantikon/cwl.py
+++ b/semantikon/cwl.py
@@ -46,25 +46,6 @@ def _get_name(tag: str) -> str:
     return tag.split("#")[-1]
 
 
-def _to_node(node_str: str) -> Node | Input | Output:
-    """Convert a compound node name to the appropriate dataclass key.
-
-    Args:
-        node_str (str): A node name string, e.g. ``"prefix-inputs-port"`` or
-            ``"prefix-outputs-port"`` or ``"prefix-step"``.
-
-    Returns:
-        Node | Input | Output: The corresponding dataclass instance.
-    """
-    if "-inputs-" in node_str:
-        node_part, port_part = node_str.split("-inputs-", 1)
-        return Input(node=Node(name=node_part), port=port_part)
-    elif "-outputs-" in node_str:
-        node_part, port_part = node_str.split("-outputs-", 1)
-        return Output(node=Node(name=node_part), port=port_part)
-    return Node(name=node_str)
-
-
 def _add_node(
     wf: parser.CommandLineTool | parser.Workflow,
     G: ontology.SemantikonDiGraph | None = None,
@@ -93,48 +74,51 @@ def _add_node(
         prefix = wf.id.split("/")[-1].replace(".cwl", "")
     if G is None:
         G = ontology.SemantikonDiGraph(prefix=prefix)
+    parent = Node(name=prefix)
 
     for position, inp in enumerate(wf.inputs):
-        inp_node = Input(node=Node(name=prefix), port=_get_name(inp.id))
+        inp_node = Input(node=parent, port=_get_name(inp.id))
         inp_position = position
         if inp.inputBinding is not None and inp.inputBinding.position is not None:
             inp_position = inp.inputBinding.position
-        G.add_node(inp_node, step="inputs", position=inp_position)
+        G.add_node(inp_node, position=inp_position)
+
     for position, out in enumerate(wf.outputs):
-        out_node = Output(node=Node(name=prefix), port=_get_name(out.id))
-        G.add_node(out_node, step="outputs", position=position)
+        out_node = Output(node=parent, port=_get_name(out.id))
+        G.add_node(out_node, position=position)
 
     if isinstance(wf, parser.CommandLineTool):
         return G
 
     for step in wf.steps:
-        node_name = f"{prefix}-{_get_name(step.id)}"
+        node = Node(parent=parent, name=_get_name(step.id))
         run_doc = parser.load_document_by_uri(step.run)
         node_type = "workflow" if isinstance(run_doc, parser.Workflow) else "atomic"
-        G.add_node(Node(name=node_name), type=node_type, step="node")
+        G.add_node(node, type=node_type)
         for inp in step.in_:
-            source = _get_name(inp.source)
-            source = (
-                source.replace("/", "-outputs-")
-                if "/" in source
-                else f"inputs-{source}"
-            )
-            dest = f"{prefix}-{_get_name(inp.id).replace('/', '-inputs-')}"
-            G.add_edge(_to_node(f"{prefix}-{source}"), _to_node(dest))
-            G.add_edge(_to_node(dest), Node(name=node_name))
+            s = _get_name(inp.source)
+            if "/" in s:
+                n, p = s.split("/")
+                source = Output(node=Node(parent=parent, name=n), port=p)
+            else:
+                source = Input(node=parent, port=s)
+            dest = Input(node=node, port=_get_name(inp.id).split("/")[-1])
+            G.add_edge(source, dest)
+            G.add_edge(dest, node)
         for out in step.out:
             out_name = _get_name(out)
             if "/" in out_name:
-                out_name = out_name.split("/")[-1]
-            G.add_edge(
-                Node(name=node_name), Output(node=Node(name=node_name), port=out_name)
-            )
-        G = _add_node(run_doc, G, prefix=node_name)
+                n, p = out_name.split("/") 
+                dest = Output(node=Node(parent=parent, name=n), port=p)
+            else:
+                dest = Output(node=Node(name=node), port=out_name)
+            G.add_edge(node, dest)
+        G = _add_node(run_doc, G, prefix=node)
     for out in wf.outputs:
+        node = Node(parent=parent, name=_get_name(out.id))
+        n, p = _get_name(out.outputSource).split("/")
         G.add_edge(
-            _to_node(
-                f"{prefix}-{_get_name(out.outputSource.replace('/', '-outputs-'))}"
-            ),
-            Output(node=Node(name=prefix), port=_get_name(out.id)),
+            Output(node=Node(parent=parent, name=n), port=p),
+            Output(node=parent, port=_get_name(out.id)),
         )
     return G

--- a/semantikon/flowrep_to_networkx.py
+++ b/semantikon/flowrep_to_networkx.py
@@ -24,6 +24,36 @@ from semantikon.flowrep_dict import (
 
 
 @dataclass(frozen=True, slots=True)
+class Node:
+    name: str
+    parent: str | None = None
+
+    def __str__(self) -> str:
+        if self.parent:
+            return f"{self.parent}-{self.name}"
+        else:
+            return self.name
+
+
+@dataclass(frozen=True, slots=True)
+class IO:
+    node: str
+    arg: str
+
+
+@dataclass(frozen=True, slots=True)
+class Input(IO):
+    def __str__(self) -> str:
+        return f"{self.node}-inputs-{self.arg}"
+
+
+@dataclass(frozen=True, slots=True)
+class Output(IO):
+    def __str__(self) -> str:
+        return f"{self.node}-outputs-{self.arg}"
+
+
+@dataclass(frozen=True, slots=True)
 class TNodeData:
     type: str
     step: str
@@ -292,7 +322,7 @@ def _workflow_to_networkx(
 
     def _add_node(
         node_data: fr.schemas.NodeData,
-        node_name: str,
+        node_name: Node,
         *,
         parent_name: str | None = None,
         workflow_label: str | None = None,
@@ -334,7 +364,7 @@ def _workflow_to_networkx(
             output_labels = ["output"]
 
         for position, (label, port) in enumerate(node_data.input_ports.items()):
-            io_name = f"{node_name}-inputs-{label}"
+            io_name = Input(node=str(node_name), arg=label)
             io_data: dict[str, Any] = {
                 "step": "inputs",
                 "arg": label,
@@ -352,7 +382,7 @@ def _workflow_to_networkx(
             G.add_edge(io_name, node_name)
         for position, (raw_label, port) in enumerate(node_data.output_ports.items()):
             label = output_labels[position] if raw_label == "output_0" else raw_label
-            io_name = f"{node_name}-outputs-{label}"
+            io_name = Output(node=str(node_name), arg=label)
             io_data = {
                 "step": "outputs",
                 "arg": label,
@@ -372,7 +402,7 @@ def _workflow_to_networkx(
 
         recipe = node_data.recipe
         for child_label, child in node_data.nodes.items():
-            child_name = f"{node_name}-{child_label}"
+            child_name = Node(name=child_label, parent=node_name)
             _add_node(
                 child,
                 child_name,
@@ -385,32 +415,32 @@ def _workflow_to_networkx(
         child_recipes = recipe.nodes
         for target, source in recipe.input_edges.items():
             G.add_edge(
-                f"{node_name}-inputs-{source.port}",
-                f"{node_name}-{target.node}-inputs-{target.port}",
+                Input(node=str(node_name), arg=source.port),
+                Input(node=f"{node_name}-{target.node}", arg=target.port)
             )
         for target, source in recipe.edges.items():
             child_outputs = list(child_recipes[source.node].outputs)
             src_port = _output_port_label(source.port, child_outputs)
             G.add_edge(
-                f"{node_name}-{source.node}-outputs-{src_port}",
-                f"{node_name}-{target.node}-inputs-{target.port}",
+                Output(node=f"{node_name}-{source.node}", arg=src_port),
+                Input(node=f"{node_name}-{target.node}", arg=target.port)
             )
         for target, source in recipe.output_edges.items():
             target_port = _output_port_label(target.port, list(recipe.outputs))
             if isinstance(source, fr.schemas.InputSource):
                 G.add_edge(
-                    f"{node_name}-inputs-{source.port}",
-                    f"{node_name}-outputs-{target_port}",
+                    Input(node=str(node_name), arg=source.port),
+                    Output(node=str(node_name), arg=target_port)
                 )
             else:
                 child_outputs = list(child_recipes[source.node].outputs)
                 src_port = _output_port_label(source.port, child_outputs)
                 G.add_edge(
-                    f"{node_name}-{source.node}-outputs-{src_port}",
-                    f"{node_name}-outputs-{target_port}",
+                    Output(node=f"{node_name}-{source.node}", arg=src_port),
+                    Output(node=str(node_name), arg=target_port)
                 )
 
-    _add_node(workflow, root_label, workflow_label=root_label)
+    _add_node(workflow, Node(root_label), workflow_label=root_label)
     return G
 
 
@@ -432,7 +462,7 @@ def _get_hashed_node_dict_from_graph(G: SemantikonDiGraph) -> dict[str, dict[str
         hash_dict_tmp: dict[str, Any] = {
             "inputs": {},
             "outputs": [
-                G.nodes[out].get("label", out.split("-")[-1])
+                G.nodes[out].get("label", out.arg)
                 for out in G.successors(node)
             ],
             "node": copy.deepcopy(data.get("function")),
@@ -443,16 +473,15 @@ def _get_hashed_node_dict_from_graph(G: SemantikonDiGraph) -> dict[str, dict[str
         missing_input = False
         for inp in G.predecessors(node):
             inp_data = G.nodes[inp]
-            inp_name = inp.split("-")[-1]
             if "hash" in inp_data:
-                hash_dict_tmp["inputs"][inp_name] = inp_data["hash"]
-                hash_dict_tmp["node"]["connected_inputs"].append(inp_name)
+                hash_dict_tmp["inputs"][inp.arg] = inp_data["hash"]
+                hash_dict_tmp["node"]["connected_inputs"].append(inp.arg)
             elif "value" in inp_data or "default" in inp_data:
                 value = inp_data.get("value", inp_data.get("default"))
                 if is_dataclass(value) and not isinstance(value, type):
-                    hash_dict_tmp["inputs"][inp_name] = asdict(value)
+                    hash_dict_tmp["inputs"][inp.arg] = asdict(value)
                 else:
-                    hash_dict_tmp["inputs"][inp_name] = value
+                    hash_dict_tmp["inputs"][inp.arg] = value
             else:
                 missing_input = True
                 break
@@ -463,7 +492,7 @@ def _get_hashed_node_dict_from_graph(G: SemantikonDiGraph) -> dict[str, dict[str
         ).hexdigest()
         for out in G.successors(node):
             G.nodes[out]["hash"] = (
-                h + "@" + G.nodes[out].get("label", out.split("-")[-1])
+                h + "@" + G.nodes[out].get("label", out.arg)
             )
         hash_dict_tmp["hash"] = h
         hash_dict[node] = hash_dict_tmp

--- a/semantikon/flowrep_to_networkx.py
+++ b/semantikon/flowrep_to_networkx.py
@@ -176,9 +176,7 @@ class SemantikonDiGraph(nx.DiGraph):
         super().add_node(node_for_adding, **normalized_attr)
 
     def add_nodes_from(self, nodes_for_adding, **attr):
-        assert all(
-            isinstance(n, (Node, IO)) or isinstance(n, tuple) for n in nodes_for_adding
-        )
+        assert all(isinstance(n, (Node, IO, tuple)) for n in nodes_for_adding)
         for n in nodes_for_adding:
             if isinstance(n, tuple):
                 node, node_attr = n

--- a/semantikon/flowrep_to_networkx.py
+++ b/semantikon/flowrep_to_networkx.py
@@ -578,6 +578,8 @@ class _HashGraph:
                     attrs["value"] = G.nodes[node]["value"]
                 elif "default" in G.nodes[node]:
                     attrs["value"] = G.nodes[node]["default"]
+            if isinstance(node, IO):
+                attrs["arg"] = node.arg
             G_tmp.add_node(node, canon=self._canonical_json(attrs))
         for u, v in G.edges:
             G_tmp.add_edge(u, v)

--- a/semantikon/flowrep_to_networkx.py
+++ b/semantikon/flowrep_to_networkx.py
@@ -41,7 +41,7 @@ class Node:
 
 @dataclass(frozen=True, slots=True)
 class IO(ABC):
-    node: str
+    node: Node
     port: str
 
     def __radd__(self, other: str) -> str:
@@ -170,6 +170,8 @@ class SemantikonDiGraph(nx.DiGraph):
             )
             return output_meta.to_attrs()
 
+        raise TypeError(f"Unknown step type: {type(step)}")
+
     def add_node(self, node_for_adding, **attr):  # type: ignore[override]
         assert isinstance(node_for_adding, (Node, IO))
         normalized_attr = self._validate_semantikon_attrs(node_for_adding, attr)
@@ -297,7 +299,7 @@ def _workflow_to_networkx(
         node_data: fr.schemas.NodeData,
         node_name: Node,
         *,
-        parent_name: str | None = None,
+        parent_name: Node | None = None,
         workflow_label: Node | None = None,
     ):
         metadata: dict[str, Any] = {}
@@ -335,7 +337,7 @@ def _workflow_to_networkx(
             output_labels = ["output"]
 
         for position, (label, port) in enumerate(node_data.input_ports.items()):
-            io_name = Input(node=node_name, port=label)
+            inp_name = Input(node=node_name, port=label)
             io_data: dict[str, Any] = {"position": position}
             if not isinstance(port.value, fr.schemas.NotData):
                 io_data["value"] = port.value
@@ -345,11 +347,11 @@ def _workflow_to_networkx(
                 io_data.update(type_metadata.to_dictionary())
             if not isinstance(port.default, fr.schemas.NotData):
                 io_data["default"] = port.default
-            G.add_node(io_name, **io_data)
-            G.add_edge(io_name, node_name)
+            G.add_node(inp_name, **io_data)
+            G.add_edge(inp_name, node_name)
         for position, (raw_label, port) in enumerate(node_data.output_ports.items()):
             label = output_labels[position] if raw_label == "output_0" else raw_label
-            io_name = Output(node=node_name, port=label)
+            out_name = Output(node=node_name, port=label)
             io_data = {"position": position}
             if not isinstance(port.value, fr.schemas.NotData):
                 io_data["value"] = port.value
@@ -357,8 +359,8 @@ def _workflow_to_networkx(
                 io_data["dtype"] = type_hint
             if type_metadata := annotation_to_type_metadata(port.annotation):
                 io_data.update(type_metadata.to_dictionary())
-            G.add_node(io_name, **io_data)
-            G.add_edge(node_name, io_name)
+            G.add_node(out_name, **io_data)
+            G.add_edge(node_name, out_name)
 
         if not isinstance(node_data, fr.schemas.DagData):
             return

--- a/semantikon/flowrep_to_networkx.py
+++ b/semantikon/flowrep_to_networkx.py
@@ -67,7 +67,6 @@ class TNodeData:
     identifier: str | None = None
     label: str | None = None
     function: dict | None = None
-    parent: str | None = None
     extras: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
@@ -85,8 +84,6 @@ class TNodeData:
             attrs["label"] = self.label
         if self.function is not None:
             attrs["function"] = self.function
-        if self.parent is not None:
-            attrs["parent"] = self.parent
         attrs.update(self.extras)
         return attrs
 
@@ -148,14 +145,13 @@ class SemantikonDiGraph(nx.DiGraph):
 
         step = attrs["step"]
         if step == "node":
-            known = {"type", "step", "identifier", "label", "function", "parent"}
+            known = {"type", "step", "identifier", "label", "function"}
             node_meta = TNodeData(
                 type=attrs["type"],
                 step=step,
                 identifier=attrs.get("identifier"),
                 label=attrs.get("label"),
                 function=attrs.get("function"),
-                parent=attrs.get("parent"),
                 extras={k: v for k, v in attrs.items() if k not in known},
             )
             return node_meta.to_attrs()
@@ -362,8 +358,6 @@ def _workflow_to_networkx(
                 )
             )
             metadata["function"] = function_data
-        if parent_name is not None:
-            metadata["parent"] = parent_name
         G.add_node(node_name, **metadata)
 
         output_labels = list(node_data.output_ports)

--- a/semantikon/flowrep_to_networkx.py
+++ b/semantikon/flowrep_to_networkx.py
@@ -63,7 +63,6 @@ class Output(IO):
 @dataclass(frozen=True, slots=True)
 class TNodeData:
     type: str
-    step: str
     identifier: str | None = None
     label: str | None = None
     function: dict | None = None
@@ -76,7 +75,6 @@ class TNodeData:
     def to_attrs(self) -> dict[str, Any]:
         attrs: dict[str, Any] = {
             "type": self.type,
-            "step": self.step,
         }
         if self.identifier is not None:
             attrs["identifier"] = self.identifier
@@ -90,7 +88,6 @@ class TNodeData:
 
 @dataclass(frozen=True, slots=True)
 class TIOData:
-    arg: str
     position: int
     dtype: Any | None = None
     value: Any | None = None
@@ -99,7 +96,6 @@ class TIOData:
 
     def to_attrs(self) -> dict[str, Any]:
         attrs: dict[str, Any] = {
-            "arg": self.arg,
             "position": self.position,
         }
         if self.dtype is not None:
@@ -117,7 +113,6 @@ class TInputData(TIOData):
 
     def to_attrs(self) -> dict[str, Any]:
         attrs = super().to_attrs()
-        attrs["step"] = "inputs"
         if self.has_default:
             attrs["default"] = self.default
         return attrs
@@ -125,10 +120,7 @@ class TInputData(TIOData):
 
 @dataclass(frozen=True, slots=True)
 class TOutputData(TIOData):
-    def to_attrs(self) -> dict[str, Any]:
-        attrs = super().to_attrs()
-        attrs["step"] = "outputs"
-        return attrs
+    pass
 
 
 class SemantikonDiGraph(nx.DiGraph):
@@ -139,16 +131,14 @@ class SemantikonDiGraph(nx.DiGraph):
     later by the ontology serialization layer.
     """
 
-    def _validate_semantikon_attrs(self, attrs: dict[str, Any]) -> dict[str, Any]:
-        if "step" not in attrs:
-            return attrs
+    def _validate_semantikon_attrs(
+        self, step: IO | Node, attrs: dict[str, Any]
+    ) -> dict[str, Any]:
 
-        step = attrs["step"]
-        if step == "node":
-            known = {"type", "step", "identifier", "label", "function"}
+        if isinstance(step, Node):
+            known = {"type", "identifier", "label", "function"}
             node_meta = TNodeData(
                 type=attrs["type"],
-                step=step,
                 identifier=attrs.get("identifier"),
                 label=attrs.get("label"),
                 function=attrs.get("function"),
@@ -156,10 +146,9 @@ class SemantikonDiGraph(nx.DiGraph):
             )
             return node_meta.to_attrs()
 
-        if step == "inputs":
-            known = {"step", "arg", "position", "dtype", "value", "default"}
+        if isinstance(step, Input):
+            known = {"position", "dtype", "value", "default"}
             input_meta = TInputData(
-                arg=attrs["arg"],
                 position=attrs["position"],
                 dtype=attrs.get("dtype"),
                 value=attrs.get("value"),
@@ -170,10 +159,9 @@ class SemantikonDiGraph(nx.DiGraph):
             )
             return input_meta.to_attrs()
 
-        if step == "outputs":
-            known = {"step", "arg", "position", "dtype", "value"}
+        if isinstance(step, Output):
+            known = {"position", "dtype", "value"}
             output_meta = TOutputData(
-                arg=attrs["arg"],
                 position=attrs["position"],
                 dtype=attrs.get("dtype"),
                 value=attrs.get("value"),
@@ -182,37 +170,23 @@ class SemantikonDiGraph(nx.DiGraph):
             )
             return output_meta.to_attrs()
 
-        raise ValueError(
-            f"Unknown step {step!r}. Expected one of 'node', 'inputs', or 'outputs'."
-        )
-
     def add_node(self, node_for_adding, **attr):  # type: ignore[override]
-        normalized_attr = self._validate_semantikon_attrs(attr)
+        assert isinstance(node_for_adding, (Node, IO))
+        normalized_attr = self._validate_semantikon_attrs(node_for_adding, attr)
         super().add_node(node_for_adding, **normalized_attr)
 
     def add_nodes_from(self, nodes_for_adding, **attr):
-        normalized_attr = self._validate_semantikon_attrs(attr)
-
-        def normalized_nodes():
-            for n in nodes_for_adding:
-                try:
-                    hash(n)
-                except TypeError:
-                    n, ndict = n
-                    ndict = self._validate_semantikon_attrs(ndict)
-                    if normalized_attr:
-                        merged = normalized_attr.copy()
-                        merged.update(ndict)
-                        yield n, merged
-                    else:
-                        yield n, ndict
-                else:
-                    if normalized_attr:
-                        yield n, normalized_attr
-                    else:
-                        yield n
-
-        super().add_nodes_from(normalized_nodes())
+        assert all(
+            isinstance(n, (Node, IO)) or isinstance(n, tuple) for n in nodes_for_adding
+        )
+        for n in nodes_for_adding:
+            if isinstance(n, tuple):
+                node, node_attr = n
+                normalized_attr = self._validate_semantikon_attrs(node, attr | node_attr)
+                super().add_node(node, **normalized_attr)
+            else:
+                normalized_attr = self._validate_semantikon_attrs(n, attr)
+                super().add_node(n, **normalized_attr)
 
     @cached_property
     def t_ns(self) -> str:
@@ -232,9 +206,7 @@ class SemantikonDiGraph(nx.DiGraph):
 
     def _get_data_node(self, io: IO) -> str:
         while True:
-            candidate = [
-                c for c in self.predecessors(io) if self.nodes[c]["step"] != "node"
-            ]
+            candidate = [c for c in self.predecessors(io) if isinstance(c, IO)]
             assert len(candidate) <= 1
             if len(candidate) == 0:
                 return f"{io}_data"
@@ -261,7 +233,7 @@ class SemantikonDiGraph(nx.DiGraph):
                 descendants.
             label (str | None, optional): A label to use for hash computation.
                 If not provided, the label is derived from the node's data
-                (e.g., "label" or "arg"). Defaults to None.
+                (e.g., "label"). Defaults to None.
 
         Notes:
             - The function uses an iterative approach to avoid recursion,
@@ -275,14 +247,12 @@ class SemantikonDiGraph(nx.DiGraph):
             current_node, current_hash, current_label = stack.pop()
 
             for child in self.successors(current_node):
-                if self.nodes[child]["step"] == "node":
+                if isinstance(child, Node):
                     continue
 
                 child_label = current_label
                 if child_label is None:
-                    child_label = self.nodes[child].get(
-                        "label", self.nodes[child]["arg"]
-                    )
+                    child_label = self.nodes[child].get("label", child.arg)
 
                 self.nodes[child]["hash"] = current_hash + f"@{child_label}"
                 stack.append((child, current_hash, child_label))
@@ -330,7 +300,7 @@ def _workflow_to_networkx(
         parent_name: str | None = None,
         workflow_label: Node | None = None,
     ):
-        metadata: dict[str, Any] = {"step": "node"}
+        metadata: dict[str, Any] = {}
         function = None
         if isinstance(node_data, fr.schemas.AtomicData):
             metadata["type"] = "atomic"
@@ -366,11 +336,7 @@ def _workflow_to_networkx(
 
         for position, (label, port) in enumerate(node_data.input_ports.items()):
             io_name = Input(node=node_name, arg=label)
-            io_data: dict[str, Any] = {
-                "step": "inputs",
-                "arg": label,
-                "position": position,
-            }
+            io_data: dict[str, Any] = {"position": position}
             if not isinstance(port.value, fr.schemas.NotData):
                 io_data["value"] = port.value
             if type_hint := annotation_to_type_hint(port.annotation):
@@ -384,11 +350,7 @@ def _workflow_to_networkx(
         for position, (raw_label, port) in enumerate(node_data.output_ports.items()):
             label = output_labels[position] if raw_label == "output_0" else raw_label
             io_name = Output(node=node_name, arg=label)
-            io_data = {
-                "step": "outputs",
-                "arg": label,
-                "position": position,
-            }
+            io_data = {"position": position}
             if not isinstance(port.value, fr.schemas.NotData):
                 io_data["value"] = port.value
             if type_hint := annotation_to_type_hint(port.annotation):
@@ -449,7 +411,7 @@ def _get_hashed_node_dict_from_graph(G: SemantikonDiGraph) -> dict[str, dict[str
     hash_dict: dict[str, dict[str, Any]] = {}
     for node in nx.topological_sort(G):
         data = G.nodes[node]
-        if data.get("step") != "node":
+        if isinstance(node, IO):
             for term in ("hash", "value"):
                 if term in data:
                     continue
@@ -500,7 +462,7 @@ def _get_hashed_node_dict_from_graph(G: SemantikonDiGraph) -> dict[str, dict[str
 def _remove_constant(G: SemantikonDiGraph) -> None:
     to_delete = []
     for node, data in G.nodes.data():
-        if data["step"] == "node" and data["type"] == "constant":
+        if isinstance(node, Node) and data["type"] == "constant":
             output_node = next(iter(G.successors(node)))
             const_value = G.nodes[output_node]["value"]
             to_delete.extend([node, output_node])
@@ -606,8 +568,6 @@ class _HashGraph:
 
         for node in G.nodes:
             attrs = {}
-            if "arg" in G.nodes[node]:
-                attrs["arg"] = G.nodes[node]["arg"]
             if "function" in G.nodes[node]:
                 func = G.nodes[node]["function"]
                 attrs["function"] = func.get("hash") or func.get("identifier")

--- a/semantikon/flowrep_to_networkx.py
+++ b/semantikon/flowrep_to_networkx.py
@@ -24,7 +24,7 @@ from semantikon.flowrep_dict import (
 
 
 @dataclass(frozen=True, slots=True)
-class TNode:
+class TNodeData:
     type: str
     step: str
     identifier: str | None = None
@@ -55,7 +55,7 @@ class TNode:
 
 
 @dataclass(frozen=True, slots=True)
-class TIO:
+class TIOData:
     arg: str
     position: int
     dtype: Any | None = None
@@ -77,12 +77,12 @@ class TIO:
 
 
 @dataclass(frozen=True, slots=True)
-class TInput(TIO):
+class TInputData(TIOData):
     default: Any | None = None
     has_default: bool = False
 
     def to_attrs(self) -> dict[str, Any]:
-        attrs = super(TInput, self).to_attrs()
+        attrs = super().to_attrs()
         attrs["step"] = "inputs"
         if self.has_default:
             attrs["default"] = self.default
@@ -90,9 +90,9 @@ class TInput(TIO):
 
 
 @dataclass(frozen=True, slots=True)
-class TOutput(TIO):
+class TOutputData(TIOData):
     def to_attrs(self) -> dict[str, Any]:
-        attrs = super(TOutput, self).to_attrs()
+        attrs = super().to_attrs()
         attrs["step"] = "outputs"
         return attrs
 
@@ -112,7 +112,7 @@ class SemantikonDiGraph(nx.DiGraph):
         step = attrs["step"]
         if step == "node":
             known = {"type", "step", "identifier", "label", "function", "parent"}
-            node_meta = TNode(
+            node_meta = TNodeData(
                 type=attrs["type"],
                 step=step,
                 identifier=attrs.get("identifier"),
@@ -125,7 +125,7 @@ class SemantikonDiGraph(nx.DiGraph):
 
         if step == "inputs":
             known = {"step", "arg", "position", "dtype", "value", "default"}
-            input_meta = TInput(
+            input_meta = TInputData(
                 arg=attrs["arg"],
                 position=attrs["position"],
                 dtype=attrs.get("dtype"),
@@ -139,7 +139,7 @@ class SemantikonDiGraph(nx.DiGraph):
 
         if step == "outputs":
             known = {"step", "arg", "position", "dtype", "value"}
-            output_meta = TOutput(
+            output_meta = TOutputData(
                 arg=attrs["arg"],
                 position=attrs["position"],
                 dtype=attrs.get("dtype"),

--- a/semantikon/flowrep_to_networkx.py
+++ b/semantikon/flowrep_to_networkx.py
@@ -62,20 +62,16 @@ class Output(IO):
 
 @dataclass(frozen=True, slots=True)
 class TNodeData:
-    type: str
+    type: str | None = None
     identifier: str | None = None
     label: str | None = None
     function: dict | None = None
     extras: dict[str, Any] = field(default_factory=dict)
 
-    def __post_init__(self):
-        if self.type not in {"atomic", "constant", "workflow"}:
-            raise ValueError("type must be either 'atomic', 'constant', or 'workflow'")
-
     def to_attrs(self) -> dict[str, Any]:
-        attrs: dict[str, Any] = {
-            "type": self.type,
-        }
+        attrs: dict[str, Any] = {}
+        if self.type is not None:
+            attrs["type"] = self.type
         if self.identifier is not None:
             attrs["identifier"] = self.identifier
         if self.label is not None:
@@ -138,7 +134,7 @@ class SemantikonDiGraph(nx.DiGraph):
         if isinstance(step, Node):
             known = {"type", "identifier", "label", "function"}
             node_meta = TNodeData(
-                type=attrs["type"],
+                type=attrs.get("type"),
                 identifier=attrs.get("identifier"),
                 label=attrs.get("label"),
                 function=attrs.get("function"),
@@ -273,6 +269,32 @@ class SemantikonDiGraph(nx.DiGraph):
                 hash_dict[data["hash"]] = data["value"]
         return hash_dict
 
+    def _initialize_type(self):
+        for node, data in self.nodes.data():
+            if isinstance(node, Node):
+                data["type"] = data.get("type", "atomic")
+                if node.parent:
+                    self.nodes[node.parent]["type"] = "workflow"
+
+    def get_type(self, node_name: Node) -> str:
+        """
+        Get the type of a node in the graph.
+
+        Parameters:
+            node_name (Node): The name of the node for which to retrieve the
+                type.
+
+        Returns:
+            str: The type of the node. Possible values are "atomic",
+                "constant", or "workflow".
+
+        Raises:
+            ValueError: If the node is not found in the graph.
+        """
+        if "type" not in self.nodes[node_name]:
+            self._initialize_type()
+        return self.nodes[node_name]["type"]
+
 
 def _infer_workflow_label(recipe: fr.schemas.WorkflowRecipe) -> str:
     if recipe.reference is None:
@@ -305,12 +327,10 @@ def _workflow_to_networkx(
         metadata: dict[str, Any] = {}
         function = None
         if isinstance(node_data, fr.schemas.AtomicData):
-            metadata["type"] = "atomic"
             function = node_data.function
         elif isinstance(node_data, fr.schemas.ConstantData):
             metadata["type"] = "constant"
         else:
-            metadata["type"] = "workflow"
             if workflow_label is not None:
                 metadata["label"] = str(workflow_label)
             if node_data.recipe.reference is not None:
@@ -465,8 +485,8 @@ def _get_hashed_node_dict_from_graph(G: SemantikonDiGraph) -> dict[str, dict[str
 
 def _remove_constant(G: SemantikonDiGraph) -> None:
     to_delete = []
-    for node, data in G.nodes.data():
-        if isinstance(node, Node) and data["type"] == "constant":
+    for node in G.nodes:
+        if isinstance(node, Node) and G.get_type(node) == "constant":
             output_node = next(iter(G.successors(node)))
             const_value = G.nodes[output_node]["value"]
             to_delete.extend([node, output_node])

--- a/semantikon/flowrep_to_networkx.py
+++ b/semantikon/flowrep_to_networkx.py
@@ -26,7 +26,7 @@ from semantikon.flowrep_dict import (
 @dataclass(frozen=True, slots=True)
 class TNode:
     type: str
-    step: str = "node"
+    step: str
     identifier: str | None = None
     label: str | None = None
     function: dict | None = None
@@ -58,7 +58,6 @@ class TNode:
 class TIO:
     arg: str
     position: int
-    step: str = field(default="", init=False)
     dtype: Any | None = None
     value: Any | None = None
     has_value: bool = False
@@ -66,7 +65,6 @@ class TIO:
 
     def to_attrs(self) -> dict[str, Any]:
         attrs: dict[str, Any] = {
-            "step": self.step,
             "arg": self.arg,
             "position": self.position,
         }
@@ -80,12 +78,12 @@ class TIO:
 
 @dataclass(frozen=True, slots=True)
 class TInput(TIO):
-    step: str = field(default="inputs", init=False)
     default: Any | None = None
     has_default: bool = False
 
     def to_attrs(self) -> dict[str, Any]:
         attrs = super(TInput, self).to_attrs()
+        attrs["step"] = "inputs"
         if self.has_default:
             attrs["default"] = self.default
         return attrs
@@ -93,7 +91,10 @@ class TInput(TIO):
 
 @dataclass(frozen=True, slots=True)
 class TOutput(TIO):
-    step: str = field(default="outputs", init=False)
+    def to_attrs(self) -> dict[str, Any]:
+        attrs = super(TOutput, self).to_attrs()
+        attrs["step"] = "outputs"
+        return attrs
 
 
 class SemantikonDiGraph(nx.DiGraph):

--- a/semantikon/flowrep_to_networkx.py
+++ b/semantikon/flowrep_to_networkx.py
@@ -42,7 +42,7 @@ class Node:
 @dataclass(frozen=True, slots=True)
 class IO(ABC):
     node: str
-    arg: str
+    port: str
 
     def __radd__(self, other: str) -> str:
         return other + str(self)
@@ -51,13 +51,13 @@ class IO(ABC):
 @dataclass(frozen=True, slots=True)
 class Input(IO):
     def __str__(self) -> str:
-        return f"{self.node}-inputs-{self.arg}"
+        return f"{self.node}-inputs-{self.port}"
 
 
 @dataclass(frozen=True, slots=True)
 class Output(IO):
     def __str__(self) -> str:
-        return f"{self.node}-outputs-{self.arg}"
+        return f"{self.node}-outputs-{self.port}"
 
 
 @dataclass(frozen=True, slots=True)
@@ -112,7 +112,7 @@ class TInputData(TIOData):
     has_default: bool = False
 
     def to_attrs(self) -> dict[str, Any]:
-        attrs = super().to_attrs()
+        attrs = TIOData.to_attrs(self)
         if self.has_default:
             attrs["default"] = self.default
         return attrs
@@ -252,7 +252,7 @@ class SemantikonDiGraph(nx.DiGraph):
 
                 child_label = current_label
                 if child_label is None:
-                    child_label = self.nodes[child].get("label", child.arg)
+                    child_label = self.nodes[child].get("label", child.port)
 
                 self.nodes[child]["hash"] = current_hash + f"@{child_label}"
                 stack.append((child, current_hash, child_label))
@@ -335,7 +335,7 @@ def _workflow_to_networkx(
             output_labels = ["output"]
 
         for position, (label, port) in enumerate(node_data.input_ports.items()):
-            io_name = Input(node=node_name, arg=label)
+            io_name = Input(node=node_name, port=label)
             io_data: dict[str, Any] = {"position": position}
             if not isinstance(port.value, fr.schemas.NotData):
                 io_data["value"] = port.value
@@ -349,7 +349,7 @@ def _workflow_to_networkx(
             G.add_edge(io_name, node_name)
         for position, (raw_label, port) in enumerate(node_data.output_ports.items()):
             label = output_labels[position] if raw_label == "output_0" else raw_label
-            io_name = Output(node=node_name, arg=label)
+            io_name = Output(node=node_name, port=label)
             io_data = {"position": position}
             if not isinstance(port.value, fr.schemas.NotData):
                 io_data["value"] = port.value
@@ -378,29 +378,29 @@ def _workflow_to_networkx(
         child_recipes = recipe.nodes
         for target, source in recipe.input_edges.items():
             G.add_edge(
-                Input(node=node_name, arg=source.port),
-                Input(node=Node(parent=node_name, name=target.node), arg=target.port),
+                Input(node=node_name, port=source.port),
+                Input(node=Node(parent=node_name, name=target.node), port=target.port),
             )
         for target, source in recipe.edges.items():
             child_outputs = list(child_recipes[source.node].outputs)
             src_port = _output_port_label(source.port, child_outputs)
             G.add_edge(
-                Output(node=Node(parent=node_name, name=source.node), arg=src_port),
-                Input(node=Node(parent=node_name, name=target.node), arg=target.port),
+                Output(node=Node(parent=node_name, name=source.node), port=src_port),
+                Input(node=Node(parent=node_name, name=target.node), port=target.port),
             )
         for target, source in recipe.output_edges.items():
             target_port = _output_port_label(target.port, list(recipe.outputs))
             if isinstance(source, fr.schemas.InputSource):
                 G.add_edge(
-                    Input(node=node_name, arg=source.port),
-                    Output(node=node_name, arg=target_port),
+                    Input(node=node_name, port=source.port),
+                    Output(node=node_name, port=target_port),
                 )
             else:
                 child_outputs = list(child_recipes[source.node].outputs)
                 src_port = _output_port_label(source.port, child_outputs)
                 G.add_edge(
-                    Output(node=Node(parent=node_name, name=source.node), arg=src_port),
-                    Output(node=node_name, arg=target_port),
+                    Output(node=Node(parent=node_name, name=source.node), port=src_port),
+                    Output(node=node_name, port=target_port),
                 )
 
     _add_node(workflow, Node(root_label), workflow_label=Node(root_label))
@@ -425,7 +425,7 @@ def _get_hashed_node_dict_from_graph(G: SemantikonDiGraph) -> dict[str, dict[str
         hash_dict_tmp: dict[str, Any] = {
             "inputs": {},
             "outputs": [
-                G.nodes[out].get("label", out.arg) for out in G.successors(node)
+                G.nodes[out].get("label", out.port) for out in G.successors(node)
             ],
             "node": copy.deepcopy(data.get("function")),
         }
@@ -436,14 +436,14 @@ def _get_hashed_node_dict_from_graph(G: SemantikonDiGraph) -> dict[str, dict[str
         for inp in G.predecessors(node):
             inp_data = G.nodes[inp]
             if "hash" in inp_data:
-                hash_dict_tmp["inputs"][inp.arg] = inp_data["hash"]
-                hash_dict_tmp["node"]["connected_inputs"].append(inp.arg)
+                hash_dict_tmp["inputs"][inp.port] = inp_data["hash"]
+                hash_dict_tmp["node"]["connected_inputs"].append(inp.port)
             elif "value" in inp_data or "default" in inp_data:
                 value = inp_data.get("value", inp_data.get("default"))
                 if is_dataclass(value) and not isinstance(value, type):
-                    hash_dict_tmp["inputs"][inp.arg] = asdict(value)
+                    hash_dict_tmp["inputs"][inp.port] = asdict(value)
                 else:
-                    hash_dict_tmp["inputs"][inp.arg] = value
+                    hash_dict_tmp["inputs"][inp.port] = value
             else:
                 missing_input = True
                 break
@@ -453,7 +453,7 @@ def _get_hashed_node_dict_from_graph(G: SemantikonDiGraph) -> dict[str, dict[str
             json.dumps(hash_dict_tmp, sort_keys=True).encode("utf-8")
         ).hexdigest()
         for out in G.successors(node):
-            G.nodes[out]["hash"] = h + "@" + G.nodes[out].get("label", out.arg)
+            G.nodes[out]["hash"] = h + "@" + G.nodes[out].get("label", out.port)
         hash_dict_tmp["hash"] = h
         hash_dict[node] = hash_dict_tmp
     return hash_dict
@@ -577,7 +577,7 @@ class _HashGraph:
                 elif "default" in G.nodes[node]:
                     attrs["value"] = G.nodes[node]["default"]
             if isinstance(node, IO):
-                attrs["arg"] = node.arg
+                attrs["port"] = node.port
             G_tmp.add_node(node, canon=self._canonical_json(attrs))
         for u, v in G.edges:
             G_tmp.add_edge(u, v)

--- a/semantikon/flowrep_to_networkx.py
+++ b/semantikon/flowrep_to_networkx.py
@@ -27,7 +27,7 @@ from semantikon.flowrep_dict import (
 @dataclass(frozen=True, slots=True)
 class Node:
     name: str
-    parent: str | None = None
+    parent: Node | None = None
 
     def __str__(self) -> str:
         if self.parent:

--- a/semantikon/flowrep_to_networkx.py
+++ b/semantikon/flowrep_to_networkx.py
@@ -332,7 +332,7 @@ def _workflow_to_networkx(
         node_name: Node,
         *,
         parent_name: str | None = None,
-        workflow_label: str | None = None,
+        workflow_label: Node | None = None,
     ):
         metadata: dict[str, Any] = {"step": "node"}
         function = None
@@ -344,7 +344,7 @@ def _workflow_to_networkx(
         else:
             metadata["type"] = "workflow"
             if workflow_label is not None:
-                metadata["label"] = workflow_label
+                metadata["label"] = str(workflow_label)
             if node_data.recipe.reference is not None:
                 function = retrieve.import_from_string(
                     node_data.recipe.reference.info.fully_qualified_name
@@ -371,7 +371,7 @@ def _workflow_to_networkx(
             output_labels = ["output"]
 
         for position, (label, port) in enumerate(node_data.input_ports.items()):
-            io_name = Input(node=str(node_name), arg=label)
+            io_name = Input(node=node_name, arg=label)
             io_data: dict[str, Any] = {
                 "step": "inputs",
                 "arg": label,
@@ -389,7 +389,7 @@ def _workflow_to_networkx(
             G.add_edge(io_name, node_name)
         for position, (raw_label, port) in enumerate(node_data.output_ports.items()):
             label = output_labels[position] if raw_label == "output_0" else raw_label
-            io_name = Output(node=str(node_name), arg=label)
+            io_name = Output(node=node_name, arg=label)
             io_data = {
                 "step": "outputs",
                 "arg": label,
@@ -415,39 +415,39 @@ def _workflow_to_networkx(
                 child_name,
                 parent_name=node_name,
                 workflow_label=(
-                    child_label if isinstance(child, fr.schemas.DagData) else None
+                    Node(child_label) if isinstance(child, fr.schemas.DagData) else None
                 ),
             )
 
         child_recipes = recipe.nodes
         for target, source in recipe.input_edges.items():
             G.add_edge(
-                Input(node=str(node_name), arg=source.port),
-                Input(node=f"{node_name}-{target.node}", arg=target.port),
+                Input(node=node_name, arg=source.port),
+                Input(node=Node(parent=node_name, name=target.node), arg=target.port),
             )
         for target, source in recipe.edges.items():
             child_outputs = list(child_recipes[source.node].outputs)
             src_port = _output_port_label(source.port, child_outputs)
             G.add_edge(
-                Output(node=f"{node_name}-{source.node}", arg=src_port),
-                Input(node=f"{node_name}-{target.node}", arg=target.port),
+                Output(node=Node(parent=node_name, name=source.node), arg=src_port),
+                Input(node=Node(parent=node_name, name=target.node), arg=target.port),
             )
         for target, source in recipe.output_edges.items():
             target_port = _output_port_label(target.port, list(recipe.outputs))
             if isinstance(source, fr.schemas.InputSource):
                 G.add_edge(
-                    Input(node=str(node_name), arg=source.port),
-                    Output(node=str(node_name), arg=target_port),
+                    Input(node=node_name, arg=source.port),
+                    Output(node=node_name, arg=target_port),
                 )
             else:
                 child_outputs = list(child_recipes[source.node].outputs)
                 src_port = _output_port_label(source.port, child_outputs)
                 G.add_edge(
-                    Output(node=f"{node_name}-{source.node}", arg=src_port),
-                    Output(node=str(node_name), arg=target_port),
+                    Output(node=Node(parent=node_name, name=source.node), arg=src_port),
+                    Output(node=node_name, arg=target_port),
                 )
 
-    _add_node(workflow, Node(root_label), workflow_label=root_label)
+    _add_node(workflow, Node(root_label), workflow_label=Node(root_label))
     return G
 
 

--- a/semantikon/flowrep_to_networkx.py
+++ b/semantikon/flowrep_to_networkx.py
@@ -4,6 +4,7 @@ import copy
 import json
 import unicodedata
 import warnings
+from abc import ABC
 from dataclasses import asdict, dataclass, field, is_dataclass
 from functools import cached_property
 from hashlib import sha256
@@ -34,11 +35,17 @@ class Node:
         else:
             return self.name
 
+    def __radd__(self, other: str) -> str:
+        return other + str(self)
+
 
 @dataclass(frozen=True, slots=True)
-class IO:
+class IO(ABC):
     node: str
     arg: str
+
+    def __radd__(self, other: str) -> str:
+        return other + str(self)
 
 
 @dataclass(frozen=True, slots=True)

--- a/semantikon/flowrep_to_networkx.py
+++ b/semantikon/flowrep_to_networkx.py
@@ -227,7 +227,7 @@ class SemantikonDiGraph(nx.DiGraph):
         h = _get_graph_hash(self, with_global_inputs=True)
         return h + "_"
 
-    def _get_data_node(self, io: str) -> str:
+    def _get_data_node(self, io: IO) -> str:
         while True:
             candidate = [
                 c for c in self.predecessors(io) if self.nodes[c]["step"] != "node"
@@ -416,28 +416,28 @@ def _workflow_to_networkx(
         for target, source in recipe.input_edges.items():
             G.add_edge(
                 Input(node=str(node_name), arg=source.port),
-                Input(node=f"{node_name}-{target.node}", arg=target.port)
+                Input(node=f"{node_name}-{target.node}", arg=target.port),
             )
         for target, source in recipe.edges.items():
             child_outputs = list(child_recipes[source.node].outputs)
             src_port = _output_port_label(source.port, child_outputs)
             G.add_edge(
                 Output(node=f"{node_name}-{source.node}", arg=src_port),
-                Input(node=f"{node_name}-{target.node}", arg=target.port)
+                Input(node=f"{node_name}-{target.node}", arg=target.port),
             )
         for target, source in recipe.output_edges.items():
             target_port = _output_port_label(target.port, list(recipe.outputs))
             if isinstance(source, fr.schemas.InputSource):
                 G.add_edge(
                     Input(node=str(node_name), arg=source.port),
-                    Output(node=str(node_name), arg=target_port)
+                    Output(node=str(node_name), arg=target_port),
                 )
             else:
                 child_outputs = list(child_recipes[source.node].outputs)
                 src_port = _output_port_label(source.port, child_outputs)
                 G.add_edge(
                     Output(node=f"{node_name}-{source.node}", arg=src_port),
-                    Output(node=str(node_name), arg=target_port)
+                    Output(node=str(node_name), arg=target_port),
                 )
 
     _add_node(workflow, Node(root_label), workflow_label=root_label)
@@ -462,8 +462,7 @@ def _get_hashed_node_dict_from_graph(G: SemantikonDiGraph) -> dict[str, dict[str
         hash_dict_tmp: dict[str, Any] = {
             "inputs": {},
             "outputs": [
-                G.nodes[out].get("label", out.arg)
-                for out in G.successors(node)
+                G.nodes[out].get("label", out.arg) for out in G.successors(node)
             ],
             "node": copy.deepcopy(data.get("function")),
         }
@@ -491,9 +490,7 @@ def _get_hashed_node_dict_from_graph(G: SemantikonDiGraph) -> dict[str, dict[str
             json.dumps(hash_dict_tmp, sort_keys=True).encode("utf-8")
         ).hexdigest()
         for out in G.successors(node):
-            G.nodes[out]["hash"] = (
-                h + "@" + G.nodes[out].get("label", out.arg)
-            )
+            G.nodes[out]["hash"] = h + "@" + G.nodes[out].get("label", out.arg)
         hash_dict_tmp["hash"] = h
         hash_dict[node] = hash_dict_tmp
     return hash_dict

--- a/semantikon/flowrep_to_networkx.py
+++ b/semantikon/flowrep_to_networkx.py
@@ -401,7 +401,9 @@ def _workflow_to_networkx(
                 child_outputs = list(child_recipes[source.node].outputs)
                 src_port = _output_port_label(source.port, child_outputs)
                 G.add_edge(
-                    Output(node=Node(parent=node_name, name=source.node), port=src_port),
+                    Output(
+                        node=Node(parent=node_name, name=source.node), port=src_port
+                    ),
                     Output(node=node_name, port=target_port),
                 )
 

--- a/semantikon/flowrep_to_networkx.py
+++ b/semantikon/flowrep_to_networkx.py
@@ -182,7 +182,9 @@ class SemantikonDiGraph(nx.DiGraph):
         for n in nodes_for_adding:
             if isinstance(n, tuple):
                 node, node_attr = n
-                normalized_attr = self._validate_semantikon_attrs(node, attr | node_attr)
+                normalized_attr = self._validate_semantikon_attrs(
+                    node, attr | node_attr
+                )
                 super().add_node(node, **normalized_attr)
             else:
                 normalized_attr = self._validate_semantikon_attrs(n, attr)

--- a/semantikon/kg_to_flowrep.py
+++ b/semantikon/kg_to_flowrep.py
@@ -14,7 +14,7 @@ from rdflib.query import ResultRow
 from rdflib.term import IdentifiedNode, Node
 
 from semantikon.flowrep_dict import _flowrep_recipe_from_callable
-from semantikon.flowrep_to_networkx import TNode, TOutput
+from semantikon.flowrep_to_networkx import TNodeData, TOutputData
 from semantikon.ontology import SNS
 
 
@@ -660,14 +660,14 @@ def _reconstruct_constant_nodes(G: nx.DiGraph) -> None:
         const_output_name = f"{const_node_name}-outputs-constant"
 
         # Create the constant node
-        const_node_attrs = TNode(
+        const_node_attrs = TNodeData(
             type="constant",
             parent=parent_data.get("parent"),
         )
         G.add_node(const_node_name, **const_node_attrs.to_attrs())
 
         # Create the constant output node
-        const_output_attrs = TOutput(
+        const_output_attrs = TOutputData(
             arg=fr.schemas.ConstantRecipe.std_label,
             position=0,
             value=data["constant_value"],

--- a/semantikon/kg_to_flowrep.py
+++ b/semantikon/kg_to_flowrep.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import hashlib
 import itertools
-from collections.abc import Iterable
 from typing import Any, cast
 
 import flowrep as fr
@@ -10,17 +9,16 @@ import networkx as nx
 from pyiron_snippets import retrieve
 from rdflib import OWL, RDF, RDFS, Graph, Literal, URIRef
 from rdflib.namespace import SH
-from rdflib.query import ResultRow
 from rdflib.term import IdentifiedNode, Node
 
 from semantikon.flowrep_dict import _flowrep_recipe_from_callable
 from semantikon.flowrep_to_networkx import (
     IO,
+    Input,
+    Node,
+    Output,
     TNodeData,
     TOutputData,
-    Node,
-    Input,
-    Output,
 )
 from semantikon.ontology import SNS
 
@@ -239,7 +237,7 @@ def _networkx_to_flowrep(G: nx.DiGraph) -> fr.schemas.WorkflowRecipe:
 
             # First collect all direct children
             direct_children: dict[str, str] = {}
-            for child_label, child_node in G.nodes.items():
+            for child_label in G.nodes:
                 if isinstance(child_label, Node) and child_label.parent == node_name:
                     # Extract child short label correctly by removing parent prefix
                     direct_children[child_label.name] = child_label

--- a/semantikon/kg_to_flowrep.py
+++ b/semantikon/kg_to_flowrep.py
@@ -256,8 +256,6 @@ def _networkx_to_dict(G: nx.DiGraph) -> fr.schemas.WorkflowRecipe:
 
             def _is_direct_io(node_id: str) -> bool:
                 """Check if this is a direct IO of the workflow."""
-                if not node_id.startswith(node_name + "-"):
-                    return False
                 rest = node_id[len(node_name) + 1 :]
                 parts = rest.split("-")
                 # Direct IO is like "inputs-arg" or "outputs-arg" (2 parts)

--- a/semantikon/kg_to_flowrep.py
+++ b/semantikon/kg_to_flowrep.py
@@ -158,7 +158,9 @@ def _graph_to_function(graph: Graph, f_node: URIRef) -> dict[str, Any]:
                     continue
                 pairs = tuple(
                     pair
-                    for pair in _restriction_pairs(cast(term.IdentifiedNode, property_shape))
+                    for pair in _restriction_pairs(
+                        cast(term.IdentifiedNode, property_shape)
+                    )
                     if pair[0] != RDF.type
                 )
             else:

--- a/semantikon/kg_to_flowrep.py
+++ b/semantikon/kg_to_flowrep.py
@@ -651,7 +651,8 @@ def _reconstruct_constant_nodes(G: nx.DiGraph) -> None:
 
 
 def _ensure_workflow_name(
-    wf_name: str | URIRef | None, uri_to_node: dict[URIRef, Node]
+    uri_to_node: dict[URIRef, Node],
+    wf_name: str | URIRef | None = None,
 ) -> URIRef:
     roots = {k: v for k, v in uri_to_node.items() if v.parent is None}
     if len(roots) == 0:
@@ -721,7 +722,7 @@ def _rename_workflow(
 def _kg2digraph(graph: Graph, workflow_name: str | URIRef | None = None) -> nx.DiGraph:
     uri_to_node = _uri_to_node_names(graph)
     all_workflow_graph = _build_workflow_graph(graph)
-    workflow_name = _ensure_workflow_name(workflow_name, uri_to_node)
+    workflow_name = _ensure_workflow_name(uri_to_node, workflow_name)
     workflow_graph = _extract_workflow(all_workflow_graph, workflow_name)
     _append_metadata_to_graph(graph, workflow_graph)
     uri_to_node_and_io = _uri_to_node_and_io_names(graph, uri_to_node, workflow_graph)

--- a/semantikon/kg_to_flowrep.py
+++ b/semantikon/kg_to_flowrep.py
@@ -7,9 +7,8 @@ from typing import Any, cast
 import flowrep as fr
 import networkx as nx
 from pyiron_snippets import retrieve
-from rdflib import OWL, RDF, RDFS, Graph, Literal, URIRef
+from rdflib import OWL, RDF, RDFS, Graph, Literal, URIRef, term
 from rdflib.namespace import SH
-from rdflib import term
 
 from semantikon.flowrep_dict import _flowrep_recipe_from_callable
 from semantikon.flowrep_to_networkx import (

--- a/semantikon/kg_to_flowrep.py
+++ b/semantikon/kg_to_flowrep.py
@@ -277,19 +277,19 @@ def _networkx_to_flowrep(G: nx.DiGraph) -> fr.schemas.WorkflowRecipe:
                         v_child = _find_child_for_io(v)
                         if v_child is not None:
                             edges_key = fr.schemas.TargetHandle(
-                                node=v_child, port=v.arg
+                                node=v_child, port=v.port
                             )
-                            input_edges[edges_key] = fr.schemas.InputSource(port=u.arg)
+                            input_edges[edges_key] = fr.schemas.InputSource(port=u.port)
                 elif isinstance(u, Output) and isinstance(v, Input):
                     if u_is_child_io and v_is_child_io:
                         u_child = _find_child_for_io(u)
                         v_child = _find_child_for_io(v)
                         if u_child is not None and v_child is not None:
                             u_port = _normalize_output_label(
-                                u.arg, nodes[u_child].outputs
+                                u.port, nodes[u_child].outputs
                             )
                             edges_key = fr.schemas.TargetHandle(
-                                node=v_child, port=v.arg
+                                node=v_child, port=v.port
                             )
                             edges[edges_key] = fr.schemas.SourceHandle(
                                 node=u_child, port=u_port
@@ -303,9 +303,9 @@ def _networkx_to_flowrep(G: nx.DiGraph) -> fr.schemas.WorkflowRecipe:
                 ):
                     u_child = _find_child_for_io(u)
                     if u_child is not None:
-                        u_port = _normalize_output_label(u.arg, nodes[u_child].outputs)
+                        u_port = _normalize_output_label(u.port, nodes[u_child].outputs)
                         v_port = _normalize_output_label(
-                            v.arg, list(base_recipe.outputs)
+                            v.port, list(base_recipe.outputs)
                         )
                         output_edges[fr.schemas.OutputTarget(port=v_port)] = (
                             fr.schemas.SourceHandle(node=u_child, port=u_port)
@@ -447,12 +447,12 @@ def _uri_to_node_and_io_names(
             if out in uri_to_node:  # node; not an IO
                 continue
             arg = graph.value(out, SNS.local_identifier)
-            io_dict[out] = Output(arg=arg.toPython(), node=node)
+            io_dict[out] = Output(port=arg.toPython(), node=node)
         for inp in G.predecessors(uri):
             if inp in uri_to_node:  # node; not an IO
                 continue
             arg = graph.value(inp, SNS.local_identifier)
-            io_dict[inp] = Input(arg=arg.toPython(), node=node)
+            io_dict[inp] = Input(port=arg.toPython(), node=node)
     return io_dict | uri_to_node
 
 
@@ -629,7 +629,7 @@ def _reconstruct_constant_nodes(G: nx.DiGraph) -> None:
             if const_node not in G:
                 break
 
-        const_output_name = Output(arg="constant", node=const_node)
+        const_output_name = Output(port="constant", node=const_node)
 
         # Create the constant node
         const_node_attrs = TNodeData(type="constant")

--- a/semantikon/kg_to_flowrep.py
+++ b/semantikon/kg_to_flowrep.py
@@ -238,20 +238,14 @@ def _networkx_to_dict(G: nx.DiGraph) -> fr.schemas.WorkflowRecipe:
                     and child_node.get("parent") == node_name
                 ):
                     # Extract child short label correctly by removing parent prefix
-                    child_short_label = child_label[len(node_name) + 1 :]
-                    direct_children[child_short_label] = child_label
-                    nodes[child_short_label] = _process_node(child_label)
+                    direct_children[child_label.name] = child_label
+                    nodes[child_label.name] = _process_node(child_label)
 
-            def _find_child_for_io(io_node_name: str) -> str | None:
+            def _find_child_for_io(io_node_name: IO) -> Node | None:
                 """Find the child node (short label) that owns this IO node."""
                 for child_label in direct_children.values():
-                    if io_node_name.startswith(child_label + "-"):
-                        # Extract child short label correctly
-                        if child_label.startswith(node_name + "-"):
-                            child_short_label = child_label[len(node_name) + 1 :]
-                        else:
-                            child_short_label = child_label.split("-", 1)[1]
-                        return child_short_label
+                    if io_node_name.node == str(child_label):
+                        return child_label.name
                 return None
 
             def _is_direct_io(node_id: str) -> bool:

--- a/semantikon/kg_to_flowrep.py
+++ b/semantikon/kg_to_flowrep.py
@@ -244,7 +244,7 @@ def _networkx_to_dict(G: nx.DiGraph) -> fr.schemas.WorkflowRecipe:
             def _find_child_for_io(io_node_name: IO) -> Node | None:
                 """Find the child node (short label) that owns this IO node."""
                 for child_label in direct_children.values():
-                    if io_node_name.node == str(child_label):
+                    if io_node_name.node == child_label:
                         return child_label.name
                 return None
 
@@ -252,7 +252,7 @@ def _networkx_to_dict(G: nx.DiGraph) -> fr.schemas.WorkflowRecipe:
                 """Check if this is a direct IO of the workflow."""
                 if isinstance(node_id, Node):
                     return False
-                return node_id.parent == str(node_name)
+                return node_id.parent == node_name
 
             def _is_child_io(node_id: str) -> bool:
                 """Check if this is an IO of a direct child (and only direct child)."""

--- a/semantikon/kg_to_flowrep.py
+++ b/semantikon/kg_to_flowrep.py
@@ -14,7 +14,7 @@ from rdflib.query import ResultRow
 from rdflib.term import IdentifiedNode, Node
 
 from semantikon.flowrep_dict import _flowrep_recipe_from_callable
-from semantikon.flowrep_to_networkx import TNodeData, TOutputData, Node, Input, Output
+from semantikon.flowrep_to_networkx import IO, TNodeData, TOutputData, Node, Input, Output
 from semantikon.ontology import SNS
 
 
@@ -259,15 +259,8 @@ def _networkx_to_dict(G: nx.DiGraph) -> fr.schemas.WorkflowRecipe:
                 if not isinstance(node_id, IO):
                     return False
                 for child_label in direct_children.values():
-                    if node_id.parent == child_label:
-                        # Make sure it's not a grandchild IO
-                        rest = node_id[len(child_label) + 1 :]
-                        parts = rest.split("-")
-                        # Direct child IO is like "inputs-arg" or "outputs-arg" (2 parts)
-                        if len(parts) == 2:
-                            node = G.nodes.get(node_id)
-                            if node and node.get("step") in ["inputs", "outputs"]:
-                                return True
+                    if node_id.node == child_label:
+                        return True
                 return False
 
             for u, v in G.edges:

--- a/semantikon/kg_to_flowrep.py
+++ b/semantikon/kg_to_flowrep.py
@@ -517,6 +517,14 @@ def _append_metadata_to_graph(graph: Graph, workflow_graph: nx.DiGraph) -> None:
                     workflow_graph.nodes[out_node][key] = value
 
 
+def _get_node_positions(workflow_graph: nx.DiGraph) -> dict[Node, int]:
+    return {
+        node: i
+        for i, node in enumerate(nx.topological_sort(workflow_graph))
+        if isinstance(node, Node)
+    }
+
+
 def _reorganize_workflow_graph(workflow_graph: nx.DiGraph) -> None:
     """
     Reorganize the workflow graph to ensure that data nodes are properly connected
@@ -526,11 +534,7 @@ def _reorganize_workflow_graph(workflow_graph: nx.DiGraph) -> None:
     Args:
         workflow_graph (nx.DiGraph): The workflow graph to reorganize.
     """
-    position = {
-        node: i
-        for i, node in enumerate(nx.topological_sort(workflow_graph))
-        if isinstance(node, Node)
-    }
+    position = _get_node_positions(workflow_graph)
     for node in tuple(workflow_graph.nodes):
         if not isinstance(node, URIRef):
             continue
@@ -545,9 +549,7 @@ def _reorganize_workflow_graph(workflow_graph: nx.DiGraph) -> None:
             _reconnect_io(workflow_graph, node)
 
     workflow_graph.remove_nodes_from(
-        [
-            node for node in workflow_graph.nodes if isinstance(node, URIRef)
-        ]
+        [node for node in workflow_graph.nodes if isinstance(node, URIRef)]
     )
     workflow_graph.remove_edges_from(
         [
@@ -556,10 +558,13 @@ def _reorganize_workflow_graph(workflow_graph: nx.DiGraph) -> None:
             if all(isinstance(node, Node) for node in edge)
         ]
     )
+    workflow_graph.name = str(next(iter(position.keys())))
 
 
 def _extract_constant_values_from_kg(
-    rdf_graph: Graph, workflow_graph: nx.DiGraph, uri_to_node_and_io: dict[URIRef, Node | IO]
+    rdf_graph: Graph,
+    workflow_graph: nx.DiGraph,
+    uri_to_node_and_io: dict[URIRef, Node | IO],
 ) -> None:
     """
     Extract constant values from the RDF knowledge graph and add them to
@@ -620,7 +625,7 @@ def _reconstruct_constant_nodes(G: nx.DiGraph) -> None:
         for constant_index in itertools.count():
             const_node = Node(
                 name=f"{fr.schemas.ConstantRecipe.std_label}_{constant_index}",
-                parent=node.node.parent
+                parent=node.node.parent,
             )
             if const_node not in G:
                 break
@@ -703,7 +708,10 @@ def _extract_workflow(
 
 
 def _rename_workflow(
-    workflow_graph: nx.DiGraph, uri_to_node: dict[URIRef, Node], uri_to_node_and_io: dict[URIRef, Node | IO], graph: Graph
+    workflow_graph: nx.DiGraph,
+    uri_to_node: dict[URIRef, Node],
+    uri_to_node_and_io: dict[URIRef, Node | IO],
+    graph: Graph,
 ) -> nx.DiGraph:
     return nx.relabel_nodes(workflow_graph, uri_to_node_and_io)
 
@@ -715,7 +723,9 @@ def _kg2digraph(graph: Graph, workflow_name: str | URIRef | None = None) -> nx.D
     workflow_graph = _extract_workflow(all_workflow_graph, workflow_name)
     _append_metadata_to_graph(graph, workflow_graph)
     uri_to_node_and_io = _uri_to_node_and_io_names(graph, uri_to_node, workflow_graph)
-    renamed_workflow_graph = _rename_workflow(workflow_graph, uri_to_node, uri_to_node_and_io, graph)
+    renamed_workflow_graph = _rename_workflow(
+        workflow_graph, uri_to_node, uri_to_node_and_io, graph
+    )
     _reorganize_workflow_graph(renamed_workflow_graph)
     _extract_constant_values_from_kg(graph, renamed_workflow_graph, uri_to_node_and_io)
     _reconstruct_constant_nodes(renamed_workflow_graph)

--- a/semantikon/kg_to_flowrep.py
+++ b/semantikon/kg_to_flowrep.py
@@ -221,7 +221,7 @@ def _networkx_to_flowrep(G: SemantikonDiGraph) -> fr.schemas.WorkflowRecipe:
 
     def _process_node(node_name: Node) -> fr.schemas.RecipeDiscrimination:
         node_data = G.nodes[node_name]
-        node_type = node_data.get("type", "atomic")
+        node_type = G.get_type(node_name)
         if node_type == "constant":
             output_node = list(G.successors(node_name))
             assert (

--- a/semantikon/kg_to_flowrep.py
+++ b/semantikon/kg_to_flowrep.py
@@ -662,6 +662,7 @@ def _reconstruct_constant_nodes(G: nx.DiGraph) -> None:
         # Create the constant node
         const_node_attrs = TNodeData(
             type="constant",
+            step="node",
             parent=parent_data.get("parent"),
         )
         G.add_node(const_node_name, **const_node_attrs.to_attrs())

--- a/semantikon/kg_to_flowrep.py
+++ b/semantikon/kg_to_flowrep.py
@@ -381,9 +381,7 @@ def _node_functions(graph: Graph) -> dict[URIRef, URIRef]:
     return dict(graph.query(query))
 
 
-def _reorganize_output_edges(
-    graph: nx.DiGraph, node: URIRef, position: dict[Any, int]
-):
+def _reorganize_output_edges(graph: nx.DiGraph, node: URIRef, position: dict[Any, int]):
     io_dict: dict[URIRef, URIRef] = {}
     for n in graph.predecessors(node):
         pred = list(graph.predecessors(n))
@@ -396,9 +394,7 @@ def _reorganize_output_edges(
     graph.add_edges_from(itertools.pairwise(nodes))
 
 
-def _reorganize_input_edges(
-    graph: nx.DiGraph, node: URIRef, position: dict[Any, int]
-):
+def _reorganize_input_edges(graph: nx.DiGraph, node: URIRef, position: dict[Any, int]):
     io_dict: dict[URIRef, URIRef] = {}
     for n in graph.successors(node):
         succ = list(graph.successors(n))
@@ -429,11 +425,15 @@ def _uri_to_node_names(graph: Graph):
 
     node_dict: dict[URIRef, Node] = {}
     for parent in nx.topological_sort(node_graph):
-        parent_name = cast(Literal, graph.value(parent, SNS.local_identifier)).toPython()
+        parent_name = cast(
+            Literal, graph.value(parent, SNS.local_identifier)
+        ).toPython()
         node_dict[parent] = node_dict.get(parent, Node(parent_name))
         for child in node_graph.successors(parent):
             assert child not in node_dict
-            child_name = cast(Literal, graph.value(child, SNS.local_identifier)).toPython()
+            child_name = cast(
+                Literal, graph.value(child, SNS.local_identifier)
+            ).toPython()
             node_dict[child] = Node(child_name, parent=node_dict[parent])
     return node_dict
 

--- a/semantikon/kg_to_flowrep.py
+++ b/semantikon/kg_to_flowrep.py
@@ -14,7 +14,14 @@ from rdflib.query import ResultRow
 from rdflib.term import IdentifiedNode, Node
 
 from semantikon.flowrep_dict import _flowrep_recipe_from_callable
-from semantikon.flowrep_to_networkx import IO, TNodeData, TOutputData, Node, Input, Output
+from semantikon.flowrep_to_networkx import (
+    IO,
+    TNodeData,
+    TOutputData,
+    Node,
+    Input,
+    Output,
+)
 from semantikon.ontology import SNS
 
 

--- a/semantikon/kg_to_flowrep.py
+++ b/semantikon/kg_to_flowrep.py
@@ -739,7 +739,9 @@ def _translate_to_semantikon_digraph(workflow_graph: nx.DiGraph) -> SemantikonDi
     return semantikon_digraph
 
 
-def _kg2digraph(graph: Graph, workflow_name: str | URIRef | None = None) -> SemantikonDiGraph:
+def _kg2digraph(
+    graph: Graph, workflow_name: str | URIRef | None = None
+) -> SemantikonDiGraph:
     uri_to_node = _uri_to_node_names(graph)
     all_workflow_graph = _build_workflow_graph(graph)
     workflow_name = _ensure_workflow_name(uri_to_node, workflow_name)

--- a/semantikon/kg_to_flowrep.py
+++ b/semantikon/kg_to_flowrep.py
@@ -382,7 +382,7 @@ def _node_functions(graph: Graph) -> dict[URIRef, URIRef]:
 
 
 def _reorganize_output_edges(
-    graph: nx.DiGraph, node: URIRef, position: dict[URIRef, int]
+    graph: nx.DiGraph, node: URIRef, position: dict[Any, int]
 ):
     io_dict: dict[URIRef, URIRef] = {}
     for n in graph.predecessors(node):
@@ -397,7 +397,7 @@ def _reorganize_output_edges(
 
 
 def _reorganize_input_edges(
-    graph: nx.DiGraph, node: URIRef, position: dict[URIRef, int]
+    graph: nx.DiGraph, node: URIRef, position: dict[Any, int]
 ):
     io_dict: dict[URIRef, URIRef] = {}
     for n in graph.successors(node):
@@ -422,18 +422,18 @@ def _reconnect_io(graph: nx.DiGraph, node: URIRef):
 
 def _uri_to_node_names(graph: Graph):
     node_graph = nx.DiGraph()
-    for parent, child in graph.query(
+    for parent, child in graph.query(  # type: ignore[misc]
         _get_connection_query(SNS.workflow_node, SNS.has_part, SNS.workflow_node)
     ):
         node_graph.add_edge(parent, child)
 
     node_dict: dict[URIRef, Node] = {}
     for parent in nx.topological_sort(node_graph):
-        parent_name = graph.value(parent, SNS.local_identifier).toPython()
+        parent_name = cast(Literal, graph.value(parent, SNS.local_identifier)).toPython()
         node_dict[parent] = node_dict.get(parent, Node(parent_name))
         for child in node_graph.successors(parent):
             assert child not in node_dict
-            child_name = graph.value(child, SNS.local_identifier).toPython()
+            child_name = cast(Literal, graph.value(child, SNS.local_identifier)).toPython()
             node_dict[child] = Node(child_name, parent=node_dict[parent])
     return node_dict
 
@@ -460,24 +460,24 @@ def _build_workflow_graph(graph: Graph) -> nx.DiGraph:
 
     workflow_graph = nx.DiGraph()
 
-    for node, io_node in graph.query(
+    for node, io_node in graph.query(  # type: ignore[misc]
         _get_connection_query(SNS.workflow_node, SNS.has_part, SNS.input_assignment)
     ):
         workflow_graph.add_edge(io_node, node)
 
-    for node, io_node in graph.query(
+    for node, io_node in graph.query(  # type: ignore[misc]
         _get_connection_query(SNS.workflow_node, SNS.has_part, SNS.output_assignment)
     ):
         workflow_graph.add_edge(node, io_node)
 
-    for out_assignment, data_node in graph.query(
+    for out_assignment, data_node in graph.query(  # type: ignore[misc]
         _get_connection_query(
             SNS.output_assignment, SNS.has_participant, SNS.value_specification
         )
     ):
         workflow_graph.add_edge(out_assignment, data_node)
 
-    for in_assignment, data_node in graph.query(
+    for in_assignment, data_node in graph.query(  # type: ignore[misc]
         _get_connection_query(
             SNS.input_assignment, SNS.has_participant, SNS.value_specification
         )
@@ -486,7 +486,7 @@ def _build_workflow_graph(graph: Graph) -> nx.DiGraph:
 
     # This is only needed to correctly identify input - input and
     # output - output edges in the workflow graph.
-    for parent_node, child_node in graph.query(
+    for parent_node, child_node in graph.query(  # type: ignore[misc]
         _get_connection_query(SNS.workflow_node, SNS.has_part, SNS.workflow_node)
     ):
         workflow_graph.add_edge(parent_node, child_node)
@@ -598,7 +598,7 @@ def _extract_constant_values_from_kg(
     }}"""
 
     for input_node, value_literal in rdf_graph.query(query):  # type: ignore[misc]
-        inp = uri_to_node_and_io.get(input_node)
+        inp = uri_to_node_and_io.get(input_node)  # type: ignore[arg-type]
         workflow_graph.nodes[inp]["constant_value"] = (
             _literal_to_constant(value_literal)
             if isinstance(value_literal, Literal)
@@ -688,7 +688,7 @@ def _ensure_workflow_name(
                 )
             return next(k for k, v in roots.items() if str(v) == str(wf_name))
         elif wf_name in roots:
-            return wf_name
+            return cast(URIRef, wf_name)
         else:
             raise ValueError(
                 f"Unknown workflow {wf_name!r}. Available workflows: {list(roots.keys()) + list(roots.values())!r}"

--- a/semantikon/kg_to_flowrep.py
+++ b/semantikon/kg_to_flowrep.py
@@ -496,7 +496,7 @@ def _build_workflow_graph(graph: Graph) -> nx.DiGraph:
 def _append_metadata_to_graph(graph: Graph, workflow_graph: nx.DiGraph) -> None:
     node_to_f = _node_functions(graph)
     for node in workflow_graph.nodes:
-        if not node in node_to_f:
+        if node not in node_to_f:
             continue
         f_meta = _graph_to_function(graph, node_to_f[node])
         workflow_graph.nodes[node]["function"] = f_meta["data"]

--- a/semantikon/kg_to_flowrep.py
+++ b/semantikon/kg_to_flowrep.py
@@ -252,12 +252,14 @@ def _networkx_to_dict(G: nx.DiGraph) -> fr.schemas.WorkflowRecipe:
                 """Check if this is a direct IO of the workflow."""
                 if isinstance(node_id, Node):
                     return False
-                return node_id.parent == node_name
+                return node_id.node == node_name
 
-            def _is_child_io(node_id: str) -> bool:
+            def _is_child_io(node_id: IO | Node) -> bool:
                 """Check if this is an IO of a direct child (and only direct child)."""
+                if not isinstance(node_id, IO):
+                    return False
                 for child_label in direct_children.values():
-                    if node_id.startswith(child_label + "-"):
+                    if node_id.parent == child_label:
                         # Make sure it's not a grandchild IO
                         rest = node_id[len(child_label) + 1 :]
                         parts = rest.split("-")

--- a/semantikon/kg_to_flowrep.py
+++ b/semantikon/kg_to_flowrep.py
@@ -209,7 +209,8 @@ def _networkx_to_flowrep(G: nx.DiGraph) -> fr.schemas.WorkflowRecipe:
             return retrieve.import_from_string(fqn)
         except Exception as exc:
             raise ImportError(
-                f"Failed to import {fqn!r} while reconstructing a workflow from a knowledge graph."
+                f"Failed to import {fqn!r} while reconstructing a workflow from"
+                + " a knowledge graph."
             ) from exc
 
     def _normalize_output_label(label: str, recipe_outputs: list[str]) -> str:
@@ -666,7 +667,8 @@ def _ensure_workflow_name(
         ):
             return next(iter(roots.keys()))
         raise ValueError(
-            f"Unknown workflow {wf_name!r}. Available workflow: {list(roots.keys()) + list(roots.values())!r}"
+            f"Unknown workflow {wf_name!r}. Available workflow:"
+            + f" {list(roots.keys()) + list(roots.values())!r}"
         )
     else:
         if wf_name is None:
@@ -677,21 +679,22 @@ def _ensure_workflow_name(
                 else sorted(roots.keys())
             )
             raise ValueError(
-                "Graph contains multiple root workflows. Pass `workflow_name` explicitly. "
-                f"Available workflows: {wfs}"
+                "Graph contains multiple root workflows. Pass `workflow_name`"
+                f" explicitly. Available workflows: {wfs}"
             )
         if c := [str(v) for v in roots.values()].count(str(wf_name)):
             if c > 1:
                 raise ValueError(
-                    f"Ambiguous workflow name {wf_name!r}. It matches {c} workflows. "
-                    f"Available workflows: {list(roots.keys()) + list(roots.values())!r}"
+                    f"Ambiguous workflow name {wf_name!r}. It matches {c} workflows."
+                    f" Available workflows: {list(roots.keys()) + list(roots.values())!r}"
                 )
             return next(k for k, v in roots.items() if str(v) == str(wf_name))
         elif wf_name in roots:
             return cast(URIRef, wf_name)
         else:
             raise ValueError(
-                f"Unknown workflow {wf_name!r}. Available workflows: {list(roots.keys()) + list(roots.values())!r}"
+                f"Unknown workflow {wf_name!r}. Available workflows:"
+                + f" {list(roots.keys()) + list(roots.values())!r}"
             )
 
 

--- a/semantikon/kg_to_flowrep.py
+++ b/semantikon/kg_to_flowrep.py
@@ -248,12 +248,11 @@ def _networkx_to_dict(G: nx.DiGraph) -> fr.schemas.WorkflowRecipe:
                         return child_label.name
                 return None
 
-            def _is_direct_io(node_id: str) -> bool:
+            def _is_direct_io(node_id: Node | IO) -> bool:
                 """Check if this is a direct IO of the workflow."""
-                rest = node_id[len(node_name) + 1 :]
-                parts = rest.split("-")
-                # Direct IO is like "inputs-arg" or "outputs-arg" (2 parts)
-                return len(parts) == 2
+                if isinstance(node_id, Node):
+                    return False
+                return node_id.parent == str(node_name)
 
             def _is_child_io(node_id: str) -> bool:
                 """Check if this is an IO of a direct child (and only direct child)."""

--- a/semantikon/kg_to_flowrep.py
+++ b/semantikon/kg_to_flowrep.py
@@ -240,10 +240,7 @@ def _networkx_to_dict(G: nx.DiGraph) -> fr.schemas.WorkflowRecipe:
             # First collect all direct children
             direct_children: dict[str, str] = {}
             for child_label, child_node in G.nodes.items():
-                if (
-                    child_node.get("step") == "node"
-                    and child_node.get("parent") == node_name
-                ):
+                if isinstance(child_label, Node) and child_label.parent == node_name:
                     # Extract child short label correctly by removing parent prefix
                     direct_children[child_label.name] = child_label
                     nodes[child_label.name] = _process_node(child_label)
@@ -271,55 +268,45 @@ def _networkx_to_dict(G: nx.DiGraph) -> fr.schemas.WorkflowRecipe:
                 return False
 
             for u, v in G.edges:
-                u_data = G.nodes[u]
-                v_data = G.nodes[v]
-                u_step = u_data.get("step")
-                v_step = v_data.get("step")
-
                 u_is_direct_io = _is_direct_io(u)
                 v_is_direct_io = _is_direct_io(v)
                 u_is_child_io = _is_child_io(u)
                 v_is_child_io = _is_child_io(v)
 
-                if u_step == v_step == "inputs":
+                if isinstance(u, Input) and isinstance(v, Input):
                     if u_is_direct_io and v_is_child_io:
-                        u_port = u_data["arg"]
                         v_child = _find_child_for_io(v)
                         if v_child is not None:
-                            v_port = v_data["arg"]
                             edges_key = fr.schemas.TargetHandle(
-                                node=v_child, port=v_port
+                                node=v_child, port=v.arg
                             )
-                            input_edges[edges_key] = fr.schemas.InputSource(port=u_port)
-                elif u_step == "outputs" and v_step == "inputs":
+                            input_edges[edges_key] = fr.schemas.InputSource(port=u.arg)
+                elif isinstance(u, Output) and isinstance(v, Input):
                     if u_is_child_io and v_is_child_io:
                         u_child = _find_child_for_io(u)
                         v_child = _find_child_for_io(v)
                         if u_child is not None and v_child is not None:
-                            u_port = u_data["arg"]
-                            v_port = v_data["arg"]
                             u_port = _normalize_output_label(
-                                u_port, nodes[u_child].outputs
+                                u.arg, nodes[u_child].outputs
                             )
                             edges_key = fr.schemas.TargetHandle(
-                                node=v_child, port=v_port
+                                node=v_child, port=v.arg
                             )
                             edges[edges_key] = fr.schemas.SourceHandle(
                                 node=u_child, port=u_port
                             )
                 elif (
-                    u_step == v_step == "outputs"
+                    isinstance(u, Output)
+                    and isinstance(v, Output)
                     and u != v
                     and u_is_child_io
                     and v_is_direct_io
                 ):
                     u_child = _find_child_for_io(u)
                     if u_child is not None:
-                        u_port = u_data["arg"]
-                        v_port = v_data["arg"]
-                        u_port = _normalize_output_label(u_port, nodes[u_child].outputs)
+                        u_port = _normalize_output_label(u.arg, nodes[u_child].outputs)
                         v_port = _normalize_output_label(
-                            v_port, list(base_recipe.outputs)
+                            v.arg, list(base_recipe.outputs)
                         )
                         output_edges[fr.schemas.OutputTarget(port=v_port)] = (
                             fr.schemas.SourceHandle(node=u_child, port=u_port)
@@ -462,7 +449,7 @@ def _add_io_nodes(
         function_data = function_dict.get(func_node) if func_node is not None else None
         if function_data is None:
             continue
-        workflow_graph.add_node(node, step="node", function=function_data["data"])
+        workflow_graph.add_node(Node(node), function=function_data["data"])
 
         arg_values = list(graph.objects(io_node, SNS.local_identifier))
         if len(arg_values) != 1:
@@ -470,7 +457,10 @@ def _add_io_nodes(
         arg = cast(Literal, arg_values[0]).toPython()
         for data in function_data[f"{io_type}_args"]:
             if arg == data["arg"]:
-                workflow_graph.add_node(io_node, step=f"{io_type}s", **data)
+                if io_type == "input":
+                    workflow_graph.add_node(Input(io_node, arg=arg), **data)
+                else:
+                    workflow_graph.add_node(Output(io_node, arg=arg), **data)
                 break
         else:
             raise ValueError(f"Could not match argument {arg!r} for {node!r}.")
@@ -529,7 +519,7 @@ def _build_workflow_graph(graph: Graph) -> nx.DiGraph:
     position = {
         node: i
         for i, node in enumerate(nx.topological_sort(workflow_graph))
-        if workflow_graph.nodes[node].get("step") == "node"
+        if isinstance(node, Node)
     }
     for node, data in tuple(workflow_graph.nodes.data()):
         if data.get("step") != "data":
@@ -555,7 +545,7 @@ def _build_workflow_graph(graph: Graph) -> nx.DiGraph:
         [
             edge
             for edge in workflow_graph.edges
-            if all(workflow_graph.nodes[node].get("step") == "node" for node in edge)
+            if all(isinstance(node, Node) for node in edge)
         ]
     )
     return workflow_graph
@@ -616,7 +606,7 @@ def _reconstruct_constant_nodes(G: nx.DiGraph) -> None:
     """
 
     for node, data in tuple(G.nodes.data()):
-        if data.get("step") != "inputs" or "constant_value" not in data:
+        if not isinstance(node, Input) or "constant_value" not in data:
             continue
 
         # Extract the parent node and argument name

--- a/semantikon/kg_to_flowrep.py
+++ b/semantikon/kg_to_flowrep.py
@@ -16,6 +16,7 @@ from semantikon.flowrep_to_networkx import (
     Input,
     Node,
     Output,
+    SemantikonDiGraph,
     TNodeData,
     TOutputData,
 )
@@ -181,12 +182,12 @@ def _graph_to_function(graph: Graph, f_node: URIRef) -> dict[str, Any]:
     }
 
 
-def _networkx_to_flowrep(G: nx.DiGraph) -> fr.schemas.WorkflowRecipe:
+def _networkx_to_flowrep(G: SemantikonDiGraph) -> fr.schemas.WorkflowRecipe:
     """
-    Convert a NetworkX DiGraph into flowrep WorkflowRecipe.
+    Convert a SemantikonDiGraph into flowrep WorkflowRecipe.
 
     Args:
-        G (nx.DiGraph): Graph to convert, using Semantikon node/edge attributes.
+        G (SemantikonDiGraph): Graph to convert, using Semantikon node/edge attributes.
 
     Returns:
         fr.schemas.WorkflowRecipe: Reconstructed workflow recipe.
@@ -719,7 +720,26 @@ def _rename_workflow(
     return nx.relabel_nodes(workflow_graph, uri_to_node_and_io)
 
 
-def _kg2digraph(graph: Graph, workflow_name: str | URIRef | None = None) -> nx.DiGraph:
+def _translate_to_semantikon_digraph(workflow_graph: nx.DiGraph) -> SemantikonDiGraph:
+    """
+    Translate a workflow graph to a SemantikonDiGraph.
+
+    Args:
+        workflow_graph (nx.DiGraph): Workflow graph to translate.
+
+    Returns:
+        SemantikonDiGraph: Translated SemantikonDiGraph.
+    """
+    semantikon_digraph = SemantikonDiGraph()
+    for node, data in workflow_graph.nodes(data=True):
+        semantikon_digraph.add_node(node, **data)
+    for u, v in workflow_graph.edges():
+        semantikon_digraph.add_edge(u, v)
+    semantikon_digraph.name = workflow_graph.name
+    return semantikon_digraph
+
+
+def _kg2digraph(graph: Graph, workflow_name: str | URIRef | None = None) -> SemantikonDiGraph:
     uri_to_node = _uri_to_node_names(graph)
     all_workflow_graph = _build_workflow_graph(graph)
     workflow_name = _ensure_workflow_name(uri_to_node, workflow_name)
@@ -732,6 +752,7 @@ def _kg2digraph(graph: Graph, workflow_name: str | URIRef | None = None) -> nx.D
     _reorganize_workflow_graph(renamed_workflow_graph)
     _extract_constant_values_from_kg(graph, renamed_workflow_graph, uri_to_node_and_io)
     _reconstruct_constant_nodes(renamed_workflow_graph)
+    semantikon_digraph = _translate_to_semantikon_digraph(renamed_workflow_graph)
     return renamed_workflow_graph
 
 

--- a/semantikon/kg_to_flowrep.py
+++ b/semantikon/kg_to_flowrep.py
@@ -14,7 +14,7 @@ from rdflib.query import ResultRow
 from rdflib.term import IdentifiedNode, Node
 
 from semantikon.flowrep_dict import _flowrep_recipe_from_callable
-from semantikon.flowrep_to_networkx import TNodeData, TOutputData
+from semantikon.flowrep_to_networkx import TNodeData, TOutputData, Node, Input, Output
 from semantikon.ontology import SNS
 
 
@@ -211,7 +211,7 @@ def _networkx_to_dict(G: nx.DiGraph) -> fr.schemas.WorkflowRecipe:
             return "output_0"
         return label
 
-    def _process_node(node_name: str) -> fr.schemas.RecipeDiscrimination:
+    def _process_node(node_name: Node) -> fr.schemas.RecipeDiscrimination:
         node_data = G.nodes[node_name]
         node_type = node_data.get("type", "atomic")
         if node_type == "constant":
@@ -348,7 +348,7 @@ def _networkx_to_dict(G: nx.DiGraph) -> fr.schemas.WorkflowRecipe:
             return _flowrep_recipe_from_callable(func_obj, node_type="atomic")
         raise TypeError(f"Unsupported workflow node type: {node_type!r}")
 
-    root_node = G.name
+    root_node = Node(G.name)
     recipe = _process_node(root_node)
     if not isinstance(recipe, fr.schemas.WorkflowRecipe):
         raise TypeError(
@@ -631,15 +631,13 @@ def _reconstruct_constant_nodes(G: nx.DiGraph) -> None:
 
         # Extract the parent node and argument name
         # Node format: parent-inputs-arg
-        parts = node.rsplit("-", 2)
-        assert len(parts) == 3, f"Unexpected input node format: {node}"
-        assert parts[1] == "inputs", f"Expected 'inputs' in node name: {node}"
+        assert isinstance(node, Input), f"Expected 'inputs' in node name: {node}"
 
-        parent_node = parts[0]
-        parent_data = G.nodes.get(parent_node)
+        parent_node = node.node
+        parent_data = G.nodes[parent_node]
         assert (
             parent_data is not None
-        ), f"Parent node {parent_node} not found for {node}"
+        ), f"Parent node {parent_node} not found for {node} in {G.nodes}"
         assert (
             parent_data.get("step") == "node"
         ), f"Parent node {parent_node} is not a workflow node for {node}"
@@ -715,7 +713,7 @@ def _split_by_roots(
         # Relabel nodes to strings after splitting
         mapping = {node: _label(graph, node) for node in subgraph.nodes}
         subgraph = nx.relabel_nodes(subgraph, mapping)
-        subgraph.name = name
+        subgraph.name = str(name)
         subgraphs[name] = subgraph
     return subgraphs
 

--- a/semantikon/kg_to_flowrep.py
+++ b/semantikon/kg_to_flowrep.py
@@ -237,14 +237,14 @@ def _networkx_to_flowrep(G: nx.DiGraph) -> fr.schemas.WorkflowRecipe:
             output_edges: fr.schemas.OutputEdges = {}
 
             # First collect all direct children
-            direct_children: dict[str, str] = {}
+            direct_children: dict[str, Node] = {}
             for child_label in G.nodes:
                 if isinstance(child_label, Node) and child_label.parent == node_name:
                     # Extract child short label correctly by removing parent prefix
                     direct_children[child_label.name] = child_label
                     nodes[child_label.name] = _process_node(child_label)
 
-            def _find_child_for_io(io_node_name: IO) -> Node | None:
+            def _find_child_for_io(io_node_name: IO) -> str | None:
                 """Find the child node (short label) that owns this IO node."""
                 for child_label in direct_children.values():
                     if io_node_name.node == child_label:
@@ -427,7 +427,7 @@ def _uri_to_node_names(graph: Graph):
     ):
         node_graph.add_edge(parent, child)
 
-    node_dict = {}
+    node_dict: dict[URIRef, Node] = {}
     for parent in nx.topological_sort(node_graph):
         parent_name = graph.value(parent, SNS.local_identifier).toPython()
         node_dict[parent] = node_dict.get(parent, Node(parent_name))
@@ -441,7 +441,7 @@ def _uri_to_node_names(graph: Graph):
 def _uri_to_node_and_io_names(
     graph: Graph, uri_to_node: dict[URIRef, Node], G: nx.DiGraph
 ) -> dict[URIRef, Node | IO]:
-    io_dict = {}
+    io_dict: dict[URIRef, IO] = {}
     for uri, node in uri_to_node.items():
         for out in G.successors(uri):
             if out in uri_to_node:  # node; not an IO

--- a/semantikon/kg_to_flowrep.py
+++ b/semantikon/kg_to_flowrep.py
@@ -182,7 +182,7 @@ def _graph_to_function(graph: Graph, f_node: URIRef) -> dict[str, Any]:
     }
 
 
-def _networkx_to_dict(G: nx.DiGraph) -> fr.schemas.WorkflowRecipe:
+def _networkx_to_flowrep(G: nx.DiGraph) -> fr.schemas.WorkflowRecipe:
     """
     Convert a NetworkX DiGraph into flowrep WorkflowRecipe.
 
@@ -739,4 +739,4 @@ def kg2recipe(
         fr.schemas.WorkflowRecipe: Flowrep workflow recipe.
     """
     selected_workflow = _kg2digraph(graph, workflow_name=workflow_name)
-    return _networkx_to_dict(selected_workflow)
+    return _networkx_to_flowrep(selected_workflow)

--- a/semantikon/kg_to_flowrep.py
+++ b/semantikon/kg_to_flowrep.py
@@ -388,7 +388,7 @@ def _reorganize_output_edges(
     io_dict: dict[URIRef, URIRef] = {}
     for n in graph.predecessors(node):
         pred = list(graph.predecessors(n))
-        assert len(pred) == 1 and pred[0] not in io_dict
+        assert len(pred) == 1 and pred[0] not in io_dict, f"{pred}, {n}"
         io_dict[pred[0]] = n
     keys = sorted(io_dict.keys(), key=lambda item: position[item])[::-1]
     nodes = [io_dict[k] for k in keys]
@@ -403,7 +403,7 @@ def _reorganize_input_edges(
     io_dict: dict[URIRef, URIRef] = {}
     for n in graph.successors(node):
         succ = list(graph.successors(n))
-        assert len(succ) == 1 and succ[0] not in io_dict
+        assert len(succ) == 1 and succ[0] not in io_dict, succ
         io_dict[succ[0]] = n
     node_keys = sorted(io_dict.keys(), key=lambda item: position[item])
     for i, key_one in enumerate(node_keys):
@@ -421,108 +421,118 @@ def _reconnect_io(graph: nx.DiGraph, node: URIRef):
         graph.add_edge(outputs[0], inp)
 
 
-def _add_io_nodes(
-    graph: Graph,
-    workflow_graph: nx.DiGraph,
-    function_dict: dict[URIRef, dict[str, Any]],
-    node_function_dict: dict[URIRef, URIRef],
-    io_type: str,
-):
-    if io_type == "input":
-        io_query = graph.query(
-            _get_connection_query(SNS.workflow_node, SNS.has_part, SNS.input_assignment)
-        )
-    else:
-        io_query = graph.query(
-            _get_connection_query(
-                SNS.workflow_node, SNS.has_part, SNS.output_assignment
-            )
-        )
-    for row in io_query:
-        node, io_node = cast(ResultRow, row)
-        if io_type == "input":
-            workflow_graph.add_edge(io_node, node)
-        else:
-            workflow_graph.add_edge(node, io_node)
+def _uri_to_node_names(graph: Graph):
+    node_graph = nx.DiGraph()
+    for parent, child in graph.query(
+        _get_connection_query(SNS.workflow_node, SNS.has_part, SNS.workflow_node)
+    ):
+        node_graph.add_edge(parent, child)
 
-        func_node = node_function_dict.get(cast(URIRef, node))
-        function_data = function_dict.get(func_node) if func_node is not None else None
-        if function_data is None:
-            continue
-        workflow_graph.add_node(Node(node), function=function_data["data"])
+    node_dict = {}
+    for parent in nx.topological_sort(node_graph):
+        parent_name = graph.value(parent, SNS.local_identifier).toPython()
+        node_dict[parent] = node_dict.get(parent, Node(parent_name))
+        for child in node_graph.successors(parent):
+            assert child not in node_dict
+            child_name = graph.value(child, SNS.local_identifier).toPython()
+            node_dict[child] = Node(child_name, parent=node_dict[parent])
+    return node_dict
 
-        arg_values = list(graph.objects(io_node, SNS.local_identifier))
-        if len(arg_values) != 1:
-            raise ValueError(f"Expected one local identifier for {io_node!r}.")
-        arg = cast(Literal, arg_values[0]).toPython()
-        for data in function_data[f"{io_type}_args"]:
-            if arg == data["arg"]:
-                if io_type == "input":
-                    workflow_graph.add_node(Input(io_node, arg=arg), **data)
-                else:
-                    workflow_graph.add_node(Output(io_node, arg=arg), **data)
-                break
-        else:
-            raise ValueError(f"Could not match argument {arg!r} for {node!r}.")
+
+def _uri_to_node_and_io_names(
+    graph: Graph, uri_to_node: dict[URIRef, Node], G: nx.DiGraph
+) -> dict[URIRef, Node | IO]:
+    io_dict = {}
+    for uri, node in uri_to_node.items():
+        for out in G.successors(uri):
+            if out in uri_to_node:  # node; not an IO
+                continue
+            arg = graph.value(out, SNS.local_identifier)
+            io_dict[out] = Output(arg=arg.toPython(), node=node)
+        for inp in G.predecessors(uri):
+            if inp in uri_to_node:  # node; not an IO
+                continue
+            arg = graph.value(inp, SNS.local_identifier)
+            io_dict[inp] = Input(arg=arg.toPython(), node=node)
+    return io_dict | uri_to_node
 
 
 def _build_workflow_graph(graph: Graph) -> nx.DiGraph:
-    function_nodes = list(
-        cast(Iterable[URIRef], graph.subjects(RDF.type, SNS.workflow_function))
-    )
-    function_dict: dict[URIRef, dict[str, Any]] = {
-        f_node: _graph_to_function(graph, f_node) for f_node in function_nodes
-    }
-    node_function_dict = _node_functions(graph)
 
     workflow_graph = nx.DiGraph()
-    _add_io_nodes(
-        graph, workflow_graph, function_dict, node_function_dict, io_type="input"
-    )
-    _add_io_nodes(
-        graph, workflow_graph, function_dict, node_function_dict, io_type="output"
-    )
 
-    for row in graph.query(
+    for node, io_node in graph.query(
+        _get_connection_query(SNS.workflow_node, SNS.has_part, SNS.input_assignment)
+    ):
+        workflow_graph.add_edge(io_node, node)
+
+    for node, io_node in graph.query(
+        _get_connection_query(SNS.workflow_node, SNS.has_part, SNS.output_assignment)
+    ):
+        workflow_graph.add_edge(node, io_node)
+
+    for out_assignment, data_node in graph.query(
         _get_connection_query(
             SNS.output_assignment, SNS.has_participant, SNS.value_specification
         )
     ):
-        out_assignment, data_node = cast(ResultRow, row)
         workflow_graph.add_edge(out_assignment, data_node)
-        workflow_graph.add_node(data_node, step="data")
 
-    for row in graph.query(
+    for in_assignment, data_node in graph.query(
         _get_connection_query(
             SNS.input_assignment, SNS.has_participant, SNS.value_specification
         )
     ):
-        in_assignment, data_node = cast(ResultRow, row)
         workflow_graph.add_edge(data_node, in_assignment)
-        workflow_graph.add_node(data_node, step="data")
 
-    for row in graph.query(
+    # This is only needed to correctly identify input - input and
+    # output - output edges in the workflow graph.
+    for parent_node, child_node in graph.query(
         _get_connection_query(SNS.workflow_node, SNS.has_part, SNS.workflow_node)
     ):
-        parent, child = cast(ResultRow, row)
-        workflow_graph.add_edge(parent, child)
-        if parent not in workflow_graph:
-            workflow_graph.add_node(parent, step="node")
-        if child not in workflow_graph:
-            workflow_graph.add_node(child, step="node")
-        workflow_graph.nodes[child]["parent"] = _label(graph, cast(URIRef, parent))
-        workflow_graph.nodes[parent]["type"] = "workflow"
-        workflow_graph.nodes[child]["type"] = workflow_graph.nodes[child].get(
-            "type", "atomic"
-        )
+        workflow_graph.add_edge(parent_node, child_node)
+    return workflow_graph
 
+
+def _append_metadata_to_graph(graph: Graph, workflow_graph: nx.DiGraph) -> None:
+    node_to_f = _node_functions(graph)
+    for node in workflow_graph.nodes:
+        if not node in node_to_f:
+            continue
+        f_meta = _graph_to_function(graph, node_to_f[node])
+        workflow_graph.nodes[node]["function"] = f_meta["data"]
+        input_args = {ent.pop("arg"): ent for ent in f_meta["input_args"]}
+        output_args = {ent.pop("arg"): ent for ent in f_meta["output_args"]}
+        for inp_node in workflow_graph.predecessors(node):
+            if a := graph.value(inp_node, SNS.local_identifier):
+                if a.toPython() not in input_args:
+                    continue
+                for key, value in input_args[a.toPython()].items():
+                    workflow_graph.nodes[inp_node][key] = value
+        for out_node in workflow_graph.successors(node):
+            if a := graph.value(out_node, SNS.local_identifier):
+                if a.toPython() not in output_args:
+                    continue
+                for key, value in output_args[a.toPython()].items():
+                    workflow_graph.nodes[out_node][key] = value
+
+
+def _reorganize_workflow_graph(workflow_graph: nx.DiGraph) -> None:
+    """
+    Reorganize the workflow graph to ensure that data nodes are properly connected
+    to their input and output assignments, and that the graph is in a suitable
+    format for conversion to a flowrep WorkflowRecipe.
+
+    Args:
+        workflow_graph (nx.DiGraph): The workflow graph to reorganize.
+    """
     position = {
         node: i
         for i, node in enumerate(nx.topological_sort(workflow_graph))
         if isinstance(node, Node)
     }
-    for node, data in tuple(workflow_graph.nodes.data()):
-        if data.get("step") != "data":
+    for node in tuple(workflow_graph.nodes):
+        if not isinstance(node, URIRef):
             continue
         if len(list(workflow_graph.predecessors(node))) > 1:
             _reorganize_output_edges(workflow_graph, node, position)
@@ -536,9 +546,7 @@ def _build_workflow_graph(graph: Graph) -> nx.DiGraph:
 
     workflow_graph.remove_nodes_from(
         [
-            node
-            for node, data in workflow_graph.nodes.data()
-            if data.get("step") == "data"
+            node for node in workflow_graph.nodes if isinstance(node, URIRef)
         ]
     )
     workflow_graph.remove_edges_from(
@@ -548,11 +556,10 @@ def _build_workflow_graph(graph: Graph) -> nx.DiGraph:
             if all(isinstance(node, Node) for node in edge)
         ]
     )
-    return workflow_graph
 
 
 def _extract_constant_values_from_kg(
-    rdf_graph: Graph, workflow_graph: nx.DiGraph
+    rdf_graph: Graph, workflow_graph: nx.DiGraph, uri_to_node_and_io: dict[URIRef, Node | IO]
 ) -> None:
     """
     Extract constant values from the RDF knowledge graph and add them to
@@ -587,7 +594,8 @@ def _extract_constant_values_from_kg(
     }}"""
 
     for input_node, value_literal in rdf_graph.query(query):  # type: ignore[misc]
-        workflow_graph.nodes[input_node]["constant_value"] = (
+        inp = uri_to_node_and_io.get(input_node)
+        workflow_graph.nodes[inp]["constant_value"] = (
             _literal_to_constant(value_literal)
             if isinstance(value_literal, Literal)
             else value_literal
@@ -609,45 +617,22 @@ def _reconstruct_constant_nodes(G: nx.DiGraph) -> None:
         if not isinstance(node, Input) or "constant_value" not in data:
             continue
 
-        # Extract the parent node and argument name
-        # Node format: parent-inputs-arg
-        assert isinstance(node, Input), f"Expected 'inputs' in node name: {node}"
-
-        parent_node = node.node
-        parent_data = G.nodes[parent_node]
-        assert (
-            parent_data is not None
-        ), f"Parent node {parent_node} not found for {node} in {G.nodes}"
-        assert (
-            parent_data.get("step") == "node"
-        ), f"Parent node {parent_node} is not a workflow node for {node}"
-
-        # Create constant node name using a unique counter
-        assert (
-            "parent" in parent_data
-        ), f"Parent node {parent_node} is missing 'parent' attribute for {node}"
-        parent_prefix = parent_data["parent"] + "-"
-
         for constant_index in itertools.count():
-            const_node_name = (
-                f"{parent_prefix}{fr.schemas.ConstantRecipe.std_label}_{constant_index}"
+            const_node = Node(
+                name=f"{fr.schemas.ConstantRecipe.std_label}_{constant_index}",
+                parent=node.node.parent
             )
-            if const_node_name not in G:
+            if const_node not in G:
                 break
 
-        const_output_name = f"{const_node_name}-outputs-constant"
+        const_output_name = Output(arg="constant", node=const_node)
 
         # Create the constant node
-        const_node_attrs = TNodeData(
-            type="constant",
-            step="node",
-            parent=parent_data.get("parent"),
-        )
-        G.add_node(const_node_name, **const_node_attrs.to_attrs())
+        const_node_attrs = TNodeData(type="constant")
+        G.add_node(const_node, **const_node_attrs.to_attrs())
 
         # Create the constant output node
         const_output_attrs = TOutputData(
-            arg=fr.schemas.ConstantRecipe.std_label,
             position=0,
             value=data["constant_value"],
             has_value=True,
@@ -656,113 +641,85 @@ def _reconstruct_constant_nodes(G: nx.DiGraph) -> None:
         G.add_node(const_output_name, **const_output_attrs.to_attrs())
 
         # Record edges to add
-        G.add_edge(const_node_name, const_output_name)
+        G.add_edge(const_node, const_output_name)
         G.add_edge(const_output_name, node)
 
 
-def _workflow_roots(graph: Graph) -> dict[URIRef, str]:
-    node_graph = nx.DiGraph()
-    workflow_nodes = list(graph.subjects(RDFS.subClassOf, SNS.workflow_node))
-    node_graph.add_nodes_from(workflow_nodes)
-    node_graph.add_edges_from(
-        graph.query(
-            _get_connection_query(SNS.workflow_node, SNS.has_part, SNS.workflow_node)
-        )
-    )
-    roots = [node for node in node_graph.nodes if node_graph.in_degree(node) == 0]
-    return {root: _label(graph, root) for root in roots}
-
-
-def _split_by_roots(
-    graph: Graph, workflow_graph: nx.DiGraph, roots: dict[URIRef, str]
-) -> dict[str, nx.DiGraph]:
-    subgraphs: dict[str, nx.DiGraph] = {}
-    for component in nx.weakly_connected_components(workflow_graph):
-        component_nodes = set(component)
-        component_workflows = component_nodes & set(roots.keys())
-        if len(component_workflows) == 0:
-            raise ValueError("Could not assign graph component to a root workflow.")
-        if len(component_workflows) > 1:
-            raise ValueError(
-                "A graph component contains more than one root workflow: "
-                f"{sorted(roots[uri] for uri in component_workflows)}"
-            )
-        root_uri = next(iter(component_workflows))
-        name = roots[root_uri]
-        subgraph = workflow_graph.subgraph(component).copy()
-        # Relabel nodes to strings after splitting
-        mapping = {node: _label(graph, node) for node in subgraph.nodes}
-        subgraph = nx.relabel_nodes(subgraph, mapping)
-        subgraph.name = str(name)
-        subgraphs[name] = subgraph
-    return subgraphs
-
-
-def _select_workflow(
-    graph: Graph,
-    roots: dict[URIRef, str],
-    workflows: Iterable[str],
-    workflow_name: str | URIRef | None,
-) -> str:
-    names = sorted(set(workflows))
-    if workflow_name is not None:
-        if isinstance(workflow_name, URIRef):
-            if workflow_name in roots:
-                return roots[workflow_name]
-            raise ValueError(
-                f"Unknown workflow URIRef {workflow_name!r}. Available workflows: {sorted(roots.keys())}"
-            )
-        if workflow_name in names:
-            return workflow_name
-        by_identifier: dict[str, list[str]] = {}
-        for uri, label in roots.items():
-            by_identifier.setdefault(_identifier(graph, uri), []).append(label)
-        matches = by_identifier.get(workflow_name, [])
-        if len(matches) == 1:
-            return matches[0]
-        if len(matches) > 1:
-            raise ValueError(
-                f"Workflow identifier {workflow_name!r} is ambiguous. Matches: {matches}"
-            )
-        if workflow_name not in names:
-            raise ValueError(
-                f"Unknown workflow {workflow_name!r}. Available workflows: {names}"
-            )
-    if len(names) != 1:
-        raise ValueError(
-            "Graph contains multiple root workflows. Pass `workflow_name` explicitly. "
-            f"Available workflows: {names}"
-        )
-    return names[0]
-
-
-def _kg2digraph(graph: Graph, workflow_name: str | URIRef | None = None) -> nx.DiGraph:
-    roots = _workflow_roots(graph)
+def _ensure_workflow_name(
+    wf_name: str | URIRef | None, uri_to_node: dict[URIRef, Node]
+) -> URIRef:
+    roots = {k: v for k, v in uri_to_node.items() if v.parent is None}
     if len(roots) == 0:
         raise ValueError(
             "No workflow nodes found in graph. Ensure T-box information is present "
             "(e.g. include_t_box=True in get_knowledge_graph)."
         )
-    if len(roots) > 1 and workflow_name is None:
-        wfs = sorted(roots.values())
-        wfs = (
-            sorted(roots.keys()) + wfs
-            if len(wfs) == len(set(wfs))
-            else sorted(roots.keys())
-        )
+    elif len(roots) == 1:
+        if (
+            wf_name is None
+            or wf_name in roots
+            or str(wf_name) in [str(v) for v in roots.values()]
+        ):
+            return next(iter(roots.keys()))
         raise ValueError(
-            "Graph contains multiple root workflows. Pass `workflow_name` explicitly. "
-            f"Available workflows: {wfs}"
+            f"Unknown workflow {wf_name!r}. Available workflow: {list(roots.keys()) + list(roots.values())!r}"
         )
-    workflow_graph = _build_workflow_graph(graph)
-    _extract_constant_values_from_kg(graph, workflow_graph)
-    workflows = _split_by_roots(graph, workflow_graph, roots)
-    selected_name = _select_workflow(
-        graph, roots, workflows.keys(), workflow_name=workflow_name
-    )
-    selected_workflow = workflows[selected_name]
-    _reconstruct_constant_nodes(selected_workflow)
-    return selected_workflow
+    else:
+        if wf_name is None:
+            wfs = sorted([str(r) for r in roots.values()])
+            wfs = (
+                sorted(roots.keys()) + wfs
+                if len(wfs) == len(set(wfs))
+                else sorted(roots.keys())
+            )
+            raise ValueError(
+                "Graph contains multiple root workflows. Pass `workflow_name` explicitly. "
+                f"Available workflows: {wfs}"
+            )
+        if c := [str(v) for v in roots.values()].count(str(wf_name)):
+            if c > 1:
+                raise ValueError(
+                    f"Ambiguous workflow name {wf_name!r}. It matches {c} workflows. "
+                    f"Available workflows: {list(roots.keys()) + list(roots.values())!r}"
+                )
+            return next(k for k, v in roots.items() if str(v) == str(wf_name))
+        elif wf_name in roots:
+            return wf_name
+        else:
+            raise ValueError(
+                f"Unknown workflow {wf_name!r}. Available workflows: {list(roots.keys()) + list(roots.values())!r}"
+            )
+
+
+def _extract_workflow(
+    workflow_graph: nx.DiGraph, workflow_name: str | URIRef
+) -> nx.DiGraph:
+    for node in nx.weakly_connected_components(workflow_graph):
+        if workflow_name in node:
+            return workflow_graph.subgraph(node)
+    # In principle this error cannot be raised because it is already checked
+    # in _ensure_workflow_name, but we keep it for safety.
+    raise ValueError(f"Workflow {workflow_name!r} not found in the graph.")
+
+
+def _rename_workflow(
+    workflow_graph: nx.DiGraph, uri_to_node: dict[URIRef, Node], uri_to_node_and_io: dict[URIRef, Node | IO], graph: Graph
+) -> nx.DiGraph:
+    return nx.relabel_nodes(workflow_graph, uri_to_node_and_io)
+
+
+def _kg2digraph(graph: Graph, workflow_name: str | URIRef | None = None) -> nx.DiGraph:
+    uri_to_node = _uri_to_node_names(graph)
+    all_workflow_graph = _build_workflow_graph(graph)
+    workflow_name = _ensure_workflow_name(workflow_name, uri_to_node)
+    workflow_graph = _extract_workflow(all_workflow_graph, workflow_name)
+    _append_metadata_to_graph(graph, workflow_graph)
+    uri_to_node_and_io = _uri_to_node_and_io_names(graph, uri_to_node, workflow_graph)
+    renamed_workflow_graph = _rename_workflow(workflow_graph, uri_to_node, uri_to_node_and_io, graph)
+    _reorganize_workflow_graph(renamed_workflow_graph)
+    _extract_constant_values_from_kg(graph, renamed_workflow_graph, uri_to_node_and_io)
+    _reconstruct_constant_nodes(renamed_workflow_graph)
+    return renamed_workflow_graph
 
 
 def kg2recipe(

--- a/semantikon/kg_to_flowrep.py
+++ b/semantikon/kg_to_flowrep.py
@@ -9,7 +9,7 @@ import networkx as nx
 from pyiron_snippets import retrieve
 from rdflib import OWL, RDF, RDFS, Graph, Literal, URIRef
 from rdflib.namespace import SH
-from rdflib.term import IdentifiedNode, Node
+from rdflib import term
 
 from semantikon.flowrep_dict import _flowrep_recipe_from_callable
 from semantikon.flowrep_to_networkx import (
@@ -35,10 +35,10 @@ def _graph_to_function(graph: Graph, f_node: URIRef) -> dict[str, Any]:
         dict[str, Any]: Data payload compatible with ``_function_to_graph``.
     """
 
-    def _to_python(value: Node | None) -> Any:
+    def _to_python(value: term.Node | None) -> Any:
         return value.toPython() if isinstance(value, Literal) else value
 
-    def _restriction_pairs(node: IdentifiedNode) -> tuple[tuple[URIRef, Any], ...]:
+    def _restriction_pairs(node: term.IdentifiedNode) -> tuple[tuple[URIRef, Any], ...]:
         return tuple(
             (cast(URIRef, p), _to_python(o)) for p, o in graph.predicate_objects(node)
         )
@@ -148,7 +148,7 @@ def _graph_to_function(graph: Graph, f_node: URIRef) -> dict[str, Any]:
                 pairs = tuple(
                     pair
                     for pair in _restriction_pairs(
-                        cast(IdentifiedNode, restriction_node)
+                        cast(term.IdentifiedNode, restriction_node)
                     )
                     if pair[0] != RDF.type
                 )
@@ -158,7 +158,7 @@ def _graph_to_function(graph: Graph, f_node: URIRef) -> dict[str, Any]:
                     continue
                 pairs = tuple(
                     pair
-                    for pair in _restriction_pairs(cast(IdentifiedNode, property_shape))
+                    for pair in _restriction_pairs(cast(term.IdentifiedNode, property_shape))
                     if pair[0] != RDF.type
                 )
             else:

--- a/semantikon/kg_to_flowrep.py
+++ b/semantikon/kg_to_flowrep.py
@@ -221,7 +221,7 @@ def _networkx_to_flowrep(G: SemantikonDiGraph) -> fr.schemas.WorkflowRecipe:
 
     def _process_node(node_name: Node) -> fr.schemas.RecipeDiscrimination:
         node_data = G.nodes[node_name]
-        node_type = G.get_type(node_name)
+        node_type = node_data.get("type", "atomic")
         if node_type == "constant":
             output_node = list(G.successors(node_name))
             assert (
@@ -753,7 +753,7 @@ def _kg2digraph(graph: Graph, workflow_name: str | URIRef | None = None) -> Sema
     _extract_constant_values_from_kg(graph, renamed_workflow_graph, uri_to_node_and_io)
     _reconstruct_constant_nodes(renamed_workflow_graph)
     semantikon_digraph = _translate_to_semantikon_digraph(renamed_workflow_graph)
-    return renamed_workflow_graph
+    return semantikon_digraph
 
 
 def kg2recipe(

--- a/semantikon/kg_to_flowrep.py
+++ b/semantikon/kg_to_flowrep.py
@@ -601,6 +601,8 @@ def _extract_constant_values_from_kg(
 
     for input_node, value_literal in rdf_graph.query(query):  # type: ignore[misc]
         inp = uri_to_node_and_io.get(input_node)  # type: ignore[arg-type]
+        if inp not in workflow_graph:
+            continue
         workflow_graph.nodes[inp]["constant_value"] = (
             _literal_to_constant(value_literal)
             if isinstance(value_literal, Literal)

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -644,7 +644,7 @@ def _input_is_connected(io: IO | Node, G: SemantikonDiGraph) -> bool:
         raise ValueError(f"Too many predecessors for {io}: {candidate}")
 
 
-def _is_macro_output(io: IO | Node, G: SemantikonDiGraph, candidates: tuple[str, str]):
+def _is_macro_output(io: IO | Node, G: SemantikonDiGraph, candidates: tuple[Node | IO, Node | IO]):
     return isinstance(io, Output) and (
         isinstance(candidates[0], Node)
         and isinstance(candidates[1], Output)

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -551,15 +551,15 @@ def _wf_node_to_graph(
                 uri=data.get("uri"),
             )
     if t_box:
-        node = BASE[G.t_ns + node_name]
+        node = BASE[G.t_ns + str(node_name)]
         for io in [G.predecessors(node_name), G.successors(node_name)]:
             for item in io:
                 g += _to_owl_restriction(
                     node,
                     SNS.has_part,
-                    BASE[G.t_ns + item],
+                    BASE[G.t_ns + str(item)],
                 )
-        g.add((BASE[G.t_ns + node_name], RDFS.subClassOf, SNS.workflow_node))
+        g.add((BASE[G.t_ns + str(node_name)], RDFS.subClassOf, SNS.workflow_node))
         if "function" in data:
             g += _to_owl_restriction(
                 node,
@@ -568,20 +568,20 @@ def _wf_node_to_graph(
                 restriction_type=OWL.hasValue,
             )
         g.add((node, RDFS.label, Literal(node_name)))
-        g.add((node, SNS.local_identifier, Literal(node_name.split("-")[-1])))
+        g.add((node, SNS.local_identifier, Literal(node_name.name)))
         if data.get("parent"):
             g += _to_owl_restriction(
-                BASE[G.t_ns + data["parent"]],
+                BASE[G.t_ns + str(data["parent"])],
                 SNS.has_part,
                 node,
             )
     else:
-        node = BASE[G.a_ns + node_name]
-        g.add((node, RDF.type, BASE[G.t_ns + node_name]))
+        node = BASE[G.a_ns + str(node_name)]
+        g.add((node, RDF.type, BASE[G.t_ns + str(node_name)]))
         for inp in G.predecessors(node_name):
-            g.add((node, SNS.has_part, BASE[G.a_ns + inp]))
+            g.add((node, SNS.has_part, BASE[G.a_ns + str(inp)]))
         for out in G.successors(node_name):
-            g.add((node, SNS.has_part, BASE[G.a_ns + out]))
+            g.add((node, SNS.has_part, BASE[G.a_ns + str(out)]))
         if "function" in data:
             g.add((node, SNS.concretizes, f_node))
         if data.get("parent"):
@@ -877,10 +877,10 @@ def _wf_io_to_graph(
     has_specified_io: URIRef,
     t_box: bool,
 ) -> Graph:
-    node = BASE[G.t_ns + node_name] if t_box else BASE[G.a_ns + node_name]
+    node = BASE[G.t_ns + str(node_name)] if t_box else BASE[G.a_ns + str(node_name)]
     g = _get_bound_graph()
     g.add((node, RDFS.label, Literal(node_name)))
-    g.add((node, SNS.local_identifier, Literal(node_name.split("-")[-1])))
+    g.add((node, SNS.local_identifier, Literal(node_name.arg)))
     if t_box:
         g += _to_owl_restriction(node, has_specified_io, data_node)
         g.add((node, RDFS.subClassOf, io_assignment))
@@ -973,9 +973,9 @@ def _nx_to_kg(G: SemantikonDiGraph, t_box: bool) -> Graph:
         data = data.copy()
         step = data.pop("step")
         if t_box:
-            g.add((BASE[G.t_ns + node_name], RDF.type, OWL.Class))
+            g.add((BASE[G.t_ns + str(node_name)], RDF.type, OWL.Class))
         else:
-            g.add((BASE[G.a_ns + node_name], RDF.type, BASE[G.t_ns + node_name]))
+            g.add((BASE[G.a_ns + str(node_name)], RDF.type, BASE[G.t_ns + str(node_name)]))
         assert step in ["node", "inputs", "outputs"], f"Unknown step: {step}"
         if step == "node":
             g += _wf_node_to_graph(

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -27,6 +27,10 @@ from semantikon.flowrep_to_networkx import (
     SemantikonDiGraph,
     _get_graph_hash,
     serialize_and_convert_to_networkx,
+    IO,
+    Input,
+    Node,
+    Output,
 )
 from semantikon.metadata import SemantikonURI
 from semantikon.qudt import UnitsDict
@@ -265,9 +269,7 @@ def _check_consistency_of_digraph(G: SemantikonDiGraph):
     for node, data in G.nodes.data():
         if "derived_from" not in data:
             continue
-        expected_input = node.rsplit("-outputs-", 1)[
-            0
-        ] + f"-{data['derived_from']}".replace(".", "-")
+        expected_input = Input(node=node.node, arg=data['derived_from'].replace("inputs.", ""))
         if expected_input not in G.nodes:
             raise ValueError(
                 f"Node '{node}' is derived from '{data['derived_from']}' but"
@@ -613,7 +615,7 @@ def _is_macro_input(io: str, G: SemantikonDiGraph, candidates: tuple[str, str]):
     return step_type == "inputs" and successor_types == input_edge_predecessors
 
 
-def _input_is_connected(io: str, G: SemantikonDiGraph) -> bool:
+def _input_is_connected(io: IO | Node, G: SemantikonDiGraph) -> bool:
     candidate = list(G.predecessors(io))
     n_predecessors = len(candidate)
     if n_predecessors == 0:
@@ -636,28 +638,27 @@ def _input_is_connected(io: str, G: SemantikonDiGraph) -> bool:
         )
 
 
-def _is_macro_output(io: str, G: SemantikonDiGraph, candidates: tuple[str, str]):
+def _is_macro_output(io: IO | Node, G: SemantikonDiGraph, candidates: tuple[str, str]):
     predecessor_types = {G.nodes[c]["step"] for c in candidates}
     step_type = G.nodes[io]["step"]
     output_edge_predecessors = {"node", "outputs"}
     return step_type == "outputs" and predecessor_types == output_edge_predecessors
 
 
-def _detect_io_from_str(G: SemantikonDiGraph, seeked_io: str, ref_io: str) -> str:
+def _detect_io_from_str(G: SemantikonDiGraph, seeked_io: str, ref_io: IO) -> str:
     assert seeked_io.startswith(("inputs", "outputs"))
-    main_node = ref_io.replace(".", "-").split("-outputs-")[0].split("-inputs-")[0]
-    candidate = (
-        G.predecessors(main_node) if "inputs" in seeked_io else G.successors(main_node)
-    )
-    for io in candidate:
-        if io.endswith(seeked_io.replace(".", "-")):
-            return G._get_data_node(io=io)
-    raise ValueError(f"IO {seeked_io} not found in graph")
+    if seeked_io.startswith("inputs"):
+        full_io = Input(node=ref_io.node, arg=seeked_io.replace("inputs.", ""))
+    else:
+        full_io = Output(node=ref_io.node, arg=seeked_io.replace("outputs.", ""))
+    if full_io not in G.nodes:
+        raise ValueError(f"IO {seeked_io} not found in graph")
+    return G._get_data_node(io=full_io)
 
 
 def _translate_triples(
     triples: TripleList,
-    node_name: str,
+    node_name: IO,
     data_node: URIRef,
     G: SemantikonDiGraph,
     t_box: bool,
@@ -755,7 +756,7 @@ def _restrictions_to_triples(
 
 
 def _wf_input_to_graph(
-    node_name: str,
+    node_name: Input,
     data: dict,
     G: SemantikonDiGraph,
     t_box: bool,
@@ -823,7 +824,7 @@ def _wf_input_to_graph(
 
 
 def _wf_output_to_graph(
-    node_name: str,
+    node_name: Output,
     data: dict,
     G: SemantikonDiGraph,
     t_box: bool,
@@ -869,7 +870,7 @@ def _wf_output_to_graph(
 
 
 def _wf_io_to_graph(
-    node_name: str,
+    node_name: IO,
     data: dict,
     data_node: URIRef,
     G: SemantikonDiGraph,

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -269,7 +269,9 @@ def _check_consistency_of_digraph(G: SemantikonDiGraph):
     for node, data in G.nodes.data():
         if "derived_from" not in data:
             continue
-        expected_input = Input(node=node.node, arg=data['derived_from'].replace("inputs.", ""))
+        expected_input = Input(
+            node=node.node, arg=data["derived_from"].replace("inputs.", "")
+        )
         if expected_input not in G.nodes:
             raise ValueError(
                 f"Node '{node}' is derived from '{data['derived_from']}' but"
@@ -976,9 +978,7 @@ def _nx_to_kg(G: SemantikonDiGraph, t_box: bool) -> Graph:
         if t_box:
             g.add((BASE[G.t_ns + node_name], RDF.type, OWL.Class))
         else:
-            g.add(
-                (BASE[G.a_ns + node_name], RDF.type, BASE[G.t_ns + node_name])
-            )
+            g.add((BASE[G.a_ns + node_name], RDF.type, BASE[G.t_ns + node_name]))
         assert step in ["node", "inputs", "outputs"], f"Unknown step: {step}"
         if step == "node":
             g += _wf_node_to_graph(

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -571,7 +571,7 @@ def _wf_node_to_graph(
                 f_node,
                 restriction_type=OWL.hasValue,
             )
-        g.add((node, RDFS.label, Literal(node_name)))
+        g.add((node, RDFS.label, Literal(str(node_name))))
         g.add((node, SNS.local_identifier, Literal(node_name.name)))
         if data.get("parent"):
             g += _to_owl_restriction(
@@ -882,7 +882,7 @@ def _wf_io_to_graph(
 ) -> Graph:
     node = BASE[G.t_ns + node_name] if t_box else BASE[G.a_ns + node_name]
     g = _get_bound_graph()
-    g.add((node, RDFS.label, Literal(node_name)))
+    g.add((node, RDFS.label, Literal(str(node_name))))
     g.add((node, SNS.local_identifier, Literal(node_name.arg)))
     if t_box:
         g += _to_owl_restriction(node, has_specified_io, data_node)

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -593,13 +593,13 @@ def _wf_node_to_graph(
     return g
 
 
-def _output_is_connected(io: str, G: SemantikonDiGraph) -> bool:
+def _output_is_connected(io: Node | IO, G: SemantikonDiGraph) -> bool:
     candidate = list(G.successors(io))
     n_candidates = len(candidate)
     if n_candidates == 0:
         return False
     elif n_candidates == 1:
-        if G.nodes[candidate[0]]["step"] == "node":
+        if isinstance(candidate[0], Node):
             return True
         return _output_is_connected(candidate[0], G)
     elif n_candidates == 2 and _is_macro_input(io, G, tuple(candidate)):
@@ -610,11 +610,15 @@ def _output_is_connected(io: str, G: SemantikonDiGraph) -> bool:
         return any(_output_is_connected(c, G) for c in candidate)
 
 
-def _is_macro_input(io: str, G: SemantikonDiGraph, candidates: tuple[str, str]):
-    successor_types = {G.nodes[c]["step"] for c in candidates}
-    step_type = G.nodes[io]["step"]
-    input_edge_predecessors = {"node", "inputs"}
-    return step_type == "inputs" and successor_types == input_edge_predecessors
+def _is_macro_input(
+    io: Node | IO, G: SemantikonDiGraph, candidates: tuple[Node | IO, Node | IO]
+):
+    return isinstance(io, Input) and (
+        isinstance(candidates[0], Node)
+        and isinstance(candidates[1], Input)
+        or isinstance(candidates[1], Node)
+        and isinstance(candidates[0], Input)
+    )
 
 
 def _input_is_connected(io: IO | Node, G: SemantikonDiGraph) -> bool:
@@ -623,28 +627,24 @@ def _input_is_connected(io: IO | Node, G: SemantikonDiGraph) -> bool:
     if n_predecessors == 0:
         return False
     elif n_predecessors == 1:
-        if G.nodes[candidate[0]]["step"] == "node":
+        if isinstance(candidate[0], Node):
             return True
         return _input_is_connected(candidate[0], G)
     elif n_predecessors == 2 and _is_macro_output(io, G, tuple(candidate)):
         return all(
-            _input_is_connected(cc, G)
-            for cc in candidate
-            if G.nodes[cc]["step"] != "node"
+            _input_is_connected(cc, G) for cc in candidate if not isinstance(cc, Node)
         )
     else:
-        predecessor_steps = {c: G.nodes[c]["step"] for c in candidate}
-        step_type = G.nodes[io]["step"]
-        raise ValueError(
-            f"Too many predecessors for {io} ({step_type}): {predecessor_steps}"
-        )
+        raise ValueError(f"Too many predecessors for {io}: {candidate}")
 
 
 def _is_macro_output(io: IO | Node, G: SemantikonDiGraph, candidates: tuple[str, str]):
-    predecessor_types = {G.nodes[c]["step"] for c in candidates}
-    step_type = G.nodes[io]["step"]
-    output_edge_predecessors = {"node", "outputs"}
-    return step_type == "outputs" and predecessor_types == output_edge_predecessors
+    return isinstance(io, Output) and (
+        isinstance(candidates[0], Node)
+        and isinstance(candidates[1], Output)
+        or isinstance(candidates[1], Node)
+        and isinstance(candidates[0], Output)
+    )
 
 
 def _detect_io_from_str(G: SemantikonDiGraph, seeked_io: str, ref_io: IO) -> str:
@@ -767,7 +767,7 @@ def _wf_input_to_graph(
     units = data.get("units", data.get("unit"))
     if "derived_from" in data:
         raise ValueError(
-            f"'derived_from' (defined for the argument '{data['arg']}') is not"
+            f"'derived_from' (defined for the argument '{node_name.arg}') is not"
             " supported for inputs."
         )
     if t_box:
@@ -776,8 +776,8 @@ def _wf_input_to_graph(
             out = list(G.predecessors(node_name))
             assert len(out) <= 1
             if len(out) == 1:
-                assert G.nodes[out[0]]["step"] in ["outputs", "inputs"]
-                if G.nodes[out[0]]["step"] == "outputs":
+                assert isinstance(out[0], IO)
+                if isinstance(out[0], Output):
                     g += _to_owl_restriction(
                         BASE[G.t_ns + out[0]], SNS.has_participant, data_node
                     )
@@ -921,13 +921,13 @@ def _parse_precedes(
     t_box: bool,
 ) -> Graph:
     g = _get_bound_graph()
-    for node in G.nodes.data():
-        if node[1]["step"] == "node":
-            successors = list(_get_successor_nodes(G, node[0]))
+    for node in G.nodes:
+        if isinstance(node, Node):
+            successors = list(_get_successor_nodes(G, node))
             if t_box:
                 for succ in successors:
                     g += _to_owl_restriction(
-                        BASE[G.t_ns + node[0]],
+                        BASE[G.t_ns + node],
                         SNS.precedes,
                         BASE[G.t_ns + succ],
                     )
@@ -935,7 +935,7 @@ def _parse_precedes(
                 for succ in successors:
                     g.add(
                         (
-                            BASE[G.a_ns + node[0]],
+                            BASE[G.a_ns + node],
                             SNS.precedes,
                             BASE[G.a_ns + succ],
                         )
@@ -949,13 +949,9 @@ def _parse_global_io(
     t_box: bool,
 ) -> Graph:
     g = _get_bound_graph()
-    global_inputs = [
-        n for n in G.nodes.data() if G.in_degree(n[0]) == 0 and n[1]["step"] == "inputs"
-    ]
+    global_inputs = [n for n in G.nodes if G.in_degree(n) == 0 and isinstance(n, Input)]
     global_outputs = [
-        n
-        for n in G.nodes.data()
-        if G.out_degree(n[0]) == 0 and n[1]["step"] == "outputs"
+        n for n in G.nodes if G.out_degree(n) == 0 and isinstance(n, Output)
     ]
     for global_io in [global_inputs, global_outputs]:
         for io in global_io:
@@ -974,20 +970,18 @@ def _nx_to_kg(G: SemantikonDiGraph, t_box: bool) -> Graph:
     g = _get_bound_graph()
     for node_name, data in G.nodes.data():
         data = data.copy()
-        step = data.pop("step")
         if t_box:
             g.add((BASE[G.t_ns + node_name], RDF.type, OWL.Class))
         else:
             g.add((BASE[G.a_ns + node_name], RDF.type, BASE[G.t_ns + node_name]))
-        assert step in ["node", "inputs", "outputs"], f"Unknown step: {step}"
-        if step == "node":
+        if isinstance(node_name, Node):
             g += _wf_node_to_graph(
                 node_name=node_name,
                 data=data,
                 G=G,
                 t_box=t_box,
             )
-        elif step == "inputs":
+        elif isinstance(node_name, Input):
             g += _wf_input_to_graph(
                 node_name=node_name,
                 data=data,

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -644,7 +644,9 @@ def _input_is_connected(io: IO | Node, G: SemantikonDiGraph) -> bool:
         raise ValueError(f"Too many predecessors for {io}: {candidate}")
 
 
-def _is_macro_output(io: IO | Node, G: SemantikonDiGraph, candidates: tuple[Node | IO, Node | IO]):
+def _is_macro_output(
+    io: IO | Node, G: SemantikonDiGraph, candidates: tuple[Node | IO, Node | IO]
+):
     return isinstance(io, Output) and (
         isinstance(candidates[0], Node)
         and isinstance(candidates[1], Output)

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -550,8 +550,14 @@ def _wf_node_to_graph(
             g += _function_to_graph(
                 f_node,
                 data["function"],
-                input_args=[{"arg": item.arg} | G.nodes[item] for item in G.predecessors(node_name)],
-                output_args=[{"arg": item.arg} | G.nodes[item] for item in G.successors(node_name)],
+                input_args=[
+                    {"arg": item.arg} | G.nodes[item]
+                    for item in G.predecessors(node_name)
+                ],
+                output_args=[
+                    {"arg": item.arg} | G.nodes[item]
+                    for item in G.successors(node_name)
+                ],
                 uri=data.get("uri"),
             )
     if t_box:

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -24,13 +24,13 @@ from semantikon.converter import (
     parse_output_args,
 )
 from semantikon.flowrep_to_networkx import (
-    SemantikonDiGraph,
-    _get_graph_hash,
-    serialize_and_convert_to_networkx,
     IO,
     Input,
     Node,
     Output,
+    SemantikonDiGraph,
+    _get_graph_hash,
+    serialize_and_convert_to_networkx,
 )
 from semantikon.metadata import SemantikonURI
 from semantikon.qudt import UnitsDict

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -538,7 +538,7 @@ def _graph_to_function(graph: Graph, f_node: URIRef) -> dict[str, Any]:
 
 
 def _wf_node_to_graph(
-    node_name: Node | IO,
+    node_name: Node,
     data: dict,
     G: SemantikonDiGraph,
     t_box: bool,
@@ -655,6 +655,7 @@ def _is_macro_output(io: IO | Node, G: SemantikonDiGraph, candidates: tuple[str,
 
 def _detect_io_from_str(G: SemantikonDiGraph, seeked_io: str, ref_io: IO) -> str:
     assert seeked_io.startswith(("inputs", "outputs"))
+    full_io: IO
     if seeked_io.startswith("inputs"):
         full_io = Input(node=ref_io.node, port=seeked_io.replace("inputs.", ""))
     else:
@@ -955,20 +956,22 @@ def _parse_global_io(
     t_box: bool,
 ) -> Graph:
     g = _get_bound_graph()
-    global_inputs = [n for n in G.nodes if G.in_degree(n) == 0 and isinstance(n, Input)]
-    global_outputs = [
+    global_inputs: list[Input] = [
+        n for n in G.nodes if G.in_degree(n) == 0 and isinstance(n, Input)
+    ]
+    global_outputs: list[Output] = [
         n for n in G.nodes if G.out_degree(n) == 0 and isinstance(n, Output)
     ]
-    for global_io in [global_inputs, global_outputs]:
-        for io in global_io:
+    for io_list in (global_inputs, global_outputs):
+        for io in io_list:
             if t_box:
                 g += _to_owl_restriction(
                     workflow_node,
                     SNS.has_part,
-                    BASE[G.t_ns + io[0]],
+                    BASE[G.t_ns + io],
                 )
             else:
-                g.add((workflow_node, SNS.has_part, BASE[G.a_ns + io[0]]))
+                g.add((workflow_node, SNS.has_part, BASE[G.a_ns + io]))
     return g
 
 

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -551,15 +551,15 @@ def _wf_node_to_graph(
                 uri=data.get("uri"),
             )
     if t_box:
-        node = BASE[G.t_ns + str(node_name)]
+        node = BASE[G.t_ns + node_name]
         for io in [G.predecessors(node_name), G.successors(node_name)]:
             for item in io:
                 g += _to_owl_restriction(
                     node,
                     SNS.has_part,
-                    BASE[G.t_ns + str(item)],
+                    BASE[G.t_ns + item],
                 )
-        g.add((BASE[G.t_ns + str(node_name)], RDFS.subClassOf, SNS.workflow_node))
+        g.add((BASE[G.t_ns + node_name], RDFS.subClassOf, SNS.workflow_node))
         if "function" in data:
             g += _to_owl_restriction(
                 node,
@@ -571,17 +571,17 @@ def _wf_node_to_graph(
         g.add((node, SNS.local_identifier, Literal(node_name.name)))
         if data.get("parent"):
             g += _to_owl_restriction(
-                BASE[G.t_ns + str(data["parent"])],
+                BASE[G.t_ns + data["parent"]],
                 SNS.has_part,
                 node,
             )
     else:
-        node = BASE[G.a_ns + str(node_name)]
-        g.add((node, RDF.type, BASE[G.t_ns + str(node_name)]))
+        node = BASE[G.a_ns + node_name]
+        g.add((node, RDF.type, BASE[G.t_ns + node_name]))
         for inp in G.predecessors(node_name):
-            g.add((node, SNS.has_part, BASE[G.a_ns + str(inp)]))
+            g.add((node, SNS.has_part, BASE[G.a_ns + inp]))
         for out in G.successors(node_name):
-            g.add((node, SNS.has_part, BASE[G.a_ns + str(out)]))
+            g.add((node, SNS.has_part, BASE[G.a_ns + out]))
         if "function" in data:
             g.add((node, SNS.concretizes, f_node))
         if data.get("parent"):
@@ -877,7 +877,7 @@ def _wf_io_to_graph(
     has_specified_io: URIRef,
     t_box: bool,
 ) -> Graph:
-    node = BASE[G.t_ns + str(node_name)] if t_box else BASE[G.a_ns + str(node_name)]
+    node = BASE[G.t_ns + node_name] if t_box else BASE[G.a_ns + node_name]
     g = _get_bound_graph()
     g.add((node, RDFS.label, Literal(node_name)))
     g.add((node, SNS.local_identifier, Literal(node_name.arg)))
@@ -973,10 +973,10 @@ def _nx_to_kg(G: SemantikonDiGraph, t_box: bool) -> Graph:
         data = data.copy()
         step = data.pop("step")
         if t_box:
-            g.add((BASE[G.t_ns + str(node_name)], RDF.type, OWL.Class))
+            g.add((BASE[G.t_ns + node_name], RDF.type, OWL.Class))
         else:
             g.add(
-                (BASE[G.a_ns + str(node_name)], RDF.type, BASE[G.t_ns + str(node_name)])
+                (BASE[G.a_ns + node_name], RDF.type, BASE[G.t_ns + node_name])
             )
         assert step in ["node", "inputs", "outputs"], f"Unknown step: {step}"
         if step == "node":

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -550,8 +550,8 @@ def _wf_node_to_graph(
             g += _function_to_graph(
                 f_node,
                 data["function"],
-                input_args=[G.nodes[item] for item in G.predecessors(node_name)],
-                output_args=[G.nodes[item] for item in G.successors(node_name)],
+                input_args=[{"arg": item.arg} | G.nodes[item] for item in G.predecessors(node_name)],
+                output_args=[{"arg": item.arg} | G.nodes[item] for item in G.successors(node_name)],
                 uri=data.get("uri"),
             )
     if t_box:

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -975,7 +975,9 @@ def _nx_to_kg(G: SemantikonDiGraph, t_box: bool) -> Graph:
         if t_box:
             g.add((BASE[G.t_ns + str(node_name)], RDF.type, OWL.Class))
         else:
-            g.add((BASE[G.a_ns + str(node_name)], RDF.type, BASE[G.t_ns + str(node_name)]))
+            g.add(
+                (BASE[G.a_ns + str(node_name)], RDF.type, BASE[G.t_ns + str(node_name)])
+            )
         assert step in ["node", "inputs", "outputs"], f"Unknown step: {step}"
         if step == "node":
             g += _wf_node_to_graph(

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -270,7 +270,7 @@ def _check_consistency_of_digraph(G: SemantikonDiGraph):
         if "derived_from" not in data:
             continue
         expected_input = Input(
-            node=node.node, arg=data["derived_from"].replace("inputs.", "")
+            node=node.node, port=data["derived_from"].replace("inputs.", "")
         )
         if expected_input not in G.nodes:
             raise ValueError(
@@ -551,11 +551,11 @@ def _wf_node_to_graph(
                 f_node,
                 data["function"],
                 input_args=[
-                    {"arg": item.arg} | G.nodes[item]
+                    {"arg": item.port} | G.nodes[item]
                     for item in G.predecessors(node_name)
                 ],
                 output_args=[
-                    {"arg": item.arg} | G.nodes[item]
+                    {"arg": item.port} | G.nodes[item]
                     for item in G.successors(node_name)
                 ],
                 uri=data.get("uri"),
@@ -656,9 +656,9 @@ def _is_macro_output(io: IO | Node, G: SemantikonDiGraph, candidates: tuple[str,
 def _detect_io_from_str(G: SemantikonDiGraph, seeked_io: str, ref_io: IO) -> str:
     assert seeked_io.startswith(("inputs", "outputs"))
     if seeked_io.startswith("inputs"):
-        full_io = Input(node=ref_io.node, arg=seeked_io.replace("inputs.", ""))
+        full_io = Input(node=ref_io.node, port=seeked_io.replace("inputs.", ""))
     else:
-        full_io = Output(node=ref_io.node, arg=seeked_io.replace("outputs.", ""))
+        full_io = Output(node=ref_io.node, port=seeked_io.replace("outputs.", ""))
     if full_io not in G.nodes:
         raise ValueError(f"IO {seeked_io} not found in graph")
     return G._get_data_node(io=full_io)
@@ -773,7 +773,7 @@ def _wf_input_to_graph(
     units = data.get("units", data.get("unit"))
     if "derived_from" in data:
         raise ValueError(
-            f"'derived_from' (defined for the argument '{node_name.arg}') is not"
+            f"'derived_from' (defined for the argument '{node_name.port}') is not"
             " supported for inputs."
         )
     if t_box:
@@ -889,7 +889,7 @@ def _wf_io_to_graph(
     node = BASE[G.t_ns + node_name] if t_box else BASE[G.a_ns + node_name]
     g = _get_bound_graph()
     g.add((node, RDFS.label, Literal(str(node_name))))
-    g.add((node, SNS.local_identifier, Literal(node_name.arg)))
+    g.add((node, SNS.local_identifier, Literal(node_name.port)))
     if t_box:
         g += _to_owl_restriction(node, has_specified_io, data_node)
         g.add((node, RDFS.subClassOf, io_assignment))

--- a/semantikon/ontology.py
+++ b/semantikon/ontology.py
@@ -538,7 +538,7 @@ def _graph_to_function(graph: Graph, f_node: URIRef) -> dict[str, Any]:
 
 
 def _wf_node_to_graph(
-    node_name: str,
+    node_name: Node | IO,
     data: dict,
     G: SemantikonDiGraph,
     t_box: bool,
@@ -573,9 +573,9 @@ def _wf_node_to_graph(
             )
         g.add((node, RDFS.label, Literal(str(node_name))))
         g.add((node, SNS.local_identifier, Literal(node_name.name)))
-        if data.get("parent"):
+        if node_name.parent:
             g += _to_owl_restriction(
-                BASE[G.t_ns + data["parent"]],
+                BASE[G.t_ns + node_name.parent],
                 SNS.has_part,
                 node,
             )
@@ -588,8 +588,8 @@ def _wf_node_to_graph(
             g.add((node, SNS.has_part, BASE[G.a_ns + out]))
         if "function" in data:
             g.add((node, SNS.concretizes, f_node))
-        if data.get("parent"):
-            g.add((BASE[G.a_ns + data["parent"]], SNS.has_part, node))
+        if node_name.parent:
+            g.add((BASE[G.a_ns + node_name.parent], SNS.has_part, node))
     return g
 
 

--- a/tests/unit/test_cwl.py
+++ b/tests/unit/test_cwl.py
@@ -7,6 +7,7 @@ try:
 except ImportError:
     cwl = None
 
+from semantikon.flowrep_to_networkx import Input, Node, Output
 from semantikon.ontology import SemantikonDiGraph
 
 
@@ -36,9 +37,9 @@ class TestCWL(unittest.TestCase):
             self.static_dir / "cwl" / "kinetic_energy_workflow.cwl"
         )
         expected_inputs = {
-            "kinetic_energy_workflow-inputs-distance",
-            "kinetic_energy_workflow-inputs-time",
-            "kinetic_energy_workflow-inputs-mass",
+            Input(node="kinetic_energy_workflow", port="distance"),
+            Input(node="kinetic_energy_workflow", port="time"),
+            Input(node="kinetic_energy_workflow", port="mass"),
         }
         self.assertTrue(expected_inputs.issubset(set(g.nodes)))
 
@@ -46,36 +47,50 @@ class TestCWL(unittest.TestCase):
         g = cwl.serialize_and_convert_to_networkx(
             self.static_dir / "cwl" / "kinetic_energy_workflow.cwl"
         )
-        self.assertIn("kinetic_energy_workflow-outputs-kinetic_energy", g.nodes)
+        self.assertIn(
+            Output(node="kinetic_energy_workflow", port="kinetic_energy"), g.nodes
+        )
 
     def test_step_nodes(self):
         g = cwl.serialize_and_convert_to_networkx(
             self.static_dir / "cwl" / "kinetic_energy_workflow.cwl"
         )
-        self.assertIn("kinetic_energy_workflow-get_speed", g.nodes)
-        self.assertIn("kinetic_energy_workflow-get_kinetic_energy", g.nodes)
+        self.assertIn(Node(name="kinetic_energy_workflow-get_speed"), g.nodes)
+        self.assertIn(Node(name="kinetic_energy_workflow-get_kinetic_energy"), g.nodes)
 
     def test_node_step_attributes(self):
         g = cwl.serialize_and_convert_to_networkx(
             self.static_dir / "cwl" / "kinetic_energy_workflow.cwl"
         )
         self.assertEqual(
-            g.nodes["kinetic_energy_workflow-inputs-distance"]["step"], "inputs"
+            g.nodes[Input(node="kinetic_energy_workflow", port="distance")]["step"],
+            "inputs",
         )
         self.assertEqual(
-            g.nodes["kinetic_energy_workflow-outputs-kinetic_energy"]["step"], "outputs"
+            g.nodes[
+                Output(node="kinetic_energy_workflow", port="kinetic_energy")
+            ]["step"],
+            "outputs",
         )
-        self.assertEqual(g.nodes["kinetic_energy_workflow-get_speed"]["step"], "node")
+        self.assertEqual(
+            g.nodes[Node(name="kinetic_energy_workflow-get_speed")]["step"], "node"
+        )
 
     def test_input_binding_position(self):
         g = cwl.serialize_and_convert_to_networkx(
             self.static_dir / "cwl" / "kinetic_energy_workflow.cwl"
         )
         self.assertEqual(
-            g.nodes["kinetic_energy_workflow-get_speed-inputs-distance"]["position"], 1
+            g.nodes[
+                Input(node="kinetic_energy_workflow-get_speed", port="distance")
+            ]["position"],
+            1,
         )
         self.assertEqual(
-            g.nodes["kinetic_energy_workflow-get_speed-inputs-time"]["position"], 2
+            g.nodes[
+                Input(node="kinetic_energy_workflow-get_speed", port="time")
+            ]["position"],
+            2,
         )
 
     def test_data_flow_edges(self):
@@ -85,31 +100,34 @@ class TestCWL(unittest.TestCase):
         # distance flows from workflow input -> get_speed input -> get_speed step
         self.assertIn(
             (
-                "kinetic_energy_workflow-inputs-distance",
-                "kinetic_energy_workflow-get_speed-inputs-distance",
+                Input(node="kinetic_energy_workflow", port="distance"),
+                Input(node="kinetic_energy_workflow-get_speed", port="distance"),
             ),
             g.edges,
         )
         self.assertIn(
             (
-                "kinetic_energy_workflow-get_speed-inputs-distance",
-                "kinetic_energy_workflow-get_speed",
+                Input(node="kinetic_energy_workflow-get_speed", port="distance"),
+                Node(name="kinetic_energy_workflow-get_speed"),
             ),
             g.edges,
         )
         # speed flows from get_speed output -> get_kinetic_energy input
         self.assertIn(
             (
-                "kinetic_energy_workflow-get_speed-outputs-speed",
-                "kinetic_energy_workflow-get_kinetic_energy-inputs-velocity",
+                Output(node="kinetic_energy_workflow-get_speed", port="speed"),
+                Input(node="kinetic_energy_workflow-get_kinetic_energy", port="velocity"),
             ),
             g.edges,
         )
         # kinetic_energy flows from step output -> workflow output
         self.assertIn(
             (
-                "kinetic_energy_workflow-get_kinetic_energy-outputs-kinetic_energy",
-                "kinetic_energy_workflow-outputs-kinetic_energy",
+                Output(
+                    node="kinetic_energy_workflow-get_kinetic_energy",
+                    port="kinetic_energy",
+                ),
+                Output(node="kinetic_energy_workflow", port="kinetic_energy"),
             ),
             g.edges,
         )

--- a/tests/unit/test_cwl.py
+++ b/tests/unit/test_cwl.py
@@ -67,9 +67,9 @@ class TestCWL(unittest.TestCase):
             "inputs",
         )
         self.assertEqual(
-            g.nodes[
-                Output(node="kinetic_energy_workflow", port="kinetic_energy")
-            ]["step"],
+            g.nodes[Output(node="kinetic_energy_workflow", port="kinetic_energy")][
+                "step"
+            ],
             "outputs",
         )
         self.assertEqual(
@@ -81,15 +81,15 @@ class TestCWL(unittest.TestCase):
             self.static_dir / "cwl" / "kinetic_energy_workflow.cwl"
         )
         self.assertEqual(
-            g.nodes[
-                Input(node="kinetic_energy_workflow-get_speed", port="distance")
-            ]["position"],
+            g.nodes[Input(node="kinetic_energy_workflow-get_speed", port="distance")][
+                "position"
+            ],
             1,
         )
         self.assertEqual(
-            g.nodes[
-                Input(node="kinetic_energy_workflow-get_speed", port="time")
-            ]["position"],
+            g.nodes[Input(node="kinetic_energy_workflow-get_speed", port="time")][
+                "position"
+            ],
             2,
         )
 
@@ -116,7 +116,9 @@ class TestCWL(unittest.TestCase):
         self.assertIn(
             (
                 Output(node="kinetic_energy_workflow-get_speed", port="speed"),
-                Input(node="kinetic_energy_workflow-get_kinetic_energy", port="velocity"),
+                Input(
+                    node="kinetic_energy_workflow-get_kinetic_energy", port="velocity"
+                ),
             ),
             g.edges,
         )

--- a/tests/unit/test_cwl.py
+++ b/tests/unit/test_cwl.py
@@ -63,29 +63,6 @@ class TestCWL(unittest.TestCase):
             g.nodes,
         )
 
-    def test_node_step_attributes(self):
-        g = cwl.serialize_and_convert_to_networkx(
-            self.static_dir / "cwl" / "kinetic_energy_workflow.cwl"
-        )
-        self.assertEqual(
-            g.nodes[Input(node=Node("kinetic_energy_workflow"), port="distance")][
-                "step"
-            ],
-            "inputs",
-        )
-        self.assertEqual(
-            g.nodes[
-                Output(node=Node("kinetic_energy_workflow"), port="kinetic_energy")
-            ]["step"],
-            "outputs",
-        )
-        self.assertEqual(
-            g.nodes[Node(name="get_speed", parent=Node("kinetic_energy_workflow"))][
-                "step"
-            ],
-            "node",
-        )
-
     def test_input_binding_position(self):
         g = cwl.serialize_and_convert_to_networkx(
             self.static_dir / "cwl" / "kinetic_energy_workflow.cwl"
@@ -161,7 +138,7 @@ class TestCWL(unittest.TestCase):
                     ),
                     port="kinetic_energy",
                 ),
-                Output(node="kinetic_energy_workflow", port="kinetic_energy"),
+                Output(node=Node("kinetic_energy_workflow"), port="kinetic_energy"),
             ),
             g.edges,
         )

--- a/tests/unit/test_cwl.py
+++ b/tests/unit/test_cwl.py
@@ -37,9 +37,9 @@ class TestCWL(unittest.TestCase):
             self.static_dir / "cwl" / "kinetic_energy_workflow.cwl"
         )
         expected_inputs = {
-            Input(node="kinetic_energy_workflow", port="distance"),
-            Input(node="kinetic_energy_workflow", port="time"),
-            Input(node="kinetic_energy_workflow", port="mass"),
+            Input(node=Node("kinetic_energy_workflow"), port="distance"),
+            Input(node=Node("kinetic_energy_workflow"), port="time"),
+            Input(node=Node("kinetic_energy_workflow"), port="mass"),
         }
         self.assertTrue(expected_inputs.issubset(set(g.nodes)))
 
@@ -48,32 +48,42 @@ class TestCWL(unittest.TestCase):
             self.static_dir / "cwl" / "kinetic_energy_workflow.cwl"
         )
         self.assertIn(
-            Output(node="kinetic_energy_workflow", port="kinetic_energy"), g.nodes
+            Output(node=Node("kinetic_energy_workflow"), port="kinetic_energy"), g.nodes
         )
 
     def test_step_nodes(self):
         g = cwl.serialize_and_convert_to_networkx(
             self.static_dir / "cwl" / "kinetic_energy_workflow.cwl"
         )
-        self.assertIn(Node(name="kinetic_energy_workflow-get_speed"), g.nodes)
-        self.assertIn(Node(name="kinetic_energy_workflow-get_kinetic_energy"), g.nodes)
+        self.assertIn(
+            Node(name="get_speed", parent=Node("kinetic_energy_workflow")), g.nodes
+        )
+        self.assertIn(
+            Node(name="get_kinetic_energy", parent=Node("kinetic_energy_workflow")),
+            g.nodes,
+        )
 
     def test_node_step_attributes(self):
         g = cwl.serialize_and_convert_to_networkx(
             self.static_dir / "cwl" / "kinetic_energy_workflow.cwl"
         )
         self.assertEqual(
-            g.nodes[Input(node="kinetic_energy_workflow", port="distance")]["step"],
+            g.nodes[Input(node=Node("kinetic_energy_workflow"), port="distance")][
+                "step"
+            ],
             "inputs",
         )
         self.assertEqual(
-            g.nodes[Output(node="kinetic_energy_workflow", port="kinetic_energy")][
-                "step"
-            ],
+            g.nodes[
+                Output(node=Node("kinetic_energy_workflow"), port="kinetic_energy")
+            ]["step"],
             "outputs",
         )
         self.assertEqual(
-            g.nodes[Node(name="kinetic_energy_workflow-get_speed")]["step"], "node"
+            g.nodes[Node(name="get_speed", parent=Node("kinetic_energy_workflow"))][
+                "step"
+            ],
+            "node",
         )
 
     def test_input_binding_position(self):
@@ -81,15 +91,21 @@ class TestCWL(unittest.TestCase):
             self.static_dir / "cwl" / "kinetic_energy_workflow.cwl"
         )
         self.assertEqual(
-            g.nodes[Input(node="kinetic_energy_workflow-get_speed", port="distance")][
-                "position"
-            ],
+            g.nodes[
+                Input(
+                    node=Node(parent=Node("kinetic_energy_workflow"), name="get_speed"),
+                    port="distance",
+                )
+            ]["position"],
             1,
         )
         self.assertEqual(
-            g.nodes[Input(node="kinetic_energy_workflow-get_speed", port="time")][
-                "position"
-            ],
+            g.nodes[
+                Input(
+                    node=Node(parent=Node("kinetic_energy_workflow"), name="get_speed"),
+                    port="time",
+                )
+            ]["position"],
             2,
         )
 
@@ -100,24 +116,37 @@ class TestCWL(unittest.TestCase):
         # distance flows from workflow input -> get_speed input -> get_speed step
         self.assertIn(
             (
-                Input(node="kinetic_energy_workflow", port="distance"),
-                Input(node="kinetic_energy_workflow-get_speed", port="distance"),
+                Input(node=Node("kinetic_energy_workflow"), port="distance"),
+                Input(
+                    node=Node(parent=Node("kinetic_energy_workflow"), name="get_speed"),
+                    port="distance",
+                ),
             ),
             g.edges,
         )
         self.assertIn(
             (
-                Input(node="kinetic_energy_workflow-get_speed", port="distance"),
-                Node(name="kinetic_energy_workflow-get_speed"),
+                Input(
+                    node=Node(parent=Node("kinetic_energy_workflow"), name="get_speed"),
+                    port="distance",
+                ),
+                Node(name="get_speed", parent=Node("kinetic_energy_workflow")),
             ),
             g.edges,
         )
         # speed flows from get_speed output -> get_kinetic_energy input
         self.assertIn(
             (
-                Output(node="kinetic_energy_workflow-get_speed", port="speed"),
+                Output(
+                    node=Node(parent=Node("kinetic_energy_workflow"), name="get_speed"),
+                    port="speed",
+                ),
                 Input(
-                    node="kinetic_energy_workflow-get_kinetic_energy", port="velocity"
+                    node=Node(
+                        parent=Node("kinetic_energy_workflow"),
+                        name="get_kinetic_energy",
+                    ),
+                    port="velocity",
                 ),
             ),
             g.edges,
@@ -126,7 +155,10 @@ class TestCWL(unittest.TestCase):
         self.assertIn(
             (
                 Output(
-                    node="kinetic_energy_workflow-get_kinetic_energy",
+                    node=Node(
+                        parent=Node("kinetic_energy_workflow"),
+                        name="get_kinetic_energy",
+                    ),
                     port="kinetic_energy",
                 ),
                 Output(node="kinetic_energy_workflow", port="kinetic_energy"),

--- a/tests/unit/test_flowrep_to_networkx.py
+++ b/tests/unit/test_flowrep_to_networkx.py
@@ -128,7 +128,7 @@ class TestFlowrepToNetworkx(unittest.TestCase):
                 ftn.Input(
                     node=ftn.Node(
                         parent=ftn.Node("my_kinetic_energy_workflow"),
-                        name="get_kinetic_energy_0"
+                        name="get_kinetic_energy_0",
                     ),
                     arg="velocity",
                 )
@@ -137,7 +137,7 @@ class TestFlowrepToNetworkx(unittest.TestCase):
                 ftn.Output(
                     node=ftn.Node(
                         parent=ftn.Node("my_kinetic_energy_workflow"),
-                        name="get_kinetic_energy_0"
+                        name="get_kinetic_energy_0",
                     ),
                     arg="kinetic_energy",
                 )
@@ -244,94 +244,82 @@ class TestFlowrepToNetworkx(unittest.TestCase):
 
     def test_add_node_validates_semantikon_metadata(self):
         G = ftn.SemantikonDiGraph()
-        G.add_node("n", step="node", type="atomic")
-        self.assertEqual(G.nodes["n"]["step"], "node")
-        self.assertEqual(G.nodes["n"]["type"], "atomic")
+        G.add_node(ftn.Node("n"), type="atomic")
+        self.assertEqual(G.nodes[ftn.Node("n")]["type"], "atomic")
 
-        G.add_node("in", step="inputs", arg="x", position=0, value=None)
-        self.assertIn("value", G.nodes["in"])
-        self.assertIsNone(G.nodes["in"]["value"])
+        node_in = ftn.Input(node=ftn.Node("in"), arg="x")
+        G.add_node(node_in, position=0, value=None)
+        self.assertIn("value", G.nodes[node_in])
+        self.assertIsNone(G.nodes[node_in]["value"])
 
     def test_add_node_rejects_invalid_semantikon_metadata(self):
         G = ftn.SemantikonDiGraph()
         with self.assertRaises(ValueError):
-            G.add_node("n", step="node", type="invalid")
-        with self.assertRaises(ValueError):
-            G.add_node("n", step="banana")
+            G.add_node(ftn.Node("n"), type="invalid")
 
     def test_add_nodes_from_validates_semantikon_metadata(self):
         G = ftn.SemantikonDiGraph()
-        G.add_nodes_from(["n1", "n2"], step="inputs", arg="x", position=0, value=None)
+        G.add_nodes_from(
+            [ftn.Input(ftn.Node("n1"), arg="x"), ftn.Input(ftn.Node("n2"), arg="x")],
+            position=0,
+            value=None,
+        )
 
-        for node in ("n1", "n2"):
-            self.assertEqual(G.nodes[node]["step"], "inputs")
-            self.assertEqual(G.nodes[node]["arg"], "x")
+        for n in ("n1", "n2"):
+            node = ftn.Input(ftn.Node(n), arg="x")
             self.assertEqual(G.nodes[node]["position"], 0)
             self.assertIn("value", G.nodes[node])
             self.assertIsNone(G.nodes[node]["value"])
-
-    def test_add_nodes_from_allows_plain_nodes_without_shared_attrs(self):
-        G = ftn.SemantikonDiGraph()
-        G.add_nodes_from(["n1", "n2"])
-
-        self.assertIn("n1", G.nodes)
-        self.assertIn("n2", G.nodes)
-        self.assertEqual(dict(G.nodes["n1"]), {})
-        self.assertEqual(dict(G.nodes["n2"]), {})
 
     def test_add_nodes_from_validates_per_node_semantikon_metadata_without_shared_attrs(
         self,
     ):
         G = ftn.SemantikonDiGraph()
+        n_1 = ftn.Input(ftn.Node("n1"), arg="x")
+        n_2 = ftn.Input(ftn.Node("n2"), arg="y")
         G.add_nodes_from(
             [
-                ("n1", {"step": "inputs", "arg": "x", "position": 0, "value": 1}),
-                ("n2", {"step": "inputs", "arg": "y", "position": 1}),
+                (n_1, {"position": 0, "value": 1}),
+                (n_2, {"position": 1}),
             ]
         )
 
-        self.assertEqual(G.nodes["n1"]["arg"], "x")
-        self.assertEqual(G.nodes["n1"]["position"], 0)
-        self.assertEqual(G.nodes["n1"]["value"], 1)
+        self.assertEqual(G.nodes[n_1]["position"], 0)
+        self.assertEqual(G.nodes[n_1]["value"], 1)
 
-        self.assertEqual(G.nodes["n2"]["arg"], "y")
-        self.assertEqual(G.nodes["n2"]["position"], 1)
-        self.assertNotIn("value", G.nodes["n2"])
+        self.assertEqual(G.nodes[n_2]["position"], 1)
+        self.assertNotIn("value", G.nodes[n_2])
 
     def test_add_nodes_from_merges_per_node_semantikon_metadata(self):
         G = ftn.SemantikonDiGraph()
+        n_1 = ftn.Input(ftn.Node("n1"), arg="x")
+        n_2 = ftn.Input(ftn.Node("n2"), arg="y")
         G.add_nodes_from(
             [
-                ("n1", {"step": "inputs", "arg": "x", "position": 0, "value": 1}),
-                ("n2", {"step": "inputs", "arg": "y", "position": 1}),
+                (n_1, {"position": 0, "value": 1}),
+                (n_2, {"position": 1}),
             ],
             value=None,
             dtype="float",
         )
 
-        self.assertEqual(G.nodes["n1"]["arg"], "x")
-        self.assertEqual(G.nodes["n1"]["position"], 0)
-        self.assertEqual(G.nodes["n1"]["dtype"], "float")
-        self.assertEqual(G.nodes["n1"]["value"], 1)
+        self.assertEqual(G.nodes[n_1]["position"], 0)
+        self.assertEqual(G.nodes[n_1]["dtype"], "float")
+        self.assertEqual(G.nodes[n_1]["value"], 1)
 
-        self.assertEqual(G.nodes["n2"]["arg"], "y")
-        self.assertEqual(G.nodes["n2"]["position"], 1)
-        self.assertEqual(G.nodes["n2"]["dtype"], "float")
-        self.assertIsNone(G.nodes["n2"]["value"])
+        self.assertEqual(G.nodes[n_2]["position"], 1)
+        self.assertEqual(G.nodes[n_2]["dtype"], "float")
+        self.assertIsNone(G.nodes[n_2]["value"])
 
     def test_add_nodes_from_rejects_invalid_semantikon_metadata(self):
         G = ftn.SemantikonDiGraph()
         with self.assertRaises(ValueError):
-            G.add_nodes_from(["n"], step="node", type="invalid")
-        with self.assertRaises(ValueError):
-            G.add_nodes_from(["n"], step="banana")
+            G.add_nodes_from([ftn.Node("n")], type="invalid")
 
     def test_add_nodes_from_rejects_invalid_per_node_semantikon_metadata(self):
         G = ftn.SemantikonDiGraph()
         with self.assertRaises(ValueError):
-            G.add_nodes_from([("n", {"step": "node", "type": "invalid"})])
-        with self.assertRaises(ValueError):
-            G.add_nodes_from([("n", {"step": "banana"})])
+            G.add_nodes_from([(ftn.Node("n"), {"type": "invalid"})])
 
     def test_constant(self):
         G = ftn.serialize_and_convert_to_networkx(double_via_constant.flowrep_recipe)

--- a/tests/unit/test_flowrep_to_networkx.py
+++ b/tests/unit/test_flowrep_to_networkx.py
@@ -93,31 +93,52 @@ class TestFlowrepToNetworkx(unittest.TestCase):
         self.assertIn(
             "dtype",
             G.nodes[
-                ftn.Input(node="my_kinetic_energy_workflow-get_speed_0", arg="distance")
+                ftn.Input(
+                    node=ftn.Node(
+                        parent=ftn.Node("my_kinetic_energy_workflow"),
+                        name="get_speed_0",
+                    ),
+                    arg="distance",
+                )
             ],
             msg="dtype should not be deleted after hashing",
         )
         self.assertEqual(
             G._get_data_node(
                 ftn.Input(
-                    node="my_kinetic_energy_workflow-get_kinetic_energy_0",
-                    arg="velocity",
-                )
-            ),
-            G._get_data_node(
-                ftn.Output(node="my_kinetic_energy_workflow-get_speed_0", arg="speed")
-            ),
-        )
-        self.assertNotEqual(
-            G._get_data_node(
-                ftn.Input(
-                    node="my_kinetic_energy_workflow-get_kinetic_energy_0",
+                    node=ftn.Node(
+                        parent=ftn.Node("my_kinetic_energy_workflow"),
+                        name="get_kinetic_energy_0",
+                    ),
                     arg="velocity",
                 )
             ),
             G._get_data_node(
                 ftn.Output(
-                    node="my_kinetic_energy_workflow-get_kinetic_energy_0",
+                    node=ftn.Node(
+                        parent=ftn.Node("my_kinetic_energy_workflow"),
+                        name="get_speed_0",
+                    ),
+                    arg="speed",
+                )
+            ),
+        )
+        self.assertNotEqual(
+            G._get_data_node(
+                ftn.Input(
+                    node=ftn.Node(
+                        parent=ftn.Node("my_kinetic_energy_workflow"),
+                        name="get_kinetic_energy_0"
+                    ),
+                    arg="velocity",
+                )
+            ),
+            G._get_data_node(
+                ftn.Output(
+                    node=ftn.Node(
+                        parent=ftn.Node("my_kinetic_energy_workflow"),
+                        name="get_kinetic_energy_0"
+                    ),
                     arg="kinetic_energy",
                 )
             ),
@@ -198,8 +219,8 @@ class TestFlowrepToNetworkx(unittest.TestCase):
         )
         self.assertIn(
             (
-                ftn.Input(node="passthrough_input_workflow", arg="x"),
-                ftn.Output(node="passthrough_input_workflow", arg="x"),
+                ftn.Input(node=ftn.Node("passthrough_input_workflow"), arg="x"),
+                ftn.Output(node=ftn.Node("passthrough_input_workflow"), arg="x"),
             ),
             G.edges,
         )
@@ -314,14 +335,13 @@ class TestFlowrepToNetworkx(unittest.TestCase):
 
     def test_constant(self):
         G = ftn.serialize_and_convert_to_networkx(double_via_constant.flowrep_recipe)
-        self.assertNotIn(
-            ftn.Node(name="constant_0", parent="double_via_constant-constant_0"),
-            G.nodes,
-        )
         self.assertEqual(
-            G.nodes[ftn.Input(node="double_via_constant-mul_0", arg="a")][
-                "constant_value"
-            ],
+            G.nodes[
+                ftn.Input(
+                    node=ftn.Node(parent=ftn.Node("double_via_constant"), name="mul_0"),
+                    arg="a",
+                )
+            ]["constant_value"],
             2,
         )
 

--- a/tests/unit/test_flowrep_to_networkx.py
+++ b/tests/unit/test_flowrep_to_networkx.py
@@ -92,21 +92,34 @@ class TestFlowrepToNetworkx(unittest.TestCase):
         self.assertEqual(len(ftn._get_graph_hash(G)), 32)
         self.assertIn(
             "dtype",
-            G.nodes["my_kinetic_energy_workflow-get_speed_0-inputs-distance"],
+            G.nodes[
+                ftn.Input(node="my_kinetic_energy_workflow-get_speed_0", arg="distance")
+            ],
             msg="dtype should not be deleted after hashing",
         )
         self.assertEqual(
             G._get_data_node(
-                "my_kinetic_energy_workflow-get_kinetic_energy_0-inputs-velocity"
+                ftn.Input(
+                    node="my_kinetic_energy_workflow-get_kinetic_energy_0",
+                    arg="velocity",
+                )
             ),
-            G._get_data_node("my_kinetic_energy_workflow-get_speed_0-outputs-speed"),
+            G._get_data_node(
+                ftn.Output(node="my_kinetic_energy_workflow-get_speed_0", arg="speed")
+            ),
         )
         self.assertNotEqual(
             G._get_data_node(
-                "my_kinetic_energy_workflow-get_kinetic_energy_0-inputs-velocity"
+                ftn.Input(
+                    node="my_kinetic_energy_workflow-get_kinetic_energy_0",
+                    arg="velocity",
+                )
             ),
             G._get_data_node(
-                "my_kinetic_energy_workflow-get_kinetic_energy_0-outputs-kinetic_energy"
+                ftn.Output(
+                    node="my_kinetic_energy_workflow-get_kinetic_energy_0",
+                    arg="kinetic_energy",
+                )
             ),
         )
         wf_dict_one = fr.wfms.run_recipe(
@@ -185,8 +198,8 @@ class TestFlowrepToNetworkx(unittest.TestCase):
         )
         self.assertIn(
             (
-                "passthrough_input_workflow-inputs-x",
-                "passthrough_input_workflow-outputs-x",
+                ftn.Input(node="passthrough_input_workflow", arg="x"),
+                ftn.Output(node="passthrough_input_workflow", arg="x"),
             ),
             G.edges,
         )
@@ -301,9 +314,15 @@ class TestFlowrepToNetworkx(unittest.TestCase):
 
     def test_constant(self):
         G = ftn.serialize_and_convert_to_networkx(double_via_constant.flowrep_recipe)
-        self.assertNotIn("double_via_constant-constant_0", G.nodes)
+        self.assertNotIn(
+            ftn.Node(name="constant_0", parent="double_via_constant-constant_0"),
+            G.nodes,
+        )
         self.assertEqual(
-            G.nodes["double_via_constant-mul_0-inputs-a"]["constant_value"], 2
+            G.nodes[ftn.Input(node="double_via_constant-mul_0", arg="a")][
+                "constant_value"
+            ],
+            2,
         )
 
 

--- a/tests/unit/test_flowrep_to_networkx.py
+++ b/tests/unit/test_flowrep_to_networkx.py
@@ -252,6 +252,11 @@ class TestFlowrepToNetworkx(unittest.TestCase):
         self.assertIn("value", G.nodes[node_in])
         self.assertIsNone(G.nodes[node_in]["value"])
 
+        node_out = ftn.Output(node=ftn.Node("out"), arg="y")
+        G.add_node(node_out, position=1, default=3.14)
+        self.assertEqual(G.nodes[node_out]["default"], 3.14)
+        self.assertNotIn("value", G.nodes[node_out])
+
     def test_add_node_rejects_invalid_semantikon_metadata(self):
         G = ftn.SemantikonDiGraph()
         with self.assertRaises(ValueError):
@@ -289,6 +294,15 @@ class TestFlowrepToNetworkx(unittest.TestCase):
 
         self.assertEqual(G.nodes[n_2]["position"], 1)
         self.assertNotIn("value", G.nodes[n_2])
+
+    def test_add_nodes_from_preserves_default_on_inputs(self):
+        G = ftn.SemantikonDiGraph()
+        n_1 = ftn.Input(ftn.Node("n1"), arg="x")
+        G.add_nodes_from([(n_1, {"position": 0, "default": 7})])
+
+        self.assertEqual(G.nodes[n_1]["position"], 0)
+        self.assertIn("default", G.nodes[n_1])
+        self.assertEqual(G.nodes[n_1]["default"], 7)
 
     def test_add_nodes_from_merges_per_node_semantikon_metadata(self):
         G = ftn.SemantikonDiGraph()

--- a/tests/unit/test_flowrep_to_networkx.py
+++ b/tests/unit/test_flowrep_to_networkx.py
@@ -98,7 +98,7 @@ class TestFlowrepToNetworkx(unittest.TestCase):
                         parent=ftn.Node("my_kinetic_energy_workflow"),
                         name="get_speed_0",
                     ),
-                    arg="distance",
+                    port="distance",
                 )
             ],
             msg="dtype should not be deleted after hashing",
@@ -110,7 +110,7 @@ class TestFlowrepToNetworkx(unittest.TestCase):
                         parent=ftn.Node("my_kinetic_energy_workflow"),
                         name="get_kinetic_energy_0",
                     ),
-                    arg="velocity",
+                    port="velocity",
                 )
             ),
             G._get_data_node(
@@ -119,7 +119,7 @@ class TestFlowrepToNetworkx(unittest.TestCase):
                         parent=ftn.Node("my_kinetic_energy_workflow"),
                         name="get_speed_0",
                     ),
-                    arg="speed",
+                    port="speed",
                 )
             ),
         )
@@ -130,7 +130,7 @@ class TestFlowrepToNetworkx(unittest.TestCase):
                         parent=ftn.Node("my_kinetic_energy_workflow"),
                         name="get_kinetic_energy_0",
                     ),
-                    arg="velocity",
+                    port="velocity",
                 )
             ),
             G._get_data_node(
@@ -139,7 +139,7 @@ class TestFlowrepToNetworkx(unittest.TestCase):
                         parent=ftn.Node("my_kinetic_energy_workflow"),
                         name="get_kinetic_energy_0",
                     ),
-                    arg="kinetic_energy",
+                    port="kinetic_energy",
                 )
             ),
         )
@@ -219,8 +219,8 @@ class TestFlowrepToNetworkx(unittest.TestCase):
         )
         self.assertIn(
             (
-                ftn.Input(node=ftn.Node("passthrough_input_workflow"), arg="x"),
-                ftn.Output(node=ftn.Node("passthrough_input_workflow"), arg="x"),
+                ftn.Input(node=ftn.Node("passthrough_input_workflow"), port="x"),
+                ftn.Output(node=ftn.Node("passthrough_input_workflow"), port="x"),
             ),
             G.edges,
         )
@@ -247,12 +247,12 @@ class TestFlowrepToNetworkx(unittest.TestCase):
         G.add_node(ftn.Node("n"), type="atomic")
         self.assertEqual(G.nodes[ftn.Node("n")]["type"], "atomic")
 
-        node_in = ftn.Input(node=ftn.Node("in"), arg="x")
+        node_in = ftn.Input(node=ftn.Node("in"), port="x")
         G.add_node(node_in, position=0, value=None)
         self.assertIn("value", G.nodes[node_in])
         self.assertIsNone(G.nodes[node_in]["value"])
 
-        node_out = ftn.Output(node=ftn.Node("out"), arg="y")
+        node_out = ftn.Output(node=ftn.Node("out"), port="y")
         G.add_node(node_out, position=1, default=3.14)
         self.assertEqual(G.nodes[node_out]["default"], 3.14)
         self.assertNotIn("value", G.nodes[node_out])
@@ -265,13 +265,13 @@ class TestFlowrepToNetworkx(unittest.TestCase):
     def test_add_nodes_from_validates_semantikon_metadata(self):
         G = ftn.SemantikonDiGraph()
         G.add_nodes_from(
-            [ftn.Input(ftn.Node("n1"), arg="x"), ftn.Input(ftn.Node("n2"), arg="x")],
+            [ftn.Input(ftn.Node("n1"), port="x"), ftn.Input(ftn.Node("n2"), port="x")],
             position=0,
             value=None,
         )
 
         for n in ("n1", "n2"):
-            node = ftn.Input(ftn.Node(n), arg="x")
+            node = ftn.Input(ftn.Node(n), port="x")
             self.assertEqual(G.nodes[node]["position"], 0)
             self.assertIn("value", G.nodes[node])
             self.assertIsNone(G.nodes[node]["value"])
@@ -280,8 +280,8 @@ class TestFlowrepToNetworkx(unittest.TestCase):
         self,
     ):
         G = ftn.SemantikonDiGraph()
-        n_1 = ftn.Input(ftn.Node("n1"), arg="x")
-        n_2 = ftn.Input(ftn.Node("n2"), arg="y")
+        n_1 = ftn.Input(ftn.Node("n1"), port="x")
+        n_2 = ftn.Input(ftn.Node("n2"), port="y")
         G.add_nodes_from(
             [
                 (n_1, {"position": 0, "value": 1}),
@@ -297,7 +297,7 @@ class TestFlowrepToNetworkx(unittest.TestCase):
 
     def test_add_nodes_from_preserves_default_on_inputs(self):
         G = ftn.SemantikonDiGraph()
-        n_1 = ftn.Input(ftn.Node("n1"), arg="x")
+        n_1 = ftn.Input(ftn.Node("n1"), port="x")
         G.add_nodes_from([(n_1, {"position": 0, "default": 7})])
 
         self.assertEqual(G.nodes[n_1]["position"], 0)
@@ -306,8 +306,8 @@ class TestFlowrepToNetworkx(unittest.TestCase):
 
     def test_add_nodes_from_merges_per_node_semantikon_metadata(self):
         G = ftn.SemantikonDiGraph()
-        n_1 = ftn.Input(ftn.Node("n1"), arg="x")
-        n_2 = ftn.Input(ftn.Node("n2"), arg="y")
+        n_1 = ftn.Input(ftn.Node("n1"), port="x")
+        n_2 = ftn.Input(ftn.Node("n2"), port="y")
         G.add_nodes_from(
             [
                 (n_1, {"position": 0, "value": 1}),
@@ -341,7 +341,7 @@ class TestFlowrepToNetworkx(unittest.TestCase):
             G.nodes[
                 ftn.Input(
                     node=ftn.Node(parent=ftn.Node("double_via_constant"), name="mul_0"),
-                    arg="a",
+                    port="a",
                 )
             ]["constant_value"],
             2,

--- a/tests/unit/test_flowrep_to_networkx.py
+++ b/tests/unit/test_flowrep_to_networkx.py
@@ -244,9 +244,6 @@ class TestFlowrepToNetworkx(unittest.TestCase):
 
     def test_add_node_validates_semantikon_metadata(self):
         G = ftn.SemantikonDiGraph()
-        G.add_node(ftn.Node("n"), type="atomic")
-        self.assertEqual(G.nodes[ftn.Node("n")]["type"], "atomic")
-
         node_in = ftn.Input(node=ftn.Node("in"), port="x")
         G.add_node(node_in, position=0, value=None)
         self.assertIn("value", G.nodes[node_in])
@@ -256,11 +253,6 @@ class TestFlowrepToNetworkx(unittest.TestCase):
         G.add_node(node_out, position=1, default=3.14)
         self.assertEqual(G.nodes[node_out]["default"], 3.14)
         self.assertNotIn("value", G.nodes[node_out])
-
-    def test_add_node_rejects_invalid_semantikon_metadata(self):
-        G = ftn.SemantikonDiGraph()
-        with self.assertRaises(ValueError):
-            G.add_node(ftn.Node("n"), type="invalid")
 
     def test_add_nodes_from_validates_semantikon_metadata(self):
         G = ftn.SemantikonDiGraph()
@@ -325,27 +317,14 @@ class TestFlowrepToNetworkx(unittest.TestCase):
         self.assertEqual(G.nodes[n_2]["dtype"], "float")
         self.assertIsNone(G.nodes[n_2]["value"])
 
-    def test_add_nodes_from_rejects_invalid_semantikon_metadata(self):
-        G = ftn.SemantikonDiGraph()
-        with self.assertRaises(ValueError):
-            G.add_nodes_from([ftn.Node("n")], type="invalid")
-
-    def test_add_nodes_from_rejects_invalid_per_node_semantikon_metadata(self):
-        G = ftn.SemantikonDiGraph()
-        with self.assertRaises(ValueError):
-            G.add_nodes_from([(ftn.Node("n"), {"type": "invalid"})])
-
     def test_constant(self):
         G = ftn.serialize_and_convert_to_networkx(double_via_constant.flowrep_recipe)
-        self.assertEqual(
-            G.nodes[
-                ftn.Input(
-                    node=ftn.Node(parent=ftn.Node("double_via_constant"), name="mul_0"),
-                    port="a",
-                )
-            ]["constant_value"],
-            2,
+        inp = ftn.Input(
+            node=ftn.Node(parent=ftn.Node("double_via_constant"), name="mul_0"),
+            port="a",
         )
+        self.assertIn(inp, G.nodes)
+        self.assertEqual(G.nodes[inp]["constant_value"], 2)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_kg_to_flowrep.py
+++ b/tests/unit/test_kg_to_flowrep.py
@@ -127,7 +127,7 @@ class TestKgToFlowrep(unittest.TestCase):
         reconstructed_from_string = kg2recipe(graph, workflow_name="my_workflow")
         reconstructed_from_uri = kg2recipe(
             graph,
-            workflow_name=URIRef("http://pyiron.org/ontology/W0fba2efa_my_workflow"),
+            workflow_name=URIRef("http://pyiron.org/ontology/Wba44739c_my_workflow"),
         )
         self.assertEqual(
             fr.tools.run_recipe(reconstructed_from_string, x=3, y=5)

--- a/tests/unit/test_kg_to_flowrep.py
+++ b/tests/unit/test_kg_to_flowrep.py
@@ -147,30 +147,6 @@ class TestKgToFlowrep(unittest.TestCase):
                 workflow_name="wf_same",
             )
 
-    def test_split_by_roots_errors(self):
-        graph = Graph()
-
-        # Test 1: Graph with no roots
-        no_root_graph = nx.DiGraph()
-        no_root_graph.add_node(URIRef("http://example.org/unrelated"))
-        with self.assertRaisesRegex(ValueError, "Could not assign"):
-            _ = kgf._split_by_roots(graph, no_root_graph, roots={})
-
-        # Test 2: Multiple roots in same component
-        multi_root_graph = nx.DiGraph()
-        root_a = URIRef("http://example.org/root_a")
-        root_b = URIRef("http://example.org/root_b")
-        multi_root_graph.add_edge(root_a, root_b)
-        with self.assertRaisesRegex(ValueError, "more than one root workflow"):
-            _ = kgf._split_by_roots(
-                graph,
-                multi_root_graph,
-                roots={
-                    root_a: "root_a",
-                    root_b: "root_b",
-                },
-            )
-
     def test_add_io_nodes_error_paths(self):
         node = URIRef("http://example.org/node")
         io_node = URIRef("http://example.org/io")

--- a/tests/unit/test_kg_to_flowrep.py
+++ b/tests/unit/test_kg_to_flowrep.py
@@ -5,6 +5,7 @@ from rdflib import RDFS, Graph, Literal, URIRef
 
 from semantikon import get_knowledge_graph, kg2recipe
 from semantikon import kg_to_flowrep as kgf
+from semantikon import ontology as onto
 from semantikon.workflow import workflow
 
 
@@ -270,6 +271,42 @@ class TestKgToFlowrep(unittest.TestCase):
         reconstructed2_value = reconstructed2_result.output_ports["result"].value
 
         self.assertEqual(reconstructed2_value, expected)
+
+    def test_ensure_workflow_name(self):
+        graph = Graph()
+        uri_to_node = kgf._uri_to_node_names(graph)
+        self.assertRaises(ValueError, kgf._ensure_workflow_name, uri_to_node)
+        result_1 = fr.tools.run_recipe(multiply_then_add.flowrep_recipe, x=0, y=1)
+        graph = get_knowledge_graph(result_1)
+        self.assertRaises(
+            ValueError, kgf._ensure_workflow_name, uri_to_node, "unknown_workflow"
+        )
+        uri_to_node = kgf._uri_to_node_names(graph)
+        self.assertEqual(
+            kgf._ensure_workflow_name(uri_to_node),
+            onto.BASE["Wbcedc6be_multiply_then_add"],
+        )
+        self.assertEqual(
+            kgf._ensure_workflow_name(uri_to_node, "multiply_then_add"),
+            onto.BASE["Wbcedc6be_multiply_then_add"],
+        )
+        uri_to_node = kgf._uri_to_node_names(graph)
+        result_2 = fr.tools.run_recipe(multiply_then_add.flowrep_recipe, x=1, y=2)
+        graph += get_knowledge_graph(result_2, prefix="something")
+        uri_to_node = kgf._uri_to_node_names(graph)
+        self.assertRaises(ValueError, kgf._ensure_workflow_name, uri_to_node)
+        self.assertRaises(
+            ValueError, kgf._ensure_workflow_name, uri_to_node, "multiply_then_add"
+        )
+        self.assertEqual(
+            kgf._ensure_workflow_name(
+                uri_to_node, onto.BASE["Wbcedc6be_multiply_then_add"]
+            ),
+            onto.BASE["Wbcedc6be_multiply_then_add"],
+        )
+        self.assertRaises(
+            ValueError, kgf._ensure_workflow_name, uri_to_node, "unknown_workflow"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_kg_to_flowrep.py
+++ b/tests/unit/test_kg_to_flowrep.py
@@ -1,8 +1,6 @@
 import unittest
-from unittest.mock import MagicMock
 
 import flowrep as fr
-import networkx as nx
 from rdflib import RDFS, Graph, Literal, URIRef
 
 from semantikon import get_knowledge_graph, kg2recipe
@@ -132,12 +130,12 @@ class TestKgToFlowrep(unittest.TestCase):
             workflow_name=URIRef("http://pyiron.org/ontology/W0fba2efa_my_workflow"),
         )
         self.assertEqual(
-            fr.tools.run_recipe(reconstructed_from_string, x=3, y=5).output_ports[
-                "result"
-            ].value,
-            fr.tools.run_recipe(reconstructed_from_uri, x=3, y=5).output_ports[
-                "result"
-            ].value,
+            fr.tools.run_recipe(reconstructed_from_string, x=3, y=5)
+            .output_ports["result"]
+            .value,
+            fr.tools.run_recipe(reconstructed_from_uri, x=3, y=5)
+            .output_ports["result"]
+            .value,
         )
 
     def test_kg_to_recipe_with_constants(self):

--- a/tests/unit/test_kg_to_flowrep.py
+++ b/tests/unit/test_kg_to_flowrep.py
@@ -127,7 +127,7 @@ class TestKgToFlowrep(unittest.TestCase):
         reconstructed_from_string = kg2recipe(graph, workflow_name="my_workflow")
         reconstructed_from_uri = kg2recipe(
             graph,
-            workflow_name=URIRef("http://pyiron.org/ontology/Wba44739c_my_workflow"),
+            workflow_name=URIRef("http://pyiron.org/ontology/W0fba2efa_my_workflow"),
         )
         self.assertEqual(
             fr.tools.run_recipe(reconstructed_from_string, x=3, y=5)

--- a/tests/unit/test_kg_to_flowrep.py
+++ b/tests/unit/test_kg_to_flowrep.py
@@ -110,43 +110,6 @@ class TestKgToFlowrep(unittest.TestCase):
         self.assertEqual(kgf._identifier(graph, node), "my_identifier")
         self.assertEqual(kgf._label(graph, node), "my_label")
 
-    def test_select_workflow_variants(self):
-        graph = Graph()
-        uri_1 = URIRef("http://example.org/wf1")
-        uri_2 = URIRef("http://example.org/wf2")
-        graph.add((uri_1, kgf.SNS.local_identifier, Literal("wf_a")))
-        graph.add((uri_2, kgf.SNS.local_identifier, Literal("wf_b")))
-
-        roots = {uri_1: "label_a", uri_2: "label_b"}
-        workflows = roots.values()
-
-        self.assertEqual(
-            kgf._select_workflow(graph, roots, workflows, workflow_name="label_a"),
-            "label_a",
-        )
-        self.assertEqual(
-            kgf._select_workflow(graph, roots, workflows, workflow_name="wf_a"),
-            "label_a",
-        )
-        with self.assertRaisesRegex(ValueError, "Unknown workflow"):
-            _ = kgf._select_workflow(graph, roots, workflows, workflow_name="missing")
-        with self.assertRaisesRegex(ValueError, "multiple root workflows"):
-            _ = kgf._select_workflow(graph, roots, workflows, workflow_name=None)
-
-        ambiguous_graph = Graph()
-        ambiguous_uri_1 = URIRef("http://example.org/wf_same_1")
-        ambiguous_uri_2 = URIRef("http://example.org/wf_same_2")
-        for uri in (ambiguous_uri_1, ambiguous_uri_2):
-            ambiguous_graph.add((uri, kgf.SNS.local_identifier, Literal("wf_same")))
-        ambiguous_roots = {ambiguous_uri_1: "label_1", ambiguous_uri_2: "label_2"}
-        with self.assertRaisesRegex(ValueError, "ambiguous"):
-            _ = kgf._select_workflow(
-                ambiguous_graph,
-                ambiguous_roots,
-                ambiguous_roots.values(),
-                workflow_name="wf_same",
-            )
-
     def test_add_io_nodes_error_paths(self):
         node = URIRef("http://example.org/node")
         io_node = URIRef("http://example.org/io")

--- a/tests/unit/test_kg_to_flowrep.py
+++ b/tests/unit/test_kg_to_flowrep.py
@@ -6,7 +6,6 @@ from rdflib import RDFS, Graph, Literal, URIRef
 from semantikon import get_knowledge_graph, kg2recipe
 from semantikon import kg_to_flowrep as kgf
 from semantikon import ontology as onto
-from semantikon.workflow import workflow
 
 
 def add_one(a):
@@ -17,14 +16,14 @@ def add(x, y):
     return x + y
 
 
-@workflow
+@fr.workflow
 def add_more(x):
     y = add_one(x)
     z = add(x, y)
     return z
 
 
-@workflow
+@fr.workflow
 def my_workflow(x=1, y=2):
     z = add_one(x)
     q = add_more(z)
@@ -36,7 +35,7 @@ def times_two(x):
     return x * 2
 
 
-@workflow
+@fr.workflow
 def multiply_by_two(x=2):
     result = times_two(x)
     return result
@@ -128,7 +127,7 @@ class TestKgToFlowrep(unittest.TestCase):
         reconstructed_from_string = kg2recipe(graph, workflow_name="my_workflow")
         reconstructed_from_uri = kg2recipe(
             graph,
-            workflow_name=URIRef("http://pyiron.org/ontology/Wba44739c_my_workflow"),
+            workflow_name=URIRef("http://pyiron.org/ontology/Wcfff5bb1_my_workflow"),
         )
         self.assertEqual(
             fr.tools.run_recipe(reconstructed_from_string, x=3, y=5)

--- a/tests/unit/test_kg_to_flowrep.py
+++ b/tests/unit/test_kg_to_flowrep.py
@@ -86,10 +86,6 @@ class TestKgToFlowrep(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "multiple root workflows"):
             _ = kg2recipe(graph)
 
-        reconstructed = kg2recipe(graph, workflow_name="multiply_by_two")
-        converted_result = fr.tools.run_recipe(reconstructed, x=7)
-        self.assertEqual(converted_result.output_ports["result"].value, 14)
-
     def test_requires_t_box_information(self):
         graph = get_knowledge_graph(my_workflow.flowrep_recipe, include_t_box=False)
         with self.assertRaisesRegex(ValueError, "No workflow nodes found in graph"):
@@ -111,131 +107,38 @@ class TestKgToFlowrep(unittest.TestCase):
         self.assertEqual(kgf._label(graph, node), "my_label")
 
     def test_add_io_nodes_error_paths(self):
-        node = URIRef("http://example.org/node")
-        io_node = URIRef("http://example.org/io")
-        function_node = URIRef("http://example.org/function")
-        function_dict = {
-            function_node: {
-                "data": {"qualname": "f"},
-                "input_args": [{"arg": "x"}],
-                "output_args": [{"arg": "x"}],
-            }
-        }
-        node_function_dict = {node: function_node}
-
-        graph = MagicMock()
-        graph.query.return_value = [(node, io_node)]
-        graph.objects.return_value = []
-        workflow_graph = nx.DiGraph()
-        with self.assertRaisesRegex(ValueError, "Expected one local identifier"):
-            kgf._add_io_nodes(
-                graph,
-                workflow_graph,
-                function_dict,
-                node_function_dict,
-                io_type="input",
-            )
-
-        graph.objects.return_value = [Literal("unknown_arg")]
-        with self.assertRaisesRegex(ValueError, "Could not match argument"):
-            kgf._add_io_nodes(
-                graph,
-                workflow_graph,
-                function_dict,
-                node_function_dict,
-                io_type="input",
-            )
-
-    def test_reorganize_and_reconnect_helpers(self):
-        graph = nx.DiGraph()
-        p1 = URIRef("http://example.org/p1")
-        p2 = URIRef("http://example.org/p2")
-        n1 = URIRef("http://example.org/n1")
-        n2 = URIRef("http://example.org/n2")
-        data = URIRef("http://example.org/data")
-        graph.add_edges_from([(p1, n1), (p2, n2), (n1, data), (n2, data)])
-        kgf._reorganize_output_edges(graph, data, position={p1: 0, p2: 1})
-        self.assertEqual(len(list(graph.predecessors(data))), 1)
-
-        s1 = URIRef("http://example.org/s1")
-        s2 = URIRef("http://example.org/s2")
-        i1 = URIRef("http://example.org/i1")
-        i2 = URIRef("http://example.org/i2")
-        in_data = URIRef("http://example.org/in_data")
-        graph = nx.DiGraph()
-        graph.add_edges_from(
-            [(in_data, i1), (in_data, i2), (i1, s1), (i2, s2), (s1, s2)]
-        )
-        kgf._reorganize_input_edges(graph, in_data, position={s1: 0, s2: 1})
-        self.assertEqual(len(list(graph.successors(in_data))), 1)
-
-        reconnect = nx.DiGraph()
-        out_node = URIRef("http://example.org/out")
-        input_one = URIRef("http://example.org/in1")
-        input_two = URIRef("http://example.org/in2")
-        data_node = URIRef("http://example.org/d")
-        reconnect.add_edges_from(
-            [(out_node, data_node), (data_node, input_one), (data_node, input_two)]
-        )
-        kgf._reconnect_io(reconnect, data_node)
-        self.assertIn((out_node, input_one), reconnect.edges)
-        self.assertIn((out_node, input_two), reconnect.edges)
+        graph = get_knowledge_graph(my_workflow.flowrep_recipe)
+        with self.assertRaisesRegex(ValueError, "Unknown workflow"):
+            kg2recipe(graph, workflow_name=URIRef("http://example.org/node"))
 
     def test_kg2recipe_with_uriref_workflow_name(self):
-        """Test that kg2recipe accepts URIRef workflow_name parameter."""
         graph = get_knowledge_graph(my_workflow.flowrep_recipe)
-        roots = kgf._workflow_roots(graph)
-
-        # Get the URIRef for the workflow
-        workflow_uriref = next(iter(roots.keys()))
-
-        # Should work with URIRef as workflow_name
-        reconstructed = kg2recipe(graph, workflow_name=workflow_uriref)
-
-        # Verify round-trip correctness by running the recipe
-        original_result = fr.tools.run_recipe(my_workflow.flowrep_recipe, x=3, y=5)
+        reconstructed = kg2recipe(graph, workflow_name="my_workflow")
         converted_result = fr.tools.run_recipe(reconstructed, x=3, y=5)
-        self.assertEqual(
-            original_result.output_ports["result"].value,
-            converted_result.output_ports["result"].value,
-        )
+        self.assertEqual(converted_result.output_ports["result"].value, 14)
 
     def test_select_workflow_with_invalid_uriref(self):
         """Test that _select_workflow raises error for unknown URIRef."""
         graph = get_knowledge_graph(my_workflow.flowrep_recipe)
-        roots = kgf._workflow_roots(graph)
-        workflow_graph = kgf._build_workflow_graph(graph)
-        workflows = kgf._split_by_roots(graph, workflow_graph, roots)
-
-        # Create a non-existent URIRef
-        invalid_uriref = URIRef("http://example.org/nonexistent")
-
-        with self.assertRaises(ValueError) as context:
-            kgf._select_workflow(
-                graph, roots, workflows.keys(), workflow_name=invalid_uriref
-            )
-
-        self.assertIn("Unknown workflow URIRef", str(context.exception))
+        with self.assertRaisesRegex(ValueError, "Unknown workflow"):
+            kg2recipe(graph, workflow_name=URIRef("http://example.org/nonexistent"))
 
     def test_select_workflow_with_string_vs_uriref(self):
         """Test that string and URIRef selection produce same result."""
         graph = get_knowledge_graph(my_workflow.flowrep_recipe)
-        roots = kgf._workflow_roots(graph)
-        workflow_graph = kgf._build_workflow_graph(graph)
-        workflows = kgf._split_by_roots(graph, workflow_graph, roots)
-        # Get the workflow label and URIRef (now keys are URIRefs, values are labels)
-        workflow_uriref = next(iter(roots.keys()))
-        workflow_label = roots[workflow_uriref]
-
-        # Both should select the same workflow
-        result_from_string = kgf._select_workflow(
-            graph, roots, workflows.keys(), workflow_name=workflow_label
+        reconstructed_from_string = kg2recipe(graph, workflow_name="my_workflow")
+        reconstructed_from_uri = kg2recipe(
+            graph,
+            workflow_name=URIRef("http://pyiron.org/ontology/W0fba2efa_my_workflow"),
         )
-        result_from_uriref = kgf._select_workflow(
-            graph, roots, workflows.keys(), workflow_name=workflow_uriref
+        self.assertEqual(
+            fr.tools.run_recipe(reconstructed_from_string, x=3, y=5).output_ports[
+                "result"
+            ].value,
+            fr.tools.run_recipe(reconstructed_from_uri, x=3, y=5).output_ports[
+                "result"
+            ].value,
         )
-
-        self.assertEqual(result_from_string, result_from_uriref)
 
     def test_kg_to_recipe_with_constants(self):
         """Test converting knowledge graph back to recipe with constants preserved."""

--- a/tests/unit/test_ontology.py
+++ b/tests/unit/test_ontology.py
@@ -562,7 +562,7 @@ class TestOntology(unittest.TestCase):
         PREFIX obi: <http://purl.obolibrary.org/obo/OBI_>
 
         ASK {{
-            ?output a sns:W368081ad_my_kinetic_energy_workflow-outputs-kinetic_energy .
+            ?output a sns:W53f89b3c_my_kinetic_energy_workflow-outputs-kinetic_energy .
             ?output ro:0000057 ?data .
             ?data qudt:hasUnit unit:J .
         }}"""


### PR DESCRIPTION
Following [Liam's comment](https://github.com/pyiron/semantikon/pull/511#pullrequestreview-4900364233) I replaced all the strings in `SemantikonDiGraph` by data classes. In particular, there are the following ones:

```python
@dataclass(frozen=True, slots=True)
class Node:
    name: str
    parent: Node | None = None


@dataclass(frozen=True, slots=True)
class IO(ABC):  # this is separated into `Input` and `Output`
    node: str
    arg: str
```

This entirely changes the content of `SemantikonDiGraph`, but it is not given in the API, so I consider it as a patch.